### PR TITLE
Release prep

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+src/
+typings/
+coverage/
+.idea/
+tslint.json
+typings.json
+*.iml
+.editorconfig
+.jshintrc

--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,8 @@
 src/
-typings/
 coverage/
 .idea/
 tslint.json
-typings.json
 *.iml
 .editorconfig
 .jshintrc
+test/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,31 +15,9 @@ var tslint = require('gulp-tslint');
 var debug = require('gulp-debug');
 var rimraf = require('rimraf');
 
-var typeDefsPath = (function (typings) {
-    return typings.path || 'typings';
-})(require('./typings.json'));
-
 var tsFilesGlob = (function (c) {
     return c.filesGlob || c.files || '**/*.ts';
 })(require('./tsconfig.json'));
-
-gulp.task('gen_tsrefs', 'Generates the main.d.ts references file dynamically for all application *.ts files', function () {
-    var target = gulp.src(path.join('.', typeDefsPath, 'typings/main.d.ts'));
-    var sources = gulp.src([path.join('.', 'src', '**', '*.ts')], {read: false});
-    // sources.pipe(debug());
-    // target.pipe(debug());
-    var transformation = inject(sources, {
-        starttag: '//{',
-        endtag: '//}',
-        transform: function (filepath) {
-            console.log(filepath);
-            return '/// <reference path="..' + filepath + '" />';
-        }
-    });
-    return target
-        .pipe(transformation)
-        .pipe(gulp.dest(path.join('.', typeDefsPath)));
-});
 
 gulp.task('typings install', function(cb) {
     exec('typings install', function(err, stdout, stderr) {
@@ -63,7 +41,7 @@ gulp.task('tslint', 'Lints all TypeScript source files', function () {
         .pipe(tslint.report('verbose'));
 });
 
-gulp.task('tsBuild', 'Compiles all TypeScript source files and updates module references', gulpSequence('tslint', 'typings install', 'gen_tsrefs', '_build'));
+gulp.task('tsBuild', 'Compiles all TypeScript source files and updates module references', gulpSequence('tslint', 'typings install', '_build'));
 
 
 gulp.task('nsp', function (cb) {

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/HazelcastClient');
+module.exports = require('./lib/.');

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/.');

--- a/package.json
+++ b/package.json
@@ -1,57 +1,58 @@
 {
-  "name": "hazelcast-nodejs-client",
-  "version": "0.1.0",
-  "description": "Hazelcast - open source In-Memory Data Grid - client for NodeJS",
-  "main": "index.js",
-  "files": [
-    "lib"
-  ],
-  "dependencies": {
-    "long": "3.0.1",
-    "q": "1.4.1"
-  },
-  "devDependencies": {
-    "chai": "3.4.1",
-    "gulp": "^3.9.0",
-    "gulp-debug": "^2.1.2",
-    "gulp-eslint": "^1.0.0",
-    "gulp-exclude-gitignore": "^1.0.0",
-    "gulp-exec": "^2.1.2",
-    "gulp-help": "^1.6.0",
-    "gulp-inject": "3.0.0",
-    "gulp-istanbul": "^0.9.0",
-    "gulp-jshint": "^2.0.0",
-    "gulp-mocha": "^2.0.0",
-    "gulp-nsp": "^2.1.0",
-    "gulp-plumber": "^1.0.0",
-    "gulp-sequence": "^0.4.4",
-    "gulp-tsconfig-files": "0.0.2",
-    "gulp-tslint": "^3.1",
-    "jshint": "^2.8.0",
-    "jshint-stylish": "^2.1.0",
-    "mocha": "2.3.4",
-    "rimraf": "^2.5.2",
-    "sinon": "^1.17.3",
-    "winston": "^2.2.0"
-  },
-  "scripts": {
-    "test": "gulp test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hazelcast/hazelcast-nodejs-client.git"
-  },
-  "keywords": [
-    "hazelcast",
-    "nodejs",
-    "node",
-    "client",
-    "data",
-    "grid"
-  ],
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/hazelcast/hazelcast-nodejs-client/issues"
-  },
-  "homepage": "https://github.com/hazelcast/hazelcast-nodejs-client#readme"
+    "name": "hazelcast-nodejs-client",
+    "version": "0.1.0",
+    "description": "Hazelcast - open source In-Memory Data Grid - client for NodeJS",
+    "main": "index.js",
+    "files": [
+        "lib"
+    ],
+    "dependencies": {
+        "long": "3.0.1",
+        "q": "1.4.1"
+    },
+    "devDependencies": {
+        "chai": "3.4.1",
+        "gulp": "^3.9.0",
+        "gulp-debug": "^2.1.2",
+        "gulp-eslint": "^1.0.0",
+        "gulp-exclude-gitignore": "^1.0.0",
+        "gulp-exec": "^2.1.2",
+        "gulp-help": "^1.6.0",
+        "gulp-inject": "3.0.0",
+        "gulp-istanbul": "^0.9.0",
+        "gulp-jshint": "^2.0.0",
+        "gulp-mocha": "^2.0.0",
+        "gulp-nsp": "^2.1.0",
+        "gulp-plumber": "^1.0.0",
+        "gulp-sequence": "^0.4.4",
+        "gulp-tsconfig-files": "0.0.2",
+        "gulp-tslint": "^3.1",
+        "jshint": "^2.8.0",
+        "jshint-stylish": "^2.1.0",
+        "mocha": "2.3.4",
+        "rimraf": "^2.5.2",
+        "sinon": "^1.17.3",
+        "winston": "^2.2.0"
+    },
+    "scripts": {
+        "test": "gulp test"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/hazelcast/hazelcast-nodejs-client.git"
+    },
+    "keywords": [
+        "hazelcast",
+        "nodejs",
+        "node",
+        "client",
+        "data",
+        "grid"
+    ],
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/hazelcast/hazelcast-nodejs-client/issues"
+    },
+    "homepage": "https://github.com/hazelcast/hazelcast-nodejs-client#readme",
+    "typings": "./lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
     "name": "hazelcast-nodejs-client",
     "version": "0.1.0",
     "description": "Hazelcast - open source In-Memory Data Grid - client for NodeJS",
-    "main": "index.js",
-    "files": [
-        "lib"
-    ],
+    "main": "lib/index.js",
     "dependencies": {
         "long": "3.0.1",
         "q": "1.4.1"
@@ -54,5 +51,5 @@
         "url": "https://github.com/hazelcast/hazelcast-nodejs-client/issues"
     },
     "homepage": "https://github.com/hazelcast/hazelcast-nodejs-client#readme",
-    "typings": "./lib/index.d.ts"
+    "typings": "./lib/index"
 }

--- a/src/DistributedObject.ts
+++ b/src/DistributedObject.ts
@@ -1,4 +1,4 @@
-import Promise = Q.Promise;
+import * as Q from 'q';
 export interface DistributedObject {
     /*
      * Returns the key of the partition that this DistributedObject is assigned to.
@@ -20,5 +20,5 @@ export interface DistributedObject {
      * Destroys this object cluster-wide.
      * Clears all resources taken for this object.
      */
-    destroy() : Promise<void>;
+    destroy() : Q.Promise<void>;
 }

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -3,7 +3,7 @@ import {InvocationService, ListenerService} from './invocation/InvocationService
 import ClientConnectionManager = require('./invocation/ClientConnectionManager');
 import {ClientConfig} from './Config';
 import ProxyManager = require('./proxy/ProxyManager');
-import Q = require('q');
+import * as Q from 'q';
 import {IMap} from './IMap';
 import {JsonSerializationService} from './serialization/SerializationService';
 import PartitionService = require('./PartitionService');

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -17,7 +17,7 @@ import defer = Q.defer;
 import {ClientInfo} from './ClientInfo';
 import ClientMessage = require('./ClientMessage');
 
-class HazelcastClient {
+export default class HazelcastClient {
 
     private config: ClientConfig = new ClientConfig();
     private loggingService: LoggingService;
@@ -151,4 +151,3 @@ class HazelcastClient {
     }
 }
 
-export = HazelcastClient;

--- a/src/Heartbeat.ts
+++ b/src/Heartbeat.ts
@@ -1,5 +1,5 @@
 import {ClientPingCodec} from './codec/ClientPingCodec';
-import HazelcastClient = require('./HazelcastClient');
+import HazelcastClient from './HazelcastClient';
 import ClientConnection = require('./invocation/ClientConnection');
 import {ConnectionHeartbeatListener} from './ConnectionHeartbeatListener';
 import Q = require('q');

--- a/src/Heartbeat.ts
+++ b/src/Heartbeat.ts
@@ -2,7 +2,7 @@ import {ClientPingCodec} from './codec/ClientPingCodec';
 import HazelcastClient from './HazelcastClient';
 import ClientConnection = require('./invocation/ClientConnection');
 import {ConnectionHeartbeatListener} from './ConnectionHeartbeatListener';
-import Q = require('q');
+import * as Q from 'q';
 import {LoggingService} from './LoggingService';
 import Address = require('./Address');
 

--- a/src/IMap.ts
+++ b/src/IMap.ts
@@ -1,4 +1,4 @@
-import Promise = Q.Promise;
+import * as Q from 'q';
 import {DistributedObject} from './DistributedObject';
 export interface IMap<K, V> extends DistributedObject {
 
@@ -8,7 +8,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @throws {Error} if key is undefined or null
      * @return a promise to be resolved to true if the map contains the key, false otherwise.
      */
-    containsKey(key: K) : Promise<boolean>;
+    containsKey(key: K) : Q.Promise<boolean>;
 
     /**
      * This method return true if this map has key(s) associated with given value
@@ -16,7 +16,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @param value
      * @return a promise to be resolved to true if the map has key or keys associated with given value.
      */
-    containsValue(value: V) : Promise<boolean>;
+    containsValue(value: V) : Q.Promise<boolean>;
 
     /**
      * Associates the specified value with the specified key.
@@ -29,7 +29,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @throws {Error} if specified key or value is undefined or null or ttl is negative.
      * @return a promise to be resolved to the old value if there was any, undefined otherwise.
      */
-    put(key: K, value: V, ttl?: number) : Promise<V>;
+    put(key: K, value: V, ttl?: number) : Q.Promise<V>;
 
     /**
      * Retrieves the value associated with given key.
@@ -37,7 +37,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @throws {Error} if key is undefined or null
      * @return a promise to be resolved to the value associated with key, undefined if the key does not exist.
      */
-    get(key: K) : Promise<V>;
+    get(key: K) : Q.Promise<V>;
 
     /**
      * Removes specified key from map. If optional value is specified, the key is removed only if currently mapped to
@@ -48,24 +48,24 @@ export interface IMap<K, V> extends DistributedObject {
      * @throws {Error} if key is undefined or null
      * @return a promise to be resolved to the value associated with key, undefined if the key did not exist before.
      */
-    remove(key: K, value?: V) : Promise<V>;
+    remove(key: K, value?: V) : Q.Promise<V>;
 
     /**
      * Retrieves the number of elements in map
      * @return a promise to be resolved to the number of elements in map
      */
-    size() : Promise<number>;
+    size() : Q.Promise<number>;
 
     /**
      * Removes all of the mappings
      * @return
      */
-    clear() : Promise<void>;
+    clear() : Q.Promise<void>;
 
     /**
      * Returns whether this map is empty or not
      */
-    isEmpty() : Promise<boolean>;
+    isEmpty() : Q.Promise<boolean>;
 
     /**
      *

--- a/src/LifecycleService.ts
+++ b/src/LifecycleService.ts
@@ -1,5 +1,5 @@
-import HazelcastClient = require('./HazelcastClient');
 import {EventEmitter} from 'events';
+import HazelcastClient from './HazelcastClient';
 
 export var LifecycleEvent = {
     name: 'lifecycleEvent',

--- a/src/PartitionService.ts
+++ b/src/PartitionService.ts
@@ -1,4 +1,4 @@
-import Q = require('q');
+import * as Q from 'q';
 import GetPartitionsCodec = require('./codec/GetPartitionsCodec');
 import ClientMessage = require('./ClientMessage');
 import Address = require('./Address');

--- a/src/PartitionService.ts
+++ b/src/PartitionService.ts
@@ -1,8 +1,8 @@
-import HazelcastClient = require('./HazelcastClient');
 import Q = require('q');
 import GetPartitionsCodec = require('./codec/GetPartitionsCodec');
 import ClientMessage = require('./ClientMessage');
 import Address = require('./Address');
+import HazelcastClient from './HazelcastClient';
 
 class PartitionService {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+import HazelcastClient from './HazelcastClient';
+import * as Config from './Config';
+export {
+    HazelcastClient as Client,
+    Config
+}

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -1,5 +1,5 @@
 import net = require('net');
-import Q = require('q');
+import * as Q from 'q';
 import Address = require('../Address');
 import {BitsUtil} from '../BitsUtil';
 import {LoggingService} from '../LoggingService';

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -8,9 +8,9 @@ import InvocationService = require('./InvocationService');
 import {GroupConfig, ClientNetworkConfig} from '../Config';
 
 import ConnectionAuthenticator = require('./ConnectionAuthenticator');
-import HazelcastClient = require('../HazelcastClient');
 import {LoggingService} from '../LoggingService';
 import {EventEmitter} from 'events';
+import HazelcastClient from '../HazelcastClient';
 
 const EMIT_CONNECTION_CLOSED = 'connectionClosed';
 const EMIT_CONNECTION_OPENED = 'connectionOpened';

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -1,4 +1,4 @@
-import Q = require('q');
+import * as Q from 'q';
 
 import Address = require('../Address');
 import ClientConnection = require('./ClientConnection');

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -1,6 +1,6 @@
 import ClientConnection = require('./ClientConnection');
 import Address = require('../Address');
-import Q = require('q');
+import * as Q from 'q';
 import {ClientAddMembershipListenerCodec} from '../codec/ClientAddMembershipListenerCodec';
 import ClientMessage = require('../ClientMessage');
 import {Member} from '../Member';

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -1,5 +1,4 @@
 import ClientConnection = require('./ClientConnection');
-import HazelcastClient = require('../HazelcastClient');
 import Address = require('../Address');
 import Q = require('q');
 import {ClientAddMembershipListenerCodec} from '../codec/ClientAddMembershipListenerCodec';
@@ -8,6 +7,7 @@ import {Member} from '../Member';
 import {LoggingService} from '../LoggingService';
 import {EventEmitter} from 'events';
 import {ClientInfo} from '../ClientInfo';
+import HazelcastClient from '../HazelcastClient';
 
 const MEMBER_ADDED = 1;
 const MEMBER_REMOVED = 2;

--- a/src/invocation/ConnectionAuthenticator.ts
+++ b/src/invocation/ConnectionAuthenticator.ts
@@ -4,7 +4,7 @@ import ClientConnection = require('./ClientConnection');
 import {InvocationService} from './InvocationService';
 import ClientMessage = require('../ClientMessage');
 import {ClientAuthenticationCodec} from '../codec/ClientAuthenticationCodec';
-import HazelcastClient = require('../HazelcastClient');
+import HazelcastClient from '../HazelcastClient';
 
 class ConnectionAuthenticator {
 

--- a/src/invocation/ConnectionAuthenticator.ts
+++ b/src/invocation/ConnectionAuthenticator.ts
@@ -1,4 +1,4 @@
-import Q = require('q');
+import * as Q from 'q';
 
 import ClientConnection = require('./ClientConnection');
 import {InvocationService} from './InvocationService';

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -2,13 +2,13 @@ import ClientConnection = require('./ClientConnection');
 import ClientMessage = require('../ClientMessage');
 import Q = require('q');
 import Long = require('long');
-import HazelcastClient = require('../HazelcastClient');
 import {Data} from '../serialization/Data';
 import Address = require('../Address');
 import ExceptionCodec = require('../codec/ExceptionCodec');
 import {BitsUtil} from '../BitsUtil';
 import {LoggingService} from '../LoggingService';
 import {EventEmitter} from 'events';
+import HazelcastClient from '../HazelcastClient';
 
 var EXCEPTION_MESSAGE_TYPE = 109;
 var INVOCATION_TIMEOUT = 120000;

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -1,6 +1,6 @@
 import ClientConnection = require('./ClientConnection');
 import ClientMessage = require('../ClientMessage');
-import Q = require('q');
+import * as Q from 'q';
 import Long = require('long');
 import {Data} from '../serialization/Data';
 import Address = require('../Address');

--- a/src/proxy/BaseProxy.ts
+++ b/src/proxy/BaseProxy.ts
@@ -1,8 +1,8 @@
 import {SerializationService} from '../serialization/SerializationService';
 import {Data} from '../serialization/Data';
-import HazelcastClient = require('../HazelcastClient');
 import ClientMessage = require('../ClientMessage');
 import Q = require('q');
+import HazelcastClient from '../HazelcastClient';
 
 export class BaseProxy {
 

--- a/src/proxy/BaseProxy.ts
+++ b/src/proxy/BaseProxy.ts
@@ -1,7 +1,7 @@
 import {SerializationService} from '../serialization/SerializationService';
 import {Data} from '../serialization/Data';
 import ClientMessage = require('../ClientMessage');
-import Q = require('q');
+import * as Q from 'q';
 import HazelcastClient from '../HazelcastClient';
 
 export class BaseProxy {

--- a/src/proxy/Map.ts
+++ b/src/proxy/Map.ts
@@ -1,6 +1,6 @@
 import {BaseProxy} from './BaseProxy';
 import {IMap} from '../IMap';
-import Q = require('q');
+import * as Q from 'q';
 import {Data} from '../serialization/Data';
 import {MapPutCodec} from '../codec/MapPutCodec';
 import ClientMessage = require('../ClientMessage');

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -1,5 +1,4 @@
 import Q = require('q');
-import HazelcastClient = require('../HazelcastClient');
 import {DistributedObject} from '../DistributedObject';
 import {Map} from './Map';
 import {BaseProxy} from './BaseProxy';
@@ -10,6 +9,7 @@ import {ClientDestroyProxyCodec} from '../codec/ClientDestroyProxyCodec';
 import defer = Q.defer;
 import {ClientAddDistributedObjectListenerCodec} from '../codec/ClientAddDistributedObjectListenerCodec';
 import {ClientRemoveDistributedObjectListenerCodec} from '../codec/ClientRemoveDistributedObjectListenerCodec';
+import HazelcastClient from '../HazelcastClient';
 
 class ProxyManager {
     public MAP_SERVICE: string = 'hz:impl:mapService';

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -1,4 +1,4 @@
-import Q = require('q');
+import * as Q from 'q';
 import {DistributedObject} from '../DistributedObject';
 import {Map} from './Map';
 import {BaseProxy} from './BaseProxy';

--- a/src/proxy/Set.ts
+++ b/src/proxy/Set.ts
@@ -1,6 +1,6 @@
 import {BaseProxy} from '../proxy/BaseProxy';
 import {ISet} from '../ISet';
-import Q = require('q');
+import * as Q from 'q';
 export class Set<E> extends BaseProxy implements ISet<E> {
     add(entry : E) : Q.Promise<boolean> {
         //TODO

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -1,7 +1,7 @@
 var Controller = require('./RC');
 var expect = require('chai').expect;
-var HazelcastClient = require('../.');
-var Config = require('../lib/Config');
+var HazelcastClient = require('../.').Client;
+var Config = require('../.').Config;
 describe('ClusterService', function() {
     this.timeout(15000);
     var cluster;

--- a/test/HazelcastClientTest.js
+++ b/test/HazelcastClientTest.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect;
-var Config = require('../lib/Config');
+var Config = require('../.').ClientConfig;
 var Controller = require('./RC');
-var HazelcastClient = require('../lib/HazelcastClient');
+var HazelcastClient = require('../.').Client;
 var Q = require('q');
 describe('HazelcastClient', function() {
     this.timeout(4000);

--- a/test/HeartbeatTest.js
+++ b/test/HeartbeatTest.js
@@ -1,7 +1,7 @@
 var RC = require('./RC');
-var HazelcastClient = require('../.');
+var HazelcastClient = require('../.').Client;
 var expect = require('chai').expect;
-var Config = require('../lib/Config');
+var Config = require('../.').Config;
 
 describe('Hearbeat', function() {
     this.timeout(30000);

--- a/test/LifecycleServiceTest.js
+++ b/test/LifecycleServiceTest.js
@@ -1,6 +1,6 @@
 var RC = require('./RC');
-var HazelcastClient = require('../.');
-var Config = require('../lib/Config');
+var HazelcastClient = require('../.').Client;
+var Config = require('../.').Config;
 var expect = require('chai').expect;
 
 describe('LifecycleService', function() {

--- a/test/ListenerServiceTest.js
+++ b/test/ListenerServiceTest.js
@@ -1,6 +1,6 @@
 var Q = require('q');
 var RC = require('./RC');
-var HazelcastClient = require('../.');
+var HazelcastClient = require('../.').Client;
 var expect = require('chai').expect;
 describe('DistributedObjectListener', function() {
     var cluster;

--- a/test/LoggingTest.js
+++ b/test/LoggingTest.js
@@ -1,9 +1,9 @@
 var expect = require('chai').expect;
 var sinon = require('sinon');
 var winston = require('winston');
-var Config = require('../lib/Config');
+var Config = require('../.').Config;
 var Controller = require('./RC');
-var HazelcastClient = require('../lib/HazelcastClient');
+var HazelcastClient = require('../.').Client;
 describe('Logging Test', function() {
     var cluster;
     var client;

--- a/test/LostConnectionTest.js
+++ b/test/LostConnectionTest.js
@@ -1,7 +1,7 @@
 var Controller = require('./RC');
 var expect = require('chai').expect;
-var HazelcastClient = require('../.');
-var Config = require('../lib/Config');
+var HazelcastClient = require('../.').Client;
+var Config = require('../.').Config;
 describe('Lost connection', function() {
     var cluster;
     var member1;

--- a/test/MapProxyTest.js
+++ b/test/MapProxyTest.js
@@ -1,5 +1,5 @@
 var expect = require("chai").expect;
-var HazelcastClient = require("../.");
+var HazelcastClient = require("../.").Client;
 var Q = require("q");
 var Controller = require('./RC');
 

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -1,4 +1,4 @@
-var HazelcastClient = require('../.');
+var HazelcastClient = require('../.').Client;
 var Controller = require('./RC');
 var assert = require('chai').assert;
 var sinon = require('sinon');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "commonjs",
         "moduleResolution": "node",
         "noImplicitAny": true,
+        "target": "es5",
         "outDir": "./lib",
         "preserveConstEnums": true,
         "removeComments": true


### PR DESCRIPTION
This is mostly exposing both HazelcastClient and Config classes to users. Before this PR, we managed to use Config class in tests because we `require` it directly from `lib` folder by specifying the folder name. This is not desirable for end users.
With this PR users will be able to import
- HazelcastClient as `require('hazelcast-nodejs-client).Client`
- Config as `require('hazelcast-nodejs-client').Config`

This PR also adds `"typings": "lib/index.d.ts"` line to tsconfig.json. Typescript users will be able to use static type checking.

Adds `"target": "es5"` to tsconfig. Default was es3. Node.js fully supports es5. There is no compatibility issues with it.