### PR TITLE
heartbeat tests and change in Address class

### DIFF
--- a/src/Address.ts
+++ b/src/Address.ts
@@ -1,14 +1,14 @@
 class Address {
-    public host: string;
-    public port: number;
+    host: string;
+    port: number;
+
+    static encodeToString(address: Address): string {
+        return address.host + ':' + address.port;
+    }
 
     constructor(host: string, port: number) {
         this.host = host;
         this.port = port;
-    }
-
-    public toString(): string {
-        return this.host + ':' + this.port;
     }
 }
 

--- a/src/Heartbeat.ts
+++ b/src/Heartbeat.ts
@@ -4,6 +4,7 @@ import ClientConnection = require('./invocation/ClientConnection');
 import {ConnectionHeartbeatListener} from './ConnectionHeartbeatListener';
 import Q = require('q');
 import {LoggingService} from './LoggingService';
+import Address = require('./Address');
 
 var PROPERTY_HEARTBEAT_INTERVAL: string = 'hazelcast.client.heartbeat.interval';
 var PROPERTY_HEARTBEAT_TIMEOUT: string = 'hazelcast.client.heartbeat.timeout';
@@ -64,7 +65,7 @@ class Heartbeat {
 
     private onHeartbeatStopped(connection: ClientConnection) {
         connection.heartbeating = false;
-        this.logger.warn('HeartbeatService', 'Heartbeat stopped on ' + connection.address);
+        this.logger.warn('HeartbeatService', 'Heartbeat stopped on ' + Address.encodeToString(connection.address));
         this.listeners.forEach((listener) => {
             if (listener.hasOwnProperty('onHeartbeatStopped')) {
                 setImmediate(listener.onHeartbeatStopped.bind(this), connection);
@@ -74,7 +75,7 @@ class Heartbeat {
 
     private onHeartbeatRestored(connection: ClientConnection) {
         connection.heartbeating = true;
-        this.logger.warn('HeartbeatService', 'Heartbeat restored on ' + connection.address);
+        this.logger.warn('HeartbeatService', 'Heartbeat restored on ' + Address.encodeToString(connection.address));
         this.listeners.forEach((listener) => {
             if (listener.hasOwnProperty('onHeartbeatRestored')) {
                 setImmediate(listener.onHeartbeatRestored.bind(this), connection);

--- a/src/Member.ts
+++ b/src/Member.ts
@@ -13,6 +13,6 @@ export class Member {
     }
 
     toString() {
-        return this.address;
+        return 'Member[ uuid: ' + this.uuid + ', address: ' + Address.encodeToString(this.address) + ']';
     }
 }

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -40,7 +40,8 @@ class ClientConnection {
         });
 
         this.socket.on('error', (e: any) => {
-            this.logging.warn('ClientConnection', 'Could not connect to address ' + this.address, e);
+            this.logging.warn('ClientConnection',
+                'Could not connect to address ' + Address.encodeToString(this.address), e);
             ready.reject(e);
         });
 
@@ -53,7 +54,8 @@ class ClientConnection {
             if (e === undefined) {
                 deferred.resolve();
             } else {
-                this.logging.warn('ClientConnection', 'Error sending message to ' + this.address + ' ' + e);
+                this.logging.warn('ClientConnection',
+                    'Error sending message to ' + Address.encodeToString(this.address) + ' ' + e);
                 deferred.reject(e);
             }
         });

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -27,7 +27,7 @@ class ClientConnectionManager extends EventEmitter {
     }
 
     getOrConnect(address: Address, ownerConnection: boolean = false): Q.Promise<ClientConnection> {
-        var addressIndex = address.host + ':' + address.port;
+        var addressIndex = Address.encodeToString(address);
         var result: Q.Deferred<ClientConnection> = Q.defer<ClientConnection>();
 
         var establishedConnection = this.establishedConnections[addressIndex];

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -27,7 +27,7 @@ class ClientConnectionManager extends EventEmitter {
     }
 
     getOrConnect(address: Address, ownerConnection: boolean = false): Q.Promise<ClientConnection> {
-        var addressIndex = address.toString();
+        var addressIndex = address.host + ':' + address.port;
         var result: Q.Deferred<ClientConnection> = Q.defer<ClientConnection>();
 
         var establishedConnection = this.establishedConnections[addressIndex];
@@ -55,7 +55,7 @@ class ClientConnectionManager extends EventEmitter {
             return this.authenticate(clientConnection, ownerConnection);
         }).then((authenticated: boolean) => {
             if (authenticated) {
-                this.establishedConnections[clientConnection.address.toString()] = clientConnection;
+                this.establishedConnections[Address.encodeToString(clientConnection.address)] = clientConnection;
             } else {
                 throw new Error('Authentication failed');
             }
@@ -71,7 +71,7 @@ class ClientConnectionManager extends EventEmitter {
     }
 
     destroyConnection(address: Address): void {
-        var addressStr = address.toString();
+        var addressStr = Address.encodeToString(address);
         if (this.pendingConnections.hasOwnProperty(addressStr)) {
             this.pendingConnections[addressStr].reject(null);
         }

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -90,7 +90,7 @@ class ClusterService extends EventEmitter {
     }
 
     private onConnectionClosed(connection: ClientConnection) {
-        this.logger.warn('ClusterService', 'Connection closed to ' + connection.address);
+        this.logger.warn('ClusterService', 'Connection closed to ' + Address.encodeToString(connection.address));
         if (connection.address === this.getOwnerConnection().address) {
             this.ownerConnection = null;
             this.connectToCluster();
@@ -98,7 +98,7 @@ class ClusterService extends EventEmitter {
     }
 
     private onHeartbeatStopped(connection: ClientConnection): void {
-        this.logger.warn('ClusterService', connection.address + ' stopped heartbeating.');
+        this.logger.warn('ClusterService', Address.encodeToString(connection.address) + ' stopped heartbeating.');
         if (connection.getAddress() === this.ownerConnection.address) {
             this.client.getConnectionManager().destroyConnection(connection.address);
         }

--- a/test/HeartbeatTest.js
+++ b/test/HeartbeatTest.js
@@ -1,0 +1,93 @@
+var RC = require('./RC');
+var HazelcastClient = require('../.');
+var expect = require('chai').expect;
+var Config = require('../lib/Config');
+
+describe('Hearbeat', function() {
+    this.timeout(30000);
+
+    var cluster;
+
+    beforeEach(function() {
+        return RC.createCluster(null, null).then(function(resp) {
+            cluster = resp;
+        });
+    });
+
+    afterEach(function() {
+        return RC.shutdownCluster(cluster.id);
+    });
+
+    it('Heartbeat stopped fired when second member stops heartbeating', function(done) {
+        var client;
+        RC.startMember(cluster.id).then(function() {
+            var cfg = new Config.ClientConfig();
+            cfg.properties['hazelcast.client.heartbeat.interval'] = 500;
+            cfg.properties['hazelcast.client.heartbeat.timeout'] = 2000;
+            return HazelcastClient.newHazelcastClient(cfg);
+        }).then(function(resp) {
+            client = resp;
+        }).then(function() {
+            client.clusterService.on('memberAdded', function(member) {
+                var address = {
+                    host: member.address.host,
+                    port: member.address.port,
+                    toString: function() {
+                        return member.address.host + ':' + member.address.port;
+                    }
+                };
+                warmUpConnectionToAddress(client, address);
+            });
+            client.heartbeat.addListener({onHeartbeatStopped: function(connection) {
+                client.shutdown();
+                done();
+            }})
+        }).then(function() {
+            return RC.startMember(cluster.id);
+        }).then(function(member2) {
+            RC.terminateMember(cluster.id, member2.uuid);
+        }).catch(done);
+    });
+
+    it('Heartbeat restored fired when second member comes back', function(done) {
+        var client;
+        var member1;
+        var member2;
+        RC.startMember(cluster.id).then(function(m) {
+            member1 = m;
+            var cfg = new Config.ClientConfig();
+            cfg.properties['hazelcast.client.heartbeat.interval'] = 500;
+            cfg.properties['hazelcast.client.heartbeat.timeout'] = 2000;
+            return HazelcastClient.newHazelcastClient(cfg);
+        }).then(function(resp) {
+            client = resp;
+            client.clusterService.on('memberAdded', function(member) {
+                var address = {
+                    host: member.address.host,
+                    port: member.address.port,
+                    toString: function() {
+                        return member.address.host + ':' + member.address.port;
+                    }
+                };
+                warmUpConnectionToAddress(client, address).then(function() {
+                    simulateHeartbeatLost(client, address, 2000);
+                });
+            });
+            client.heartbeat.addListener({onHeartbeatRestored: function(connection) {
+                client.shutdown();
+                done();
+            }});
+            return RC.startMember(cluster.id);
+        }).then(function(resp) {
+            member2 = resp;
+        }).catch(done);
+    });
+
+    function simulateHeartbeatLost(client, address, timeout) {
+        client.connectionManager.establishedConnections[address].lastRead = client.connectionManager.establishedConnections[address].lastRead - timeout;
+    }
+
+    function warmUpConnectionToAddress(client, address) {
+        return client.connectionManager.getOrConnect(address);
+    }
+});

--- a/test/RC.js
+++ b/test/RC.js
@@ -48,6 +48,15 @@ function shutdownCluster(clusterId) {
     return deferrred.promise;
 }
 
+function terminateMember(clusterId, memberUuid) {
+    var deferred = Q.defer();
+    controller.terminateMember(clusterId, memberUuid, function(err, res) {
+        if (err) return deferred.reject(err);
+        return deferred.resolve(res);
+    });
+    return deferred.promise;
+}
+
 function executeOnController(clusterId, script, lang) {
     var deferred = Q.defer();
     controller.executeOnController(clusterId, script, lang, function(err, res) {
@@ -63,3 +72,4 @@ exports.startMember = startMember;
 exports.shutdownMember = shutdownMember;
 exports.shutdownCluster = shutdownCluster;
 exports.executeOnController = executeOnController;
+exports.terminateMember = terminateMember;


### PR DESCRIPTION
Two tests for Heartbeat Service.

I removed Address.toString method because implementation should not rely on any method of Address class. Users may provide Address objects created in Javascript to configuration and they may not provide a toString function in their object. Then client would behave unpredictably. I have put a static utility function instead of instance method.

