### PR TITLE
integrate remap istanbul and see typescript coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "chai-as-promised": "5.3.0",
     "istanbul": "0.4.3",
     "mocha": "2.4.5",
+    "remap-istanbul": "0.6.4",
     "rimraf": "2.5.2",
     "sinon": "1.17.3",
     "tslint": "3.10.1",
@@ -25,7 +26,8 @@
     "precompile": "typings install",
     "compile": "tsc",
     "test": "mocha --recursive",
-    "coverage": "rimraf coverage && istanbul cover --root lib/ --include-all-sources --report html --report cobertura _mocha -- --recursive --reporter spec",
+    "coverage": "rimraf coverage && istanbul cover --root lib/ --include-all-sources _mocha -- --recursive --reporter spec",
+    "postcoverage": "remap-istanbul -i coverage/coverage.json -o coverage/cobertura-coverage.xml -t cobertura && remap-istanbul -i coverage/coverage.json -o coverage -t html",
     "generate-docs": "rimraf docs && typedoc --out docs/ --exclude src/codec/*.ts --module commonjs src typings/main",
     "lint": "tslint src/*.ts src/**/*.ts src/**/**/*.ts"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "outDir": "./lib",
         "preserveConstEnums": true,
         "noLib": true,
-        "removeComments": true
+        "removeComments": true,
+        "sourceMap": true
     },
     "filesGlob": [
         "src/**/*.ts"


### PR DESCRIPTION
With this PR, our code coverage information(which depends on compiled JS code) is represented in Typescript code. This is useful as coverage information is more reliable now because Typescript compiler generates some multi statement-multi branch JS code for some single TS statements. This is mostly the case with `extends` keyword. We now can concentrate on what is covered in our code, not TS compiler.
And also coverage information is easier to track as it is projected on TS files(not JS files).

As a sidenote: typescript compiler generates source maps now. So you can put breakpoints on TS files directly instead of JS files when debugging.