### PR TITLE
Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ npm-debug.log
 # TypeScript
 *.js.map
 lib/*
+
+# TSDoc
+docs/

--- a/package.json
+++ b/package.json
@@ -1,57 +1,59 @@
 {
-  "name": "hazelcast-nodejs-client",
-  "version": "0.1.0",
-  "description": "Hazelcast - open source In-Memory Data Grid - client for NodeJS",
-  "main": "lib/index.js",
-  "dependencies": {
-    "long": "3.0.1",
-    "q": "1.4.1"
-  },
-  "devDependencies": {
-    "chai": "3.4.1",
-    "gulp": "^3.9.0",
-    "gulp-debug": "^2.1.2",
-    "gulp-eslint": "^1.0.0",
-    "gulp-exclude-gitignore": "^1.0.0",
-    "gulp-exec": "^2.1.2",
-    "gulp-help": "^1.6.0",
-    "gulp-inject": "3.0.0",
-    "gulp-istanbul": "^0.9.0",
-    "gulp-jshint": "^2.0.0",
-    "gulp-mocha": "^2.0.0",
-    "gulp-nsp": "^2.1.0",
-    "gulp-plumber": "^1.0.0",
-    "gulp-sequence": "^0.4.4",
-    "gulp-tsconfig-files": "0.0.2",
-    "gulp-tslint": "^3.1",
-    "jshint": "^2.8.0",
-    "jshint-stylish": "^2.1.0",
-    "mocha": "2.3.4",
-    "rimraf": "^2.5.2",
-    "sinon": "^1.17.3",
-    "typescript": "^1.8.10",
-    "typings": "^0.7.12",
-    "winston": "^2.2.0"
-  },
-  "scripts": {
-    "test": "gulp test"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/hazelcast/hazelcast-nodejs-client.git"
-  },
-  "keywords": [
-    "hazelcast",
-    "nodejs",
-    "node",
-    "client",
-    "data",
-    "grid"
-  ],
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/hazelcast/hazelcast-nodejs-client/issues"
-  },
-  "homepage": "https://github.com/hazelcast/hazelcast-nodejs-client#readme",
-  "typings": "./lib/index"
+    "name": "hazelcast-nodejs-client",
+    "version": "0.1.0",
+    "description": "Hazelcast - open source In-Memory Data Grid - client for NodeJS",
+    "main": "lib/index.js",
+    "dependencies": {
+        "long": "3.0.1",
+        "q": "1.4.1"
+    },
+    "devDependencies": {
+        "chai": "3.4.1",
+        "gulp": "^3.9.0",
+        "gulp-debug": "^2.1.2",
+        "gulp-eslint": "^1.0.0",
+        "gulp-exclude-gitignore": "^1.0.0",
+        "gulp-exec": "^2.1.2",
+        "gulp-help": "^1.6.0",
+        "gulp-inject": "3.0.0",
+        "gulp-istanbul": "^0.9.0",
+        "gulp-jshint": "^2.0.0",
+        "gulp-mocha": "^2.0.0",
+        "gulp-nsp": "^2.1.0",
+        "gulp-plumber": "^1.0.0",
+        "gulp-sequence": "^0.4.4",
+        "gulp-tsconfig-files": "0.0.2",
+        "gulp-tslint": "^3.1",
+        "jshint": "^2.8.0",
+        "jshint-stylish": "^2.1.0",
+        "mocha": "2.3.4",
+        "rimraf": "^2.5.2",
+        "sinon": "^1.17.3",
+        "typescript": "^1.8.10",
+        "typings": "^0.7.12",
+        "typedoc": "^0.3.12",
+        "winston": "^2.2.0"
+    },
+    "scripts": {
+        "test": "gulp test",
+        "typedoc": "typedoc --out docs/ --exclude src/codec/*.ts --module commonjs src typings/main"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/hazelcast/hazelcast-nodejs-client.git"
+    },
+    "keywords": [
+        "hazelcast",
+        "nodejs",
+        "node",
+        "client",
+        "data",
+        "grid"
+    ],
+    "license": "Apache-2.0",
+    "bugs": {
+        "url": "https://github.com/hazelcast/hazelcast-nodejs-client/issues"
+    },
+    "homepage": "https://github.com/hazelcast/hazelcast-nodejs-client#readme",
+    "typings": "./lib/index"
 }

--- a/src/ClientInfo.ts
+++ b/src/ClientInfo.ts
@@ -1,7 +1,16 @@
 import {Socket} from 'net';
 import Address = require('./Address');
 export class ClientInfo {
+    /**
+     * Unique id of this client instance. It is provided by owner server instance.
+     */
     uuid: string;
