### PR TITLE
removes unused lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   ],
   "dependencies": {
     "long": "3.0.1",
-    "q": "1.4.1",
-    "lodash": "3.10.1"
+    "q": "1.4.1"
   },
   "devDependencies": {
     "chai": "3.4.1",


### PR DESCRIPTION
We do not use this dependency. I do not know why it is there.