### PR TITLE
fix forever pinging removed member

### DIFF
--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -185,6 +185,7 @@ class ClusterService extends EventEmitter {
 
     private memberRemoved(member: Member) {
         this.members.splice(this.members.indexOf(member), 1);
+        this.client.getConnectionManager().destroyConnection(member.address);
         this.emit(EMIT_MEMBER_REMOVED, member);
     }
 }


### PR DESCRIPTION
I start 3 nodes. When I start a client instance with following code:
```
var Hazelcast = require('hazelcast-nodejs-client').Client;
Hazelcast.newHazelcastClient().then(function(client) {
    var map = client.getMap('langs');
    map.put('en', 'english');
    map.put('tr', 'turkish').then(function() {
        return map.get('tr');
    }).then(function(val) {
        console.log(val);
    })
});
```
Then, I remove second node. Client tries to ping the removed node even after owner tells it the node was removed. This fixes that behaviour.