### PR TITLE
seperates compilation and testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,16 @@
     "gulp-tslint": "^3.1",
     "jshint": "^2.8.0",
     "jshint-stylish": "^2.1.0",
-    "mocha": "2.3.4"
+    "mocha": "2.3.4",
+    "rimraf": "^2.5.2"
   },
   "scripts": {
-    "test": "gulp"
+    "install": "gulp",
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hazelcast-incubator/hazelcast-nodejs-client.git"
+    "url": "git+https://github.com/hazelcast/hazelcast-nodejs-client.git"
   },
   "keywords": [
     "hazelcast",


### PR DESCRIPTION
Seperates compilation and test phases in gulp. Removes unused task.
`gulp clean` => remove `lib` folder. If you do not remove lib folder explicitly between compilations, compiled versions of the files you move continue to exist in both old and new locations.
`gulp compile` => compile the files, do not run tests,
`gulp test` or `npm test` => run the tests, do not compile files
`gulp` or `npm install` => compile and run tests