+    /**
+     * Local port address that is used to communicate with cluster.
+     */
     localAddress: Address;
-    type = 'NodeJS';
+    /**
+     * Type of this client. It is always NodeJS.
+     */
+    type: string = 'NodeJS';
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -2,8 +2,18 @@ import Address = require('./Address');
 const DEFAULT_GROUP_NAME = 'dev';
 const DEFAULT_GROUP_PASSWORD = 'dev-pass';
 
+/**
+ * Group configuration of the cluster that this client connects.
+ * A client will connect to only the cluster with these properties.
+ */
 export class GroupConfig {
+    /**
+     * Cluster group name.
+     */
     name: string = DEFAULT_GROUP_NAME;
+    /**
+     * Cluster group password.
+     */
     password: string = DEFAULT_GROUP_PASSWORD;
 }
 
@@ -11,13 +21,42 @@ export class SocketOptions {
     //TO-DO
 }
 
+/**
+ * Network configuration
+ */
 export class ClientNetworkConfig {
+    /**
+     * Client tries to connect the members at these addresses.
+     */
     addresses: Address[];
+
+    /**
+     * While client is trying to connect initially to one of the members in the {@link addresses},
+     * all might be not available. Instead of giving up, throwing Exception and stopping client, it will
+     * attempt to retry as much as {@link connectionAttemptLimit} times.
+     */
     connectionAttemptLimit: number = 2;
+    /**
+     * Period for the next attempt to find a member to connect.
+     */
     connectionAttemptPeriod: number = 3000;
+    /**
+     * Timeout value in millis for nodes to accept client connection requests.
+     */
     connectionTimeout: number = 5000;
+    /**
+     * true if redo operations are enabled (not implemented yet)
+     */
     redoOperation: boolean = false;
+    /**
+     * If true, client will behave as smart client instead of dummy client. Smart client sends key based operations
+     * to owner of the keys. Dummy client sends all operations to a single node. See http://docs.hazelcast.org to
+     * learn about smart/dummy client.
+     */
     smartRouting: boolean = true;
+    /**
+     * Not implemented.
+     */
     socketOptions: SocketOptions = new SocketOptions();
 
     constructor() {
@@ -39,6 +78,9 @@ export interface LifecycleListener {
     (event: string): void;
 }
 
+/**
+ * Configurations for LifecycleListeners. These are registered as soon as client started.
+ */
 export class ListenerConfig {
     lifecycle: Function[] = [];
 
@@ -51,7 +93,13 @@ export class ListenerConfig {
     }
 }
 
+/**
+ * Top level configuration object of Hazelcast client. Other configurations items are properties of this object.
+ */
 export class ClientConfig {
+    /**
+     * Name of this client instance.
+     */
     instanceName: string;
     properties: any = {
         'hazelcast.client.heartbeat.interval': 5000,

--- a/src/ConnectionHeartbeatListener.ts
+++ b/src/ConnectionHeartbeatListener.ts
@@ -1,5 +1,16 @@
 import ClientConnection = require('./invocation/ClientConnection');
+/**
+ * Listener interface for heartbeat service.
+ */
 export interface ConnectionHeartbeatListener {
+    /**
+     * Invoked when heartbeat of a server is restored after stopped.
+     * @param connection connection object associated with that server node.
+     */
     onHeartbeatRestored?: (connection?: ClientConnection) => void;
+    /**
+     * Invoked when heartbeat of a server node failed.
+     * @param connection connection object associated with that server node.
+     */
     onHeartbeatStopped?: (connection?: ClientConnection) => void;
 }

--- a/src/DistributedObject.ts
+++ b/src/DistributedObject.ts
@@ -1,6 +1,6 @@
 import * as Q from 'q';
 export interface DistributedObject {
-    /*
+    /**
      * Returns the key of the partition that this DistributedObject is assigned to.
      * For a partitioned data structure, the returned value will not be null, but otherwise undefined.
      */

--- a/src/Heartbeat.ts
+++ b/src/Heartbeat.ts
@@ -6,11 +6,13 @@ import * as Q from 'q';
 import {LoggingService} from './LoggingService';
 import Address = require('./Address');
 
-var PROPERTY_HEARTBEAT_INTERVAL: string = 'hazelcast.client.heartbeat.interval';
-var PROPERTY_HEARTBEAT_TIMEOUT: string = 'hazelcast.client.heartbeat.timeout';
+const PROPERTY_HEARTBEAT_INTERVAL: string = 'hazelcast.client.heartbeat.interval';
+const PROPERTY_HEARTBEAT_TIMEOUT: string = 'hazelcast.client.heartbeat.timeout';
 
+/**
+ * Hearbeat Service
+ */
 class Heartbeat {
-
     private client: HazelcastClient;
     private heartbeatTimeout: number;
     private heartbeatInterval: number;
@@ -27,14 +29,24 @@ class Heartbeat {
         this.heartbeatTimeout = this.client.getConfig().properties[PROPERTY_HEARTBEAT_TIMEOUT];
     }
 
+    /**
+     * Starts sending periodic heartbeat operations.
+     */
     start() {
         this.timer = setTimeout(this.heartbeatFunction.bind(this), this.heartbeatInterval);
     }
 
+    /**
+     * Cancels scheduled heartbeat operations.
+     */
     cancel() {
         clearTimeout(this.timer);
     }
 
+    /**
+     * Registers a heartbeat listener. Listener is invoked when a heartbeat related event occurs.
+     * @param heartbeatListener
+     */
     addListener(heartbeatListener: ConnectionHeartbeatListener) {
         this.listeners.push(heartbeatListener);
     }

--- a/src/LifecycleService.ts
+++ b/src/LifecycleService.ts
@@ -1,14 +1,35 @@
 import {EventEmitter} from 'events';
 import HazelcastClient from './HazelcastClient';
 
+/**
+ * Lifecycle events.
+ */
 export var LifecycleEvent = {
+    /**
+     * events are emitted with this name.
+     */
     name: 'lifecycleEvent',
+    /**
+     * From creation of client to connected state.
+     */
     starting: 'starting',
+    /**
+     * Client is connected to cluster. Ready to use.
+     */
     started: 'started',
+    /**
+     * Disconnect initiated.
+     */
     shuttingDown: 'shuttingDown',
+    /**
+     * Disconnect completed gracefully.
+     */
     shutdown: 'shutdown'
 };
 
+/**
+ * LifecycleService
+ */
 export class LifecycleService extends EventEmitter {
     private active: boolean;
     private client: HazelcastClient;
@@ -29,6 +50,10 @@ export class LifecycleService extends EventEmitter {
         this.emit(LifecycleEvent.name, LifecycleEvent.starting);
     }
 
+    /**
+     * Causes LifecycleService to emit given event to all registered listeners.
+     * @param state
+     */
     emitLifecycleEvent(state: string): void {
         if ( !LifecycleEvent.hasOwnProperty(state)) {
             throw new Error(state + ' is not a valid lifecycle event');
@@ -41,6 +66,10 @@ export class LifecycleService extends EventEmitter {
         this.emit(LifecycleEvent.name, state);
     }
 
+    /**
+     * Returns the active state of the client.
+     * @returns {boolean}
+     */
     isRunning(): boolean {
         return this.active;
     }

--- a/src/Member.ts
+++ b/src/Member.ts
@@ -1,7 +1,16 @@
 import Address = require('./Address');
 export class Member {
+    /**
+     * Network address of member.
+     */
     address: Address;
+    /**
+     * Unique id of member in cluster.
+     */
     uuid: string;
+    /**
+     * true if member is a lite member.
+     */
     isLiteMember: boolean;
     attributes: {[id: string]: string};
 

--- a/src/PartitionService.ts
+++ b/src/PartitionService.ts
@@ -23,6 +23,10 @@ class PartitionService {
         return deferred.promise;
     }
 
+    /**
+     * Refreshes the internal partition table.
+     * @returns {Q.Promise<U>}
+     */
     refresh(): Q.Promise<void> {
         var ownerConnection = this.client.getClusterService().getOwnerConnection();
         var clientMessage: ClientMessage = GetPartitionsCodec.encodeRequest();
@@ -35,10 +39,20 @@ class PartitionService {
             });
     };
 
+    /**
+     * Returns the {@link Address} of the node which owns given partition id.
+     * @param partitionId
+     * @returns the address of the node.
+     */
     getAddressForPartition(partitionId: number): Address {
         return this.partitionMap[partitionId];
     }
 
+    /**
+     * Computes the partition id for a given key.
+     * @param key
+     * @returns the partition id.
+     */
     getPartitionId(key: any) {
         var partitionHash = this.client.getSerializationService().toData(key).getPartitionHash();
         return Math.abs(partitionHash) % this.partitionCount;

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -19,14 +19,26 @@ class ClientConnection {
         this.lastRead = 0;
     }
 
+    /**
+     * Returns the address of local port that is associated with this connection.
+     * @returns
+     */
     getLocalAddress() {
         return new Address(this.socket.localAddress, this.socket.localPort);
     }
 
+    /**
+     * Returns the address of remote node that is associated with this connection.
+     * @returns
+     */
     getAddress(): Address {
         return this.address;
     }
 
+    /**
+     * Connects to remote server and sets the hazelcast protocol.
+     * @returns
+     */
     connect(): Q.Promise<ClientConnection> {
         var ready = Q.defer<ClientConnection>();
 
@@ -62,10 +74,17 @@ class ClientConnection {
         return deferred.promise;
     }
 
+    /**
+     * Closes this connection.
+     */
     close() {
         this.socket.destroy();
     }
 
+    /**
+     * Registers a function to pass received data on 'data' events on this connection.
+     * @param callback
+     */
     registerResponseCallback(callback: Function) {
         this.socket.on('data', (buffer: Buffer) => {
             this.lastRead = new Date().getTime();

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -15,6 +15,9 @@ import HazelcastClient from '../HazelcastClient';
 const EMIT_CONNECTION_CLOSED = 'connectionClosed';
 const EMIT_CONNECTION_OPENED = 'connectionOpened';
 
+/**
+ * Maintains connections between the client and members of the cluster.
+ */
 class ClientConnectionManager extends EventEmitter {
     private client: HazelcastClient;
     private pendingConnections: {[address: string]: Q.Deferred<ClientConnection>} = {};
@@ -26,6 +29,13 @@ class ClientConnectionManager extends EventEmitter {
         this.client = client;
     }
 
+    /**
+     * Returns the {@link ClientConnection} with given {@link Address}. If there is no such connection established,
+     * it first connects to the address and then return the {@link ClientConnection}.
+     * @param address
+     * @param ownerConnection Sets the connected node as owner of this client if true.
+     * @returns {Promise<ClientConnection>|Promise<T>}
+     */
     getOrConnect(address: Address, ownerConnection: boolean = false): Q.Promise<ClientConnection> {
         var addressIndex = Address.encodeToString(address);
         var result: Q.Deferred<ClientConnection> = Q.defer<ClientConnection>();
@@ -70,6 +80,10 @@ class ClientConnectionManager extends EventEmitter {
         return result.promise;
     }
 
+    /**
+     * Destroys the connection with given node address.
+     * @param address
+     */
     destroyConnection(address: Address): void {
         var addressStr = Address.encodeToString(address);
         if (this.pendingConnections.hasOwnProperty(addressStr)) {

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -20,12 +20,19 @@ const ATTRIBUTE_CHANGE: {[key: string]: string} = {
     2: 'remove'
 };
 
+/**
+ * Manages the relationship of this client with the cluster.
+ */
 class ClusterService extends EventEmitter {
 
-    // The unique identifier of the owner server node. This node is responsible for resource cleanup
+    /**
+     * The unique identifier of the owner server node. This node is responsible for resource cleanup
+     */
     public ownerUuid: string = null;
 
-    // The unique identifier of this client instance. Assigned by owner node on authentication
+    /**
+     * The unique identifier of this client instance. Assigned by owner node on authentication
+     */
     public uuid: string = null;
 
     private knownAddresses: Address[] = [];
@@ -41,12 +48,20 @@ class ClusterService extends EventEmitter {
         this.members = [];
     }
 
+    /**
+     * Starts cluster service.
+     * @returns
+     */
     start(): Q.Promise<void> {
         this.initHeartbeatListener();
         this.initConnectionListener();
         return this.connectToCluster();
     }
 
+    /**
+     * Connects to cluster. It uses the addresses provided in the configuration.
+     * @returns
+     */
     connectToCluster(): Q.Promise<void> {
         if (this.members.length > 0) {
             this.knownAddresses = new Array<Address>();
@@ -64,14 +79,26 @@ class ClusterService extends EventEmitter {
         return deferred.promise;
     }
 
+    /**
+     * Returns the list of members in the cluster.
+     * @returns
+     */
     getMembers() {
         return this.members;
     }
 
+    /**
+     * Returns the number of nodes in cluster.
+     * @returns {number}
+     */
     getSize() {
         return this.members.length;
     }
 
+    /**
+     * Returns information about this client.
+     * @returns {ClientInfo}
+     */
     getClientInfo(): ClientInfo {
         var info = new ClientInfo();
         info.uuid = this.uuid;
@@ -134,6 +161,10 @@ class ClusterService extends EventEmitter {
         });
     }
 
+    /**
+     * Returns the connection associated with owner node of this client.
+     * @returns {ClientConnection}
+     */
     getOwnerConnection(): ClientConnection {
         return this.ownerConnection;
     }


### PR DESCRIPTION
Adds API documentation, uses Typedoc.
When you run `npm run typedoc` it creates html documentation using stylized comments on top of functions, properties and classes. Documentation is located under `docs` folder. It is added to `.gitignore` but NOT added to `.npmignore`. So docs folder will not be in github repository but when we `npm publish` the package, it will be added to npm repo. When somebody pulls the repo through npm, they will have `docs`.

Fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/85