### PR TITLE
DistributedObjectListener

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -1,5 +1,5 @@
 import {SerializationService} from './serialization/SerializationService';
-import {InvocationService} from './invocation/InvocationService';
+import {InvocationService, ListenerService} from './invocation/InvocationService';
 import ClientConnectionManager = require('./invocation/ClientConnectionManager');
 import {ClientConfig} from './Config';
 import ProxyManager = require('./proxy/ProxyManager');
@@ -15,6 +15,7 @@ import {ClientGetDistributedObjectsCodec} from './codec/ClientGetDistributedObje
 import {DistributedObject} from './DistributedObject';
 import defer = Q.defer;
 import {ClientInfo} from './ClientInfo';
+import ClientMessage = require('./ClientMessage');
 
 class HazelcastClient {
 
@@ -22,6 +23,7 @@ class HazelcastClient {
     private loggingService: LoggingService;
     private serializationService: SerializationService;
     private invocationService: InvocationService;
+    private listenerService: ListenerService;
     private connectionManager: ClientConnectionManager;
     private partitionService: PartitionService;
     private clusterService: ClusterService;
@@ -42,6 +44,7 @@ class HazelcastClient {
         LoggingService.initialize(this.config.properties['hazelcast.logging']);
         this.loggingService = LoggingService.getLoggingService();
         this.invocationService = new InvocationService(this);
+        this.listenerService = new ListenerService(this);
         this.serializationService = new JsonSerializationService();
         this.proxyManager = new ProxyManager(this);
         this.partitionService = new PartitionService(this);
@@ -109,6 +112,10 @@ class HazelcastClient {
         return this.invocationService;
     }
 
+    getListenerService(): ListenerService {
+        return this.listenerService;
+    }
+
     getConnectionManager(): ClientConnectionManager {
         return this.connectionManager;
     }
@@ -127,6 +134,14 @@ class HazelcastClient {
 
     getHeartbeat(): Heartbeat {
         return this.heartbeat;
+    }
+
+    addDistributedObjectListener(listenerFunc: Function): Q.Promise<string> {
+        return this.proxyManager.addDistributedObjectListener(listenerFunc);
+    }
+
+    removeDistributedObjectListener(listenerId: string): Q.Promise<boolean> {
+        return this.proxyManager.removeDistributedObjectListener(listenerId);
     }
 
     shutdown() {

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -185,11 +185,10 @@ export class ListenerService {
         var deferred = Q.defer<string>();
         var invocation = new Invocation(codec.encodeRequest(true));
         invocation.handler = handler;
-        var listenerIdToCorrelation = this.listenerIdToCorrelation;
-        this.client.getInvocationService().invoke(invocation).then(function(responseMessage) {
+        this.client.getInvocationService().invoke(invocation).then((responseMessage) => {
             var correlationId = responseMessage.getCorrelationId();
             var response = codec.decodeResponse(responseMessage);
-            listenerIdToCorrelation[response.response] = correlationId;
+            this.listenerIdToCorrelation[response.response] = correlationId;
             deferred.resolve(response.response);
         });
         return deferred.promise;

--- a/test/HazelcastClientTest.js
+++ b/test/HazelcastClientTest.js
@@ -52,24 +52,21 @@ describe('HazelcastClient', function() {
             done();
         });
 
-        it('getDistributedObjects returns an array of distributed objects', function() {
-            this.timeout(100000);
-            var equalChecker = function(expected, actual) {
-                return expect(actual).to.eq(expected);
-            };
-            return client.getDistributedObjects().then(function(distributedObjects) {
-                var objects = {};
-                distributedObjects.forEach(function(distObject) {
-                    objects[distObject.getName()] = 'exist';
+        it('getDistributedObjects returns an array of distributed objects', function(done) {
+            setTimeout(function() {
+                return client.getDistributedObjects().then(function(distributedObjects) {
+                    var objects = {};
+                    distributedObjects.forEach(function(distObject) {
+                        objects[distObject.getName()] = 'exist';
+                    });
+                    expect(objects).to.have.property('map0');
+                    expect(objects).to.have.property('map1');
+                    expect(objects).to.have.property('map2');
+                    expect(objects).to.have.property('map3');
+                    expect(objects).to.have.property('map4');
+                    done();
                 });
-                return Q.all([
-                    expect(objects).to.have.property('map0'),
-                    expect(objects).to.have.property('map1'),
-                    expect(objects).to.have.property('map2'),
-                    expect(objects).to.have.property('map3'),
-                    expect(objects).to.have.property('map4')
-                ]);
-            });
+            }, 500);
         });
     });
 });

--- a/test/ListenerServiceTest.js
+++ b/test/ListenerServiceTest.js
@@ -1,0 +1,58 @@
+var Q = require('q');
+var RC = require('./RC');
+var HazelcastClient = require('../.');
+var expect = require('chai').expect;
+describe('DistributedObjectListener', function() {
+    var cluster;
+    var client;
+
+    before(function() {
+        return RC.createCluster(null, null).then(function(res) {
+            cluster = res;
+            return Q(cluster.id);
+        }).then(function(clusterId) {
+            return RC.startMember(clusterId)
+        }).then(function() {
+            return HazelcastClient.newHazelcastClient();
+        }).then(function(res) {
+            client = res;
+        });
+    });
+
+    after(function() {
+        client.shutdown();
+        return RC.shutdownCluster(cluster.id);
+    });
+
+    it('listener is invoked when a new object is created', function(done) {
+        client.addDistributedObjectListener(function(name, serviceName, eventType) {
+            if (eventType === 'created' && name === 'mapToListen') {
+                expect(serviceName).to.eq('hz:impl:mapService');
+                done();
+            }
+        });
+        client.getMap('mapToListen');
+    });
+
+    it('listener is invoked when an object is removed', function(done) {
+        var map = client.getMap('mapToRemove');
+        client.addDistributedObjectListener(function(name, serviceName, eventType) {
+            if (eventType === 'destroyed' && name === 'mapToRemove' ) {
+                expect(serviceName).to.eq('hz:impl:mapService');
+                done();
+            }
+        });
+        map.destroy();
+    });
+
+    it('listener is not invoked when listener was already removed by user', function(done) {
+        this.timeout(3000);
+        client.addDistributedObjectListener(function(name, serviceName, eventType) {
+            done('Should not have run!');
+        }).then(function(listenerId) {
+            return client.removeDistributedObjectListener(listenerId)
+        }).then(function() {
+            setTimeout(done, 1000);
+        });
+    })
+});


### PR DESCRIPTION
Introduces `ListenerService`
Adds `addDistributedObjectListener` and `removeDistributedObjectListener` methods to `ProxyManager` and `HazelcastClient`. These methods take a function as a parameter. This function is called with `objectName`, `serviceName` and `eventType` parameters in this order when an event occurs. `eventType` is either `created` or `destroyed`.

Adds tests.

Fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/55