### PR TITLE
Update version and change name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "hazelcast-nodejs-client",
-    "version": "0.1.0",
+    "name": "hazelcast-client",
+    "version": "0.2.0",
     "description": "Hazelcast - open source In-Memory Data Grid - client for NodeJS",
     "main": "lib/index.js",
     "dependencies": {
@@ -31,7 +31,6 @@
         "sinon": "^1.17.3",
         "typescript": "^1.8.10",
         "typings": "^0.7.12",
-        "typedoc": "^0.3.12",
         "winston": "^2.2.0"
     },
     "scripts": {


### PR DESCRIPTION
- Update version to 0.2.0.
- Change package name to `hazelcast-client`. It was `hazelcast-nodejs-client`.