### PR TITLE
Connection write error handling

### DIFF
--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -60,11 +60,11 @@ class ClientConnectionManager {
                 this.onConnectionOpened(connection);
             }).catch((e: any) => {
                 result.reject(e);
-            }).finally(() => {
-                delete this.pendingConnections[addressIndex];
             });
         }).catch((e: any) => {
             result.reject(e);
+        }).finally(() => {
+            delete this.pendingConnections[addressIndex];
         });
 
         return result.promise;
@@ -78,8 +78,8 @@ class ClientConnectionManager {
         if (this.establishedConnections.hasOwnProperty(addressStr)) {
             var conn = this.establishedConnections[addressStr];
             conn.close();
-            this.onConnectionClosed(conn);
             delete this.establishedConnections[addressStr];
+            this.onConnectionClosed(conn);
         }
     }
 

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -96,7 +96,9 @@ export class InvocationService {
             this.eventHandlers[correlationId] = invocation;
         }
         this.pending[correlationId] = invocation;
-        connection.write(invocation.request.getBuffer());
+        connection.write(invocation.request.getBuffer()).catch((e) => {
+            invocation.deferred.reject(e);
+        });
         return invocation.deferred.promise;
     }
 


### PR DESCRIPTION
In scenario of two members M1, M2 and client C;

- C authenticates to M1,
- C loses connection to M1,
- C authenticates to M2,
- M1 comes back to cluster,
- C loses connection to M2,
- C is not able to connect to M1

This PR solves this problem. Client is able to connect to any cluster member alive.