### PR TITLE
removes ts build from npm install stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "rimraf": "^2.5.2"
   },
   "scripts": {
-    "install": "gulp",
     "test": "gulp test"
   },
   "repository": {


### PR DESCRIPTION
npm install should not do anything related with Typescript compilation and tests. End user will have only javascript sources.
fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/59