### PR TITLE
Map Predicates

### DIFF
--- a/src/codec/MapAddEntryListenerCodec.ts
+++ b/src/codec/MapAddEntryListenerCodec.ts
@@ -1,25 +1,23 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_ADDENTRYLISTENER;
 var RESPONSE_TYPE = 104;
 var RETRYABLE = false;
 
-
 export class MapAddEntryListenerCodec {
 
-
-    static calculateSize(name:string, includeValue:boolean, listenerFlags:number, localOnly:boolean) {
-        // Calculates the request payload size
-        var dataSize:number = 0;
+    static calculateSize(name: string, includeValue: boolean, listenerFlags: number, localOnly: boolean) {
+// Calculates the request payload size
+        var dataSize: number = 0;
         dataSize += BitsUtil.calculateSizeString(name);
         dataSize += BitsUtil.BOOLEAN_SIZE_IN_BYTES;
         dataSize += BitsUtil.INT_SIZE_IN_BYTES;
@@ -27,8 +25,8 @@ export class MapAddEntryListenerCodec {
         return dataSize;
     }
 
-    static encodeRequest(name:string, includeValue:boolean, listenerFlags:number, localOnly:boolean) {
-        // Encode request into clientMessage
+    static encodeRequest(name: string, includeValue: boolean, listenerFlags: number, localOnly: boolean) {
+// Encode request into clientMessage
         var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, includeValue, listenerFlags, localOnly));
         clientMessage.setMessageType(REQUEST_TYPE);
         clientMessage.setRetryable(RETRYABLE);
@@ -40,43 +38,43 @@ export class MapAddEntryListenerCodec {
         return clientMessage;
     }
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
-        // Decode response from client message
-        var parameters:any = {'response': null};
+    static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
+// Decode response from client message
+        var parameters: any = {'response': null};
         parameters['response'] = clientMessage.readString();
         return parameters;
 
     }
 
-    static handle(clientMessage:ClientMessage, handleEventEntry:any, toObjectFunction:(data:Data) => any = null) {
+    static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {
 
         var messageType = clientMessage.getMessageType();
         if (messageType === BitsUtil.EVENT_ENTRY && handleEventEntry !== null) {
-            var key:Data;
+            var key: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                key = toObjectFunction(clientMessage.readData());
+                key = clientMessage.readData();
             }
-            var value:Data;
+            var value: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                value = toObjectFunction(clientMessage.readData());
+                value = clientMessage.readData();
             }
-            var oldValue:Data;
+            var oldValue: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                oldValue = toObjectFunction(clientMessage.readData());
+                oldValue = clientMessage.readData();
             }
-            var mergingValue:Data;
+            var mergingValue: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                mergingValue = toObjectFunction(clientMessage.readData());
+                mergingValue = clientMessage.readData();
             }
-            var eventType:number;
+            var eventType: number;
             eventType = clientMessage.readInt32();
-            var uuid:string;
+            var uuid: string;
             uuid = clientMessage.readString();
-            var numberOfAffectedEntries:number;
+            var numberOfAffectedEntries: number;
             numberOfAffectedEntries = clientMessage.readInt32();
             handleEventEntry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
         }

--- a/src/codec/MapAddEntryListenerToKeyWithPredicateCodec.ts
+++ b/src/codec/MapAddEntryListenerToKeyWithPredicateCodec.ts
@@ -1,25 +1,23 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_ADDENTRYLISTENERTOKEYWITHPREDICATE;
 var RESPONSE_TYPE = 104;
 var RETRYABLE = false;
 
-
 export class MapAddEntryListenerToKeyWithPredicateCodec {
 
-
-    static calculateSize(name:string, key:Data, predicate:Data, includeValue:boolean, listenerFlags:number, localOnly:boolean) {
+    static calculateSize(name: string, key: Data, predicate: Data, includeValue: boolean, listenerFlags: number, localOnly: boolean) {
         // Calculates the request payload size
-        var dataSize:number = 0;
+        var dataSize: number = 0;
         dataSize += BitsUtil.calculateSizeString(name);
         dataSize += BitsUtil.calculateSizeData(key);
         dataSize += BitsUtil.calculateSizeData(predicate);
@@ -29,7 +27,7 @@ export class MapAddEntryListenerToKeyWithPredicateCodec {
         return dataSize;
     }
 
-    static encodeRequest(name:string, key:Data, predicate:Data, includeValue:boolean, listenerFlags:number, localOnly:boolean) {
+    static encodeRequest(name: string, key: Data, predicate: Data, includeValue: boolean, listenerFlags: number, localOnly: boolean) {
         // Encode request into clientMessage
         var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, key, predicate, includeValue, listenerFlags, localOnly));
         clientMessage.setMessageType(REQUEST_TYPE);
@@ -44,43 +42,43 @@ export class MapAddEntryListenerToKeyWithPredicateCodec {
         return clientMessage;
     }
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
+    static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
         // Decode response from client message
-        var parameters:any = {'response': null};
+        var parameters: any = {'response': null};
         parameters['response'] = clientMessage.readString();
         return parameters;
 
     }
 
-    static handle(clientMessage:ClientMessage, handleEventEntry:any, toObjectFunction:(data:Data) => any = null) {
+    static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {
 
         var messageType = clientMessage.getMessageType();
         if (messageType === BitsUtil.EVENT_ENTRY && handleEventEntry !== null) {
-            var key:Data;
+            var key: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                key = toObjectFunction(clientMessage.readData());
+                key = clientMessage.readData();
             }
-            var value:Data;
+            var value: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                value = toObjectFunction(clientMessage.readData());
+                value = clientMessage.readData();
             }
-            var oldValue:Data;
+            var oldValue: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                oldValue = toObjectFunction(clientMessage.readData());
+                oldValue = clientMessage.readData();
             }
-            var mergingValue:Data;
+            var mergingValue: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                mergingValue = toObjectFunction(clientMessage.readData());
+                mergingValue = clientMessage.readData();
             }
-            var eventType:number;
+            var eventType: number;
             eventType = clientMessage.readInt32();
-            var uuid:string;
+            var uuid: string;
             uuid = clientMessage.readString();
-            var numberOfAffectedEntries:number;
+            var numberOfAffectedEntries: number;
             numberOfAffectedEntries = clientMessage.readInt32();
             handleEventEntry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
         }

--- a/src/codec/MapAddEntryListenerWithPredicateCodec.ts
+++ b/src/codec/MapAddEntryListenerWithPredicateCodec.ts
@@ -1,25 +1,23 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_ADDENTRYLISTENERWITHPREDICATE;
 var RESPONSE_TYPE = 104;
 var RETRYABLE = false;
 
-
 export class MapAddEntryListenerWithPredicateCodec {
 
-
-    static calculateSize(name:string, predicate:Data, includeValue:boolean, listenerFlags:number, localOnly:boolean) {
+    static calculateSize(name: string, predicate: Data, includeValue: boolean, listenerFlags: number, localOnly: boolean) {
         // Calculates the request payload size
-        var dataSize:number = 0;
+        var dataSize: number = 0;
         dataSize += BitsUtil.calculateSizeString(name);
         dataSize += BitsUtil.calculateSizeData(predicate);
         dataSize += BitsUtil.BOOLEAN_SIZE_IN_BYTES;
@@ -28,7 +26,7 @@ export class MapAddEntryListenerWithPredicateCodec {
         return dataSize;
     }
 
-    static encodeRequest(name:string, predicate:Data, includeValue:boolean, listenerFlags:number, localOnly:boolean) {
+    static encodeRequest(name: string, predicate: Data, includeValue: boolean, listenerFlags: number, localOnly: boolean) {
         // Encode request into clientMessage
         var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate, includeValue, listenerFlags, localOnly));
         clientMessage.setMessageType(REQUEST_TYPE);
@@ -42,43 +40,43 @@ export class MapAddEntryListenerWithPredicateCodec {
         return clientMessage;
     }
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
+    static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
         // Decode response from client message
-        var parameters:any = {'response': null};
+        var parameters: any = {'response': null};
         parameters['response'] = clientMessage.readString();
         return parameters;
 
     }
 
-    static handle(clientMessage:ClientMessage, handleEventEntry:any, toObjectFunction:(data:Data) => any = null) {
+    static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {
 
         var messageType = clientMessage.getMessageType();
         if (messageType === BitsUtil.EVENT_ENTRY && handleEventEntry !== null) {
-            var key:Data;
+            var key: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                key = toObjectFunction(clientMessage.readData());
+                key = clientMessage.readData();
             }
-            var value:Data;
+            var value: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                value = toObjectFunction(clientMessage.readData());
+                value = clientMessage.readData();
             }
-            var oldValue:Data;
+            var oldValue: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                oldValue = toObjectFunction(clientMessage.readData());
+                oldValue = clientMessage.readData();
             }
-            var mergingValue:Data;
+            var mergingValue: Data;
 
             if (clientMessage.readBoolean() !== true) {
-                mergingValue = toObjectFunction(clientMessage.readData());
+                mergingValue = clientMessage.readData();
             }
-            var eventType:number;
+            var eventType: number;
             eventType = clientMessage.readInt32();
-            var uuid:string;
+            var uuid: string;
             uuid = clientMessage.readString();
-            var numberOfAffectedEntries:number;
+            var numberOfAffectedEntries: number;
             numberOfAffectedEntries = clientMessage.readInt32();
             handleEventEntry(key, value, oldValue, mergingValue, eventType, uuid, numberOfAffectedEntries);
         }

--- a/src/codec/MapEntriesWithPagingPredicateCodec.ts
+++ b/src/codec/MapEntriesWithPagingPredicateCodec.ts
@@ -1,31 +1,29 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_ENTRIESWITHPAGINGPREDICATE;
 var RESPONSE_TYPE = 117;
 var RETRYABLE = false;
 
-
 export class MapEntriesWithPagingPredicateCodec {
 
-
-    static calculateSize(name:string, predicate:Data) {
+    static calculateSize(name: string, predicate: Data) {
         // Calculates the request payload size
-        var dataSize:number = 0;
+        var dataSize: number = 0;
         dataSize += BitsUtil.calculateSizeString(name);
         dataSize += BitsUtil.calculateSizeData(predicate);
         return dataSize;
     }
 
-    static encodeRequest(name:string, predicate:Data) {
+    static encodeRequest(name: string, predicate: Data) {
         // Encode request into clientMessage
         var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
         clientMessage.setMessageType(REQUEST_TYPE);
@@ -36,20 +34,23 @@ export class MapEntriesWithPagingPredicateCodec {
         return clientMessage;
     }
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
+    static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
         // Decode response from client message
-        var parameters:any = {'response': null};
+        var parameters: any = {'response': null};
         var responseSize = clientMessage.readInt32();
-        var response:any = [];
-        for (var responseIndex = 0; responseIndex <= responseSize; responseIndex++) {
-            var responseItem:any;
-            responseItem = clientMessage.readMapEntry();
+        var response: any = [];
+        for (var responseIndex = 0; responseIndex < responseSize; responseIndex++) {
+            var responseItem: any;
+            var responseItemKey: Data;
+            var responseItemVal: any;
+            responseItemKey = clientMessage.readData();
+            responseItemVal = clientMessage.readData();
+            responseItem = [responseItemKey, responseItemVal];
             response.push(responseItem)
         }
-        parameters['response'] = new ImmutableLazyDataList(response, toObjectFunction);
+        parameters['response'] = response;
         return parameters;
 
     }
-
 
 }

--- a/src/codec/MapEntriesWithPredicateCodec.ts
+++ b/src/codec/MapEntriesWithPredicateCodec.ts
@@ -1,12 +1,12 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_ENTRIESWITHPREDICATE;
@@ -14,42 +14,47 @@ var RESPONSE_TYPE = 117;
 var RETRYABLE = false;
 
 
-export class MapEntriesWithPredicateCodec {
+export class MapEntriesWithPredicateCodec{
 
 
-    static calculateSize(name:string, predicate:Data) {
-        // Calculates the request payload size
-        var dataSize:number = 0;
-        dataSize += BitsUtil.calculateSizeString(name);
-        dataSize += BitsUtil.calculateSizeData(predicate);
-        return dataSize;
-    }
 
-    static encodeRequest(name:string, predicate:Data) {
-        // Encode request into clientMessage
-        var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
-        clientMessage.setMessageType(REQUEST_TYPE);
-        clientMessage.setRetryable(RETRYABLE);
-        clientMessage.appendString(name);
-        clientMessage.appendData(predicate);
-        clientMessage.updateFrameLength();
-        return clientMessage;
-    }
+static calculateSize(name : string  , predicate : Data ){
+// Calculates the request payload size
+var dataSize : number = 0;
+            dataSize += BitsUtil.calculateSizeString(name);
+            dataSize += BitsUtil.calculateSizeData(predicate);
+return dataSize;
+}
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
-        // Decode response from client message
-        var parameters:any = {'response': null};
+static encodeRequest(name : string, predicate : Data){
+// Encode request into clientMessage
+var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
+clientMessage.setMessageType(REQUEST_TYPE);
+clientMessage.setRetryable(RETRYABLE);
+    clientMessage.appendString(name);
+    clientMessage.appendData(predicate);
+clientMessage.updateFrameLength();
+return clientMessage;
+}
+
+static decodeResponse(clientMessage : ClientMessage,  toObjectFunction: (data: Data) => any = null){
+// Decode response from client message
+var parameters :any = { 'response' : null  };
         var responseSize = clientMessage.readInt32();
-        var response:any = [];
-        for (var responseIndex = 0; responseIndex <= responseSize; responseIndex++) {
-            var responseItem:any;
-            responseItem = clientMessage.readMapEntry();
-            response.push(responseItem)
+            var response : any = [];
+                    for(var responseIndex = 0 ;  responseIndex < responseSize ; responseIndex++){
+        var responseItem : any;
+        var responseItemKey: Data;
+        var responseItemVal: any;
+                    responseItemKey = clientMessage.readData();
+                    responseItemVal = clientMessage.readData();
+        responseItem = [responseItemKey, responseItemVal];
+        response.push(responseItem)
         }
-        parameters['response'] = new ImmutableLazyDataList(response, toObjectFunction);
-        return parameters;
+            parameters['response'] = response;
+return parameters;
 
-    }
+}
 
 
 }

--- a/src/codec/MapKeySetWithPagingPredicateCodec.ts
+++ b/src/codec/MapKeySetWithPagingPredicateCodec.ts
@@ -1,31 +1,29 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_KEYSETWITHPAGINGPREDICATE;
 var RESPONSE_TYPE = 106;
 var RETRYABLE = false;
 
-
 export class MapKeySetWithPagingPredicateCodec {
 
-
-    static calculateSize(name:string, predicate:Data) {
+    static calculateSize(name: string, predicate: Data) {
         // Calculates the request payload size
-        var dataSize:number = 0;
+        var dataSize: number = 0;
         dataSize += BitsUtil.calculateSizeString(name);
         dataSize += BitsUtil.calculateSizeData(predicate);
         return dataSize;
     }
 
-    static encodeRequest(name:string, predicate:Data) {
+    static encodeRequest(name: string, predicate: Data) {
         // Encode request into clientMessage
         var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
         clientMessage.setMessageType(REQUEST_TYPE);
@@ -36,20 +34,19 @@ export class MapKeySetWithPagingPredicateCodec {
         return clientMessage;
     }
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
+    static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
         // Decode response from client message
-        var parameters:any = {'response': null};
+        var parameters: any = {'response': null};
         var responseSize = clientMessage.readInt32();
-        var response:any = [];
-        for (var responseIndex = 0; responseIndex <= responseSize; responseIndex++) {
-            var responseItem:Data;
-            responseItem = toObjectFunction(clientMessage.readData());
+        var response: any = [];
+        for (var responseIndex = 0; responseIndex < responseSize; responseIndex++) {
+            var responseItem: Data;
+            responseItem = clientMessage.readData();
             response.push(responseItem)
         }
-        parameters['response'] = new ImmutableLazyDataList(response, toObjectFunction);
+        parameters['response'] = response;
         return parameters;
 
     }
-
 
 }

--- a/src/codec/MapKeySetWithPredicateCodec.ts
+++ b/src/codec/MapKeySetWithPredicateCodec.ts
@@ -1,31 +1,29 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_KEYSETWITHPREDICATE;
 var RESPONSE_TYPE = 106;
 var RETRYABLE = false;
 
-
 export class MapKeySetWithPredicateCodec {
 
-
-    static calculateSize(name:string, predicate:Data) {
+    static calculateSize(name: string, predicate: Data) {
         // Calculates the request payload size
-        var dataSize:number = 0;
+        var dataSize: number = 0;
         dataSize += BitsUtil.calculateSizeString(name);
         dataSize += BitsUtil.calculateSizeData(predicate);
         return dataSize;
     }
 
-    static encodeRequest(name:string, predicate:Data) {
+    static encodeRequest(name: string, predicate: Data) {
         // Encode request into clientMessage
         var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
         clientMessage.setMessageType(REQUEST_TYPE);
@@ -36,20 +34,19 @@ export class MapKeySetWithPredicateCodec {
         return clientMessage;
     }
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
+    static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
         // Decode response from client message
-        var parameters:any = {'response': null};
+        var parameters: any = {'response': null};
         var responseSize = clientMessage.readInt32();
-        var response:any = [];
-        for (var responseIndex = 0; responseIndex <= responseSize; responseIndex++) {
-            var responseItem:Data;
-            responseItem = toObjectFunction(clientMessage.readData());
+        var response: any = [];
+        for (var responseIndex = 0; responseIndex < responseSize; responseIndex++) {
+            var responseItem: Data;
+            responseItem = clientMessage.readData();
             response.push(responseItem)
         }
-        parameters['response'] = new ImmutableLazyDataList(response, toObjectFunction);
+        parameters['response'] = response;
         return parameters;
 
     }
-
 
 }

--- a/src/codec/MapValuesWithPagingPredicateCodec.ts
+++ b/src/codec/MapValuesWithPagingPredicateCodec.ts
@@ -1,12 +1,12 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_VALUESWITHPAGINGPREDICATE;
@@ -14,42 +14,47 @@ var RESPONSE_TYPE = 117;
 var RETRYABLE = false;
 
 
-export class MapValuesWithPagingPredicateCodec {
+export class MapValuesWithPagingPredicateCodec{
 
 
-    static calculateSize(name:string, predicate:Data) {
-        // Calculates the request payload size
-        var dataSize:number = 0;
-        dataSize += BitsUtil.calculateSizeString(name);
-        dataSize += BitsUtil.calculateSizeData(predicate);
-        return dataSize;
-    }
 
-    static encodeRequest(name:string, predicate:Data) {
-        // Encode request into clientMessage
-        var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
-        clientMessage.setMessageType(REQUEST_TYPE);
-        clientMessage.setRetryable(RETRYABLE);
-        clientMessage.appendString(name);
-        clientMessage.appendData(predicate);
-        clientMessage.updateFrameLength();
-        return clientMessage;
-    }
+static calculateSize(name : string  , predicate : Data ){
+// Calculates the request payload size
+var dataSize : number = 0;
+            dataSize += BitsUtil.calculateSizeString(name);
+            dataSize += BitsUtil.calculateSizeData(predicate);
+return dataSize;
+}
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
-        // Decode response from client message
-        var parameters:any = {'response': null};
+static encodeRequest(name : string, predicate : Data){
+// Encode request into clientMessage
+var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
+clientMessage.setMessageType(REQUEST_TYPE);
+clientMessage.setRetryable(RETRYABLE);
+    clientMessage.appendString(name);
+    clientMessage.appendData(predicate);
+clientMessage.updateFrameLength();
+return clientMessage;
+}
+
+static decodeResponse(clientMessage : ClientMessage,  toObjectFunction: (data: Data) => any = null){
+// Decode response from client message
+var parameters :any = { 'response' : null  };
         var responseSize = clientMessage.readInt32();
-        var response:any = [];
-        for (var responseIndex = 0; responseIndex <= responseSize; responseIndex++) {
-            var responseItem:any;
-            responseItem = clientMessage.readMapEntry();
-            response.push(responseItem)
+            var response : any = [];
+                    for(var responseIndex = 0 ;  responseIndex < responseSize ; responseIndex++){
+        var responseItem : any;
+        var responseItemKey: Data;
+        var responseItemVal: any;
+                    responseItemKey = clientMessage.readData();
+                    responseItemVal = clientMessage.readData();
+        responseItem = [responseItemKey, responseItemVal];
+        response.push(responseItem)
         }
-        parameters['response'] = new ImmutableLazyDataList(response, toObjectFunction);
-        return parameters;
+            parameters['response'] = response;
+return parameters;
 
-    }
+}
 
 
 }

--- a/src/codec/MapValuesWithPredicateCodec.ts
+++ b/src/codec/MapValuesWithPredicateCodec.ts
@@ -1,12 +1,12 @@
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
-import ImmutableLazyDataList = require('./ImmutableLazyDataList');
 import {BitsUtil} from '../BitsUtil';
 import Address = require('../Address');
 import {AddressCodec} from './AddressCodec';
 import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
+import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
 import {MapMessageType} from './MapMessageType';
 
 var REQUEST_TYPE = MapMessageType.MAP_VALUESWITHPREDICATE;
@@ -14,42 +14,43 @@ var RESPONSE_TYPE = 106;
 var RETRYABLE = false;
 
 
-export class MapValuesWithPredicateCodec {
+export class MapValuesWithPredicateCodec{
 
 
-    static calculateSize(name:string, predicate:Data) {
-        // Calculates the request payload size
-        var dataSize:number = 0;
-        dataSize += BitsUtil.calculateSizeString(name);
-        dataSize += BitsUtil.calculateSizeData(predicate);
-        return dataSize;
-    }
 
-    static encodeRequest(name:string, predicate:Data) {
-        // Encode request into clientMessage
-        var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
-        clientMessage.setMessageType(REQUEST_TYPE);
-        clientMessage.setRetryable(RETRYABLE);
-        clientMessage.appendString(name);
-        clientMessage.appendData(predicate);
-        clientMessage.updateFrameLength();
-        return clientMessage;
-    }
+static calculateSize(name : string  , predicate : Data ){
+// Calculates the request payload size
+var dataSize : number = 0;
+            dataSize += BitsUtil.calculateSizeString(name);
+            dataSize += BitsUtil.calculateSizeData(predicate);
+return dataSize;
+}
 
-    static decodeResponse(clientMessage:ClientMessage, toObjectFunction:(data:Data) => any = null) {
-        // Decode response from client message
-        var parameters:any = {'response': null};
+static encodeRequest(name : string, predicate : Data){
+// Encode request into clientMessage
+var clientMessage = ClientMessage.newClientMessage(this.calculateSize(name, predicate));
+clientMessage.setMessageType(REQUEST_TYPE);
+clientMessage.setRetryable(RETRYABLE);
+    clientMessage.appendString(name);
+    clientMessage.appendData(predicate);
+clientMessage.updateFrameLength();
+return clientMessage;
+}
+
+static decodeResponse(clientMessage : ClientMessage,  toObjectFunction: (data: Data) => any = null){
+// Decode response from client message
+var parameters :any = { 'response' : null  };
         var responseSize = clientMessage.readInt32();
-        var response:any = [];
-        for (var responseIndex = 0; responseIndex <= responseSize; responseIndex++) {
-            var responseItem:Data;
-            responseItem = toObjectFunction(clientMessage.readData());
-            response.push(responseItem)
+            var response : any = [];
+                    for(var responseIndex = 0 ;  responseIndex < responseSize ; responseIndex++){
+        var responseItem : Data;
+                    responseItem = clientMessage.readData();
+        response.push(responseItem)
         }
-        parameters['response'] = new ImmutableLazyDataList(response, toObjectFunction);
-        return parameters;
+            parameters['response'] = response;
+return parameters;
 
-    }
+}
 
 
 }

--- a/src/core/Predicate.ts
+++ b/src/core/Predicate.ts
@@ -1,4 +1,84 @@
 import {IdentifiedDataSerializable} from '../serialization/Serializable';
-export interface Predicate<K, V> extends IdentifiedDataSerializable {
-    apply(key: K, value: V): boolean;
+import {
+    SqlPredicate, AndPredicate, FalsePredicate, BetweenPredicate, EqualPredicate,
+    GreaterLessPredicate, LikePredicate, ILikePredicate, InPredicate, InstanceOfPredicate, NotEqualPredicate, NotPredicate,
+    OrPredicate, RegexPredicate, TruePredicate
+} from '../serialization/DefaultPredicates';
+export interface Predicate extends IdentifiedDataSerializable {
+}
+
+export function sql(str: string): Predicate {
+    return new SqlPredicate(str);
+}
+
+export function and(...predicates: Predicate[]) {
+    return new AndPredicate(...predicates);
+}
+
+export function isBetween(field: string, from: any, to: any) {
+    return new BetweenPredicate(field, from, to);
+}
+
+export function isFalse() {
+    return FalsePredicate.INSTANCE;
+}
+
+export function isEqualTo(field: string, value: any) {
+    return new EqualPredicate(field, value);
+}
+
+export function greaterThan(field: string, value: any) {
+    return new GreaterLessPredicate(field, value, false, false);
+}
+
+export function greaterEqual(field: string, value: any) {
+    return new GreaterLessPredicate(field, value, true, false);
+}
+
+export function lessThan(field: string, value: any) {
+    return new GreaterLessPredicate(field, value, false, true);
+}
+
+export function lessEqual(field: string, value: any) {
+    return new GreaterLessPredicate(field, value, true, true);
+}
+
+export function like(field: string, expr: string) {
+    return new LikePredicate(field, expr);
+}
+
+export function ilike(field: string, expr: string) {
+    return new ILikePredicate(field, expr);
+}
+
+export function inPredicate(field: string, ...values: any[]) {
+    return new InPredicate(field, ...values);
+}
+
+export function instanceOf(className: string) {
+    return new InstanceOfPredicate(className);
+}
+
+export function notEqual(field: string, value: any) {
+    return new NotEqualPredicate(field, value);
+}
+
+export function not(predic: Predicate) {
+    return new NotPredicate(predic);
+}
+
+export function or(...predicates: Predicate[]) {
+    return new OrPredicate(...predicates);
+}
+
+export function regex(field: string, reg: string) {
+    return new RegexPredicate(field, reg);
+}
+
+export function truePredicate() {
+    return TruePredicate.INSTANCE;
+}
+
+export function falsePredicate() {
+    return FalsePredicate.INSTANCE;
 }

--- a/src/core/Predicate.ts
+++ b/src/core/Predicate.ts
@@ -1,0 +1,4 @@
+import {IdentifiedDataSerializable} from '../serialization/Serializable';
+export interface Predicate<K, V> extends IdentifiedDataSerializable {
+    apply(key: K, value: V): boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,12 @@ import * as Config from './Config';
 import {ClientInfo} from './ClientInfo';
 import {IMap} from './proxy/IMap';
 import Address = require('./Address');
+import * as Predicates from './core/Predicate';
 export {
     HazelcastClient as Client,
     Config,
     ClientInfo,
     IMap,
-    Address
+    Address,
+    Predicates
 }

--- a/src/proxy/IMap.ts
+++ b/src/proxy/IMap.ts
@@ -2,7 +2,15 @@ import * as Promise from 'bluebird';
 import {DistributedObject} from '../DistributedObject';
 import {EntryView} from '../core/EntryView';
 import {IMapListener} from '../core/MapListener';
+import {Predicate} from '../core/Predicate';
 export interface IMap<K, V> extends DistributedObject {
+
+    /**
+     * Adds an index to this map for the specified entries so that queries can run faster.
+     * @param attribute index attribute of value
+     * @param ordered `true` if index should be ordered, `false` otherwise.
+     */
+    addIndex(attribute: string, ordered: boolean): Promise<void>;
 
     /**
      * This method checks whether the map has an item asssociated with key
@@ -95,6 +103,14 @@ export interface IMap<K, V> extends DistributedObject {
     entrySet(): Promise<[K, V][]>;
 
     /**
+     * Queries the map based on the specified predicate and returns matching entries.
+     * Specified predicate runs on all members in parallel.
+     * @param predicate specified query criteria.
+     * @return result entry set of the query.
+     */
+    entrySetWithPredicate(predicate: Predicate<K, V>): Promise<[K, V][]>;
+
+    /**
      * Evicts the specified key from this map.
      * @throws {RangeError} if key is null or undefined.
      * @param key
@@ -143,6 +159,12 @@ export interface IMap<K, V> extends DistributedObject {
      * Returns the keys of this map as an array.
      */
     keySet(): Promise<K[]>;
+
+    /**
+     * Queries the map based on the specified predicate and returns the keys of matching entries.
+     * @param predicate
+     */
+    keySetWithPredicate(predicate: Predicate<K, V>): Promise<K[]>;
 
     /**
      * Loads keys to the store.
@@ -213,6 +235,13 @@ export interface IMap<K, V> extends DistributedObject {
     values(): Promise<V[]>;
 
     /**
+     * Queries the map based on the specified predicate and returns the values of matching entries.
+     * Specified predicate runs on all members in parallel.
+     * @param predicate
+     */
+    valuesWithPredicate(predicate: Predicate<K, V>): Promise<V[]>;
+
+    /**
      * Returns a key-value pair representing the association of given key
      * @param key
      * @throws {RangeError} if key is null or undefined.
@@ -265,6 +294,18 @@ export interface IMap<K, V> extends DistributedObject {
      * @return Registration id of the listener.
      */
     addEntryListener(listener: IMapListener<K, V>, key?: K, includeValue?: boolean): Promise<string>;
+
+    /**
+     * Adds a {@link IMapListener} for this map.
+     * Listener will get notified for map add/remove/update/evict events filtered by the given predicate.
+     * @param listener
+     * @param predicate
+     * @param key Events are triggered for only this key if set.
+     * @param includeValue Event message contains new value of the key if set to `true`.
+     * @return Registration id of the listener.
+     */
+    addEntryListenerWithPredicate(listener: IMapListener<K, V>, predicate: Predicate<K, V>,
+                                  key?: K, includeValue?: boolean): Promise<string>;
 
     /**
      * Removes a {@link IMapListener} from this map.

--- a/src/proxy/IMap.ts
+++ b/src/proxy/IMap.ts
@@ -108,7 +108,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @param predicate specified query criteria.
      * @return result entry set of the query.
      */
-    entrySetWithPredicate(predicate: Predicate<K, V>): Promise<[K, V][]>;
+    entrySetWithPredicate(predicate: Predicate): Promise<[K, V][]>;
 
     /**
      * Evicts the specified key from this map.
@@ -164,7 +164,7 @@ export interface IMap<K, V> extends DistributedObject {
      * Queries the map based on the specified predicate and returns the keys of matching entries.
      * @param predicate
      */
-    keySetWithPredicate(predicate: Predicate<K, V>): Promise<K[]>;
+    keySetWithPredicate(predicate: Predicate): Promise<K[]>;
 
     /**
      * Loads keys to the store.
@@ -239,7 +239,7 @@ export interface IMap<K, V> extends DistributedObject {
      * Specified predicate runs on all members in parallel.
      * @param predicate
      */
-    valuesWithPredicate(predicate: Predicate<K, V>): Promise<V[]>;
+    valuesWithPredicate(predicate: Predicate): Promise<V[]>;
 
     /**
      * Returns a key-value pair representing the association of given key
@@ -304,7 +304,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @param includeValue Event message contains new value of the key if set to `true`.
      * @return Registration id of the listener.
      */
-    addEntryListenerWithPredicate(listener: IMapListener<K, V>, predicate: Predicate<K, V>,
+    addEntryListenerWithPredicate(listener: IMapListener<K, V>, predicate: Predicate,
                                   key?: K, includeValue?: boolean): Promise<string>;
 
     /**

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -71,12 +71,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
         assertNotNull(predicate);
         var predicateData = this.toData(predicate);
         var toObject = this.toObject.bind(this);
-        var deserializedSet: K[] = [];
         return this.encodeInvokeOnRandomTarget(MapKeySetWithPredicateCodec, predicateData).then(function (entrySet: Data[]) {
-            entrySet.forEach(function (entryData) {
-                deserializedSet.push(toObject(entryData));
-            });
-            return deserializedSet;
+            return entrySet.map<K>(toObject);
         });
     }
 
@@ -84,12 +80,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
         assertNotNull(predicate);
         var predicateData = this.toData(predicate);
         var toObject = this.toObject.bind(this);
-        var deserialized: V[] = [];
         return this.encodeInvokeOnRandomTarget(MapValuesWithPredicateCodec, predicateData).then(function (rawValues: Data[]) {
-            rawValues.forEach(function (rawValue) {
-                deserialized.push(toObject(rawValue));
-            });
-            return deserialized;
+            return rawValues.map<V>(toObject);
         });
     }
 
@@ -258,13 +250,9 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     keySet(): Promise<K[]> {
-        var deserializedSet: K[] = [];
         var toObject = this.toObject.bind(this);
         return this.encodeInvokeOnRandomTarget<K[]>(MapKeySetCodec).then(function(entrySet) {
-            entrySet.forEach(function(entry) {
-                deserializedSet.push(toObject(entry));
-            });
-            return deserializedSet;
+            return entrySet.map<K>(toObject);
         });
     }
 
@@ -322,13 +310,9 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     values(): Promise<V[]> {
-        var values: V[] = [];
         var toObject = this.toObject.bind(this);
         return this.encodeInvokeOnRandomTarget<V[]>(MapValuesCodec).then(function(valuesData) {
-            valuesData.forEach(function(valueData) {
-                values.push(toObject(valueData));
-            });
-            return values;
+            return valuesData.map<V>(toObject);
         });
     }
 

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -55,11 +55,10 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
 
     entrySetWithPredicate(predicate: Predicate): Promise<any[]> {
         assertNotNull(predicate);
-        var predicateData = this.toData(predicate);
+        var pData = this.toData(predicate);
         var toObject = this.toObject.bind(this);
         var deserializedSet: [K, V][] = [];
-        return this.encodeInvokeOnRandomTarget(MapEntriesWithPredicateCodec, predicateData)
-            .then(function(entrySet: [Data, Data][]) {
+        return this.encodeInvokeOnRandomTarget(MapEntriesWithPredicateCodec, pData).then(function(entrySet: [Data, Data][]) {
             entrySet.forEach(function(entry) {
                 deserializedSet.push([toObject(entry[0]), toObject(entry[1])]);
             });

--- a/src/serialization/DefaultPredicates.ts
+++ b/src/serialization/DefaultPredicates.ts
@@ -1,0 +1,353 @@
+import {DataInput, DataOutput} from './Data';
+import {AbstractPredicate} from './PredicateFactory';
+import {Predicate} from '../core/Predicate';
+
+export class SqlPredicate extends AbstractPredicate {
+
+    private sql: string;
+
+    constructor(sql: string) {
+        super();
+        this.sql = sql;
+    }
+
+    readData(input: DataInput): any {
+        this.sql = input.readUTF();
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.sql);
+    }
+
+    getClassId(): number {
+        return 0;
+    }
+}
+
+export class AndPredicate extends AbstractPredicate {
+
+    private predicates: Predicate[];
+
+    constructor(...predicates: Predicate[]) {
+        super();
+        this.predicates = predicates;
+    }
+
+    readData(input: DataInput): any {
+        var s = input.readInt();
+        this.predicates = [];
+        for (var i = 0; i < s; i++) {
+            this.predicates[i] = input.readObject();
+        }
+    }
+
+    writeData(output: DataOutput) {
+        output.writeInt(this.predicates.length);
+        this.predicates.forEach(function (pred: Predicate) {
+            output.writeObject(pred);
+        });
+    }
+
+    getClassId(): number {
+        return 1;
+    }
+}
+
+export class BetweenPredicate extends AbstractPredicate {
+
+    private field: string;
+    private from: any;
+    private to: any;
+
+    constructor(field: string, from: any, to: any) {
+        super();
+        this.field = field;
+        this.from = from;
+        this.to = to;
+    }
+
+    readData(input: DataInput): any {
+        this.field = input.readUTF();
+        this.from = input.readObject();
+        this.to = input.readObject();
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.field);
+        output.writeObject(this.from);
+        output.writeObject(this.to);
+    }
+
+    getClassId(): number {
+        return 2;
+    }
+}
+
+export class EqualPredicate extends AbstractPredicate {
+
+    private field: string;
+    private value: any;
+
+    constructor(field: string, value: any) {
+        super();
+        this.field = field;
+        this.value = value;
+    }
+
+    readData(input: DataInput): any {
+        this.field = input.readUTF();
+        this.value = input.readObject();
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.field);
+        output.writeObject(this.value);
+    }
+
+    getClassId(): number {
+        return 3;
+    }
+}
+
+export class GreaterLessPredicate extends AbstractPredicate {
+
+    private field: string;
+    private value: any;
+    private equal: boolean;
+    private less: boolean;
+
+    constructor (field: string, value: any, equal: boolean, less: boolean) {
+        super();
+        this.field = field;
+        this.value = value;
+        this.equal = equal;
+        this.less = less;
+    }
+
+    readData(input: DataInput): any {
+        this.field = input.readUTF();
+        this.value = input.readObject();
+        this.equal = input.readBoolean();
+        this.less = input.readBoolean();
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.field);
+        output.writeObject(this.value);
+        output.writeBoolean(this.equal);
+        output.writeBoolean(this.less);
+    }
+
+    getClassId(): number {
+        return 4;
+    }
+}
+
+export class LikePredicate extends AbstractPredicate {
+
+    private field: string;
+    private expr: string;
+
+    constructor(field: string, expr: string) {
+        super();
+        this.field = field;
+        this.expr = expr;
+    }
+
+    readData(input: DataInput): any {
+        this.field = input.readUTF();
+        this.expr = input.readUTF();
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.field);
+        output.writeUTF(this.expr);
+    }
+
+    getClassId(): number {
+        return 5;
+    }
+}
+
+export class ILikePredicate extends LikePredicate {
+    getClassId(): number {
+        return 6;
+    }
+}
+
+export class InPredicate extends AbstractPredicate {
+    private field: string;
+    private values: any[];
+
+    constructor(field: string, ...values: any[]) {
+        super();
+        this.field = field;
+        this.values = values;
+    }
+
+    readData(input: DataInput): any {
+        this.field = input.readUTF();
+        var s = input.readInt();
+        this.values = [];
+        for (var i = 0; i < s; i++) {
+            this.values.push(input.readObject());
+        }
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.field);
+        output.writeInt(this.values.length);
+        this.values.forEach(function(val) {
+            output.writeObject(val);
+        });
+    }
+
+    getClassId(): number {
+        return 7;
+    }
+}
+
+export class InstanceOfPredicate extends AbstractPredicate {
+
+    private className: string;
+
+    constructor(className: string) {
+        super();
+        this.className = className;
+    }
+
+    readData(input: DataInput): any {
+        this.className = input.readUTF();
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.className);
+    }
+
+    getClassId(): number {
+        return 8;
+    }
+}
+
+export class NotEqualPredicate extends EqualPredicate {
+    getClassId(): number {
+        return 9;
+    }
+}
+
+export class NotPredicate extends AbstractPredicate {
+    private pred: Predicate;
+
+    constructor(pred: Predicate) {
+        super();
+        this.pred = pred;
+    }
+
+    readData(input: DataInput): any {
+        this.pred = input.readObject();
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeObject(this.pred);
+    }
+
+    getClassId(): number {
+        return 10;
+    }
+}
+
+export class OrPredicate extends AbstractPredicate {
+
+    private preds: Predicate[];
+
+    constructor(...preds: Predicate[]) {
+        super();
+        this.preds = preds;
+    }
+
+    readData(input: DataInput): any {
+        var s = input.readInt();
+        this.preds = [];
+        for (var i = 0; i < s; i++) {
+            this.preds.push(input.readObject());
+        }
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeInt(this.preds.length);
+        this.preds.forEach(function (pred: Predicate) {
+            output.writeObject(pred);
+        });
+    }
+
+    getClassId(): number {
+        return 11;
+    }
+}
+
+export class RegexPredicate extends AbstractPredicate {
+    private field: string;
+    private regex: string;
+
+    constructor(field: string, regex: string) {
+        super();
+        this.field = field;
+        this.regex = regex;
+    }
+
+    readData(input: DataInput): any {
+        this.field = input.readUTF();
+        this.regex = input.readUTF();
+        return this;
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeUTF(this.field);
+        output.writeUTF(this.regex);
+    }
+
+    getClassId(): number {
+        return 12;
+    }
+}
+
+export class FalsePredicate extends AbstractPredicate {
+
+    static INSTANCE: FalsePredicate = new FalsePredicate();
+
+    readData(input: DataInput): any {
+        //Empty method
+    }
+
+    writeData(output: DataOutput): any {
+        //Empty method
+    }
+
+    getClassId(): number {
+        return 13;
+    }
+}
+
+
+export class TruePredicate extends AbstractPredicate {
+
+    static INSTANCE: TruePredicate = new TruePredicate();
+
+    readData(input: DataInput): any {
+        //Empty method
+    }
+
+    writeData(output: DataOutput): any {
+        //Empty method
+    }
+
+    getClassId(): number {
+        return 14;
+    }
+}

--- a/src/serialization/PredicateFactory.ts
+++ b/src/serialization/PredicateFactory.ts
@@ -1,0 +1,36 @@
+import {IdentifiedDataSerializable, IdentifiedDataSerializableFactory} from './Serializable';
+import {DataInput, DataOutput} from './Data';
+import {Predicate} from '../core/Predicate';
+export const PREDICATE_FACTORY_ID = -32;
+export abstract class AbstractPredicate implements Predicate {
+
+    abstract readData(input: DataInput): any;
+
+    abstract writeData(output: DataOutput): void;
+
+    getFactoryId(): number {
+        return PREDICATE_FACTORY_ID;
+    }
+
+    abstract getClassId(): number;
+}
+
+export class PredicateFactory implements IdentifiedDataSerializableFactory {
+
+    private idToConstructorMap: {[id: number]: FunctionConstructor } = {};
+
+    constructor(allPredicates: any) {
+        for (var pred in allPredicates) {
+            //TODO accessing getClassId from prototype of uninitialized member function is not elegant.
+            this.idToConstructorMap[(<any>allPredicates[pred].prototype).getClassId()] = allPredicates[pred];
+        }
+    }
+
+    create(type: number): IdentifiedDataSerializable {
+        if (this.idToConstructorMap[type]) {
+            return <any>(new this.idToConstructorMap[type]());
+        } else {
+            throw new RangeError(`There is no default predicate with id ${type}.`);
+        }
+    }
+}

--- a/test/MapProxyTest.js
+++ b/test/MapProxyTest.js
@@ -1,5 +1,6 @@
 var expect = require("chai").expect;
 var HazelcastClient = require("../.").Client;
+var Predicates = require("../.").Predicates;
 var Promise = require("bluebird");
 var Controller = require('./RC');
 var Util = require('./Util');
@@ -538,14 +539,71 @@ describe("MapProxy Test", function() {
         })
     });
 
+    it('addEntryListener on map, entryAdded fires because predicate returns true for that entry', function(done) {
+        var listenerObject = {
+            added: function(key, oldValue, value, mergingValue) {
+                try {
+                    expect(key).to.equal('key10');
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }
+        };
+        map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10')).then(function() {
+            map.put('key10', 'val10');
+        });
+    });
+
+    it('addEntryListener on key, entryAdded fires because predicate returns true for that entry', function(done) {
+        var listenerObject = {
+            added: function(key, oldValue, value, mergingValue) {
+                try {
+                    expect(key).to.equal('key10');
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }
+        };
+        map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10'), 'key10').then(function() {
+            map.put('key10', 'val10');
+        });
+    });
+
+    it('addEntryListener on key, entryAdded fires because predicate returns true for that entry, inlVal=yes', function(done) {
+        var listenerObject = {
+            added: function(key, oldValue, value, mergingValue) {
+                try {
+                    expect(key).to.equal('key10');
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.equal('val10');
+                    expect(mergingValue).to.be.undefined;
+                    done();
+                } catch (err) {
+                    done(err);
+                }
+            }
+        };
+        map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10'), 'key10', true).then(function() {
+            map.put('key10', 'val10');
+        });
+    });
+
     it('addEntryListener on map entryAdded', function(done) {
         var listenerObject = {
             added: function(key, oldValue, value, mergingValue) {
                 try {
                     expect(key).to.equal('key10');
-                    expect(oldValue).to.be.null;
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     done();
                 } catch (err) {
                     done(err);
@@ -562,9 +620,9 @@ describe("MapProxy Test", function() {
             added: function(key, oldValue, value, mergingValue) {
                 try {
                     expect(key).to.equal('key10');
-                    expect(oldValue).to.be.null;
+                    expect(oldValue).to.be.undefined;
                     expect(value).to.equal('val10');
-                    expect(mergingValue).to.be.null;
+                    expect(mergingValue).to.be.undefined;
                     done();
                 } catch (err) {
                     done(err);
@@ -581,9 +639,9 @@ describe("MapProxy Test", function() {
             updated: function(key, oldValue, value, mergingValue) {
                 try {
                     expect(key).to.equal('key0');
-                    expect(oldValue).to.be.null;
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     done();
                 } catch (err) {
                     done(err);
@@ -600,9 +658,9 @@ describe("MapProxy Test", function() {
             removed: function(key, oldValue, value, mergingValue) {
                 try {
                     expect(key).to.equal('key1');
-                    expect(oldValue).to.be.null;
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     done();
                 } catch (err) {
                     done(err);
@@ -620,8 +678,8 @@ describe("MapProxy Test", function() {
                 try {
                     expect(key).to.equal('key1');
                     expect(oldValue).to.equal('val1');
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     done();
                 } catch (err) {
                     done(err);
@@ -639,8 +697,8 @@ describe("MapProxy Test", function() {
                 try {
                     expect(key).to.equal('key1');
                     expect(oldValue).to.equal('val1');
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     done();
                 } catch (err) {
                     done(err);
@@ -656,10 +714,10 @@ describe("MapProxy Test", function() {
         var listenerObject = {
             evictedAll: function(key, oldValue, value, mergingValue, numberOfAffectedEntries) {
                 try {
-                    expect(key).to.be.null;
-                    expect(oldValue).to.be.null;
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(key).to.be.undefined;
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     expect(numberOfAffectedEntries).to.equal(10);
                     done();
                 } catch (err) {
@@ -676,10 +734,10 @@ describe("MapProxy Test", function() {
         var listenerObject = {
             clearedAll: function(key, oldValue, value, mergingValue, numberOfAffectedEntries) {
                 try {
-                    expect(key).to.be.null;
-                    expect(oldValue).to.be.null;
-                    expect(value).to.be.null;
-                    expect(mergingValue).to.be.null;
+                    expect(key).to.be.undefined;
+                    expect(oldValue).to.be.undefined;
+                    expect(value).to.be.undefined;
+                    expect(mergingValue).to.be.undefined;
                     expect(numberOfAffectedEntries).to.equal(10);
                     done();
                 } catch (err) {
@@ -703,6 +761,34 @@ describe("MapProxy Test", function() {
     it('removeEntryListener with wrong id', function() {
         return map.removeEntryListener('aaa').then(function(success) {
             return expect(success).to.be.false;
+        });
+    });
+
+    it('entrySetWithPredicate', function() {
+        return map.entrySetWithPredicate(Predicates.sql('this == val3')).then(function(entrySet) {
+            expect(entrySet.length).to.equal(1);
+            expect(entrySet[0][0]).to.equal('key3');
+            expect(entrySet[0][1]).to.equal('val3');
+        });
+    });
+
+    it('keySetWithPredicate', function() {
+        return map.keySetWithPredicate(Predicates.sql('this == val3')).then(function(keySet) {
+            expect(keySet.length).to.equal(1);
+            expect(keySet[0]).to.equal('key3');
+        });
+    });
+
+    it('keySetWithPredicate null response', function() {
+        return map.keySetWithPredicate(Predicates.sql('this == nonexisting')).then(function(keySet) {
+            expect(keySet.length).to.equal(0);
+        });
+    });
+
+    it('valuesWithPredicate', function() {
+        return map.valuesWithPredicate(Predicates.sql('this == val3')).then(function(valueSet) {
+            expect(valueSet.length).to.equal(1);
+            expect(valueSet[0]).to.equal('val3');
         });
     });
 

--- a/test/PredicateTest.js
+++ b/test/PredicateTest.js
@@ -1,0 +1,185 @@
+var expect = require("chai").expect;
+var HazelcastClient = require("../.").Client;
+var Predicates = require("../.").Predicates;
+var FalsePredicate = require("../lib/serialization/DefaultPredicates").FalsePredicate;
+var TruePredicate = require("../lib/serialization/DefaultPredicates").TruePredicate;
+var Promise = require("bluebird");
+var Controller = require('./RC');
+var Util = require('./Util');
+
+describe("Predicates", function() {
+
+    var cluster;
+    var client;
+    var map;
+
+    before(function () {
+        this.timeout(32000);
+        return Controller.createCluster(null, null).then(function(res) {
+            cluster = res;
+            return Controller.startMember(cluster.id);
+        }).then(function(member) {
+            return HazelcastClient.newHazelcastClient().then(function(hazelcastClient) {
+                client = hazelcastClient;
+            });
+        });
+    });
+
+    beforeEach(function() {
+        map = client.getMap('test');
+        return _fillMap();
+    });
+
+    afterEach(function() {
+        return map.destroy();
+    });
+
+    after(function() {
+        client.shutdown();
+        return Controller.shutdownCluster(cluster.id);
+    });
+
+    function _fillMap(size) {
+        if (size == void 0) {
+            size = 50;
+        }
+        var promises = [];
+        for (var i = 0; i< size; i++) {
+            promises.push(map.put('key' + i, i));
+        }
+        return Promise.all(promises);
+    }
+
+    function testPredicate(predicate, expecteds) {
+        return map.valuesWithPredicate(predicate).then(function(values) {
+            return expect(values).to.have.members(expecteds);
+        })
+    }
+
+    it('Sql', function () {
+        return testPredicate(Predicates.sql('this == 10'), [10]);
+    });
+
+    it('And', function() {
+        return testPredicate(Predicates.and(Predicates.isEqualTo('this', 10), Predicates.isEqualTo('this', 11)), []);
+    });
+
+    it('GreaterThan', function() {
+        return testPredicate(Predicates.greaterThan('this', 47), [48, 49]);
+    });
+
+    it('GreaterEqual', function() {
+        return testPredicate(Predicates.greaterEqual('this', 47), [47, 48, 49]);
+    });
+
+    it('LessThan', function() {
+        return testPredicate(Predicates.lessThan('this', 4), [0, 1, 2, 3]);
+    });
+
+    it('LessEqual', function () {
+        return testPredicate(Predicates.lessEqual('this', 4), [0, 1, 2, 3, 4]);
+    });
+
+    it('Like', function() {
+        var localMap = client.getMap('likePredMap');
+        return localMap.put('temp', 'tempval').then(function() {
+            return localMap.valuesWithPredicate(Predicates.like('this', 'tempv%'));
+        }).then(function (values) {
+            return expect(values).to.have.members(['tempval']);
+        }).then(function() {
+            return localMap.destroy();
+        });
+    });
+
+    it('ILike', function() {
+        var localMap = client.getMap('likePredMap');
+        return localMap.putAll([['temp', 'tempval'], ['TEMP', 'TEMPVAL']]).then(function() {
+            return localMap.valuesWithPredicate(Predicates.ilike('this', 'tempv%'));
+        }).then(function (values) {
+            return expect(values).to.have.members(['tempval', 'TEMPVAL']);
+        }).then(function() {
+            return localMap.destroy();
+        });
+    });
+
+    it('In', function () {
+        return testPredicate(Predicates.inPredicate('this', 48, 49, 50, 51, 52), [48, 49]);
+    });
+
+    it('InstanceOf', function () {
+        var assertionList = Array.apply(null, {length: 50}).map(Number.call, Number);
+        return testPredicate(Predicates.instanceOf('java.lang.Double'), assertionList);
+    });
+
+    it('NotEqual', function() {
+        var assertionList = Array.apply(null, {length: 49}).map(Number.call, Number);
+        return testPredicate(Predicates.notEqual('this', 49), assertionList);
+    });
+
+    it('Not', function() {
+        return testPredicate(Predicates.not(Predicates.greaterEqual('this', 2)), [0, 1]);
+    });
+
+    it('Or', function() {
+        return testPredicate(Predicates.or(Predicates.greaterEqual('this', 49), Predicates.lessEqual('this', 0)), [0, 49]);
+    });
+
+    it('Regex', function() {
+        var localMap = client.getMap('regexMap');
+        return localMap.putAll([['06', 'ankara'], ['07', 'antalya']]).then(function() {
+            return localMap.valuesWithPredicate(Predicates.regex('this', '^.*ya$'));
+        }).then(function (values) {
+            return expect(values).to.have.members(['antalya']);
+        }).then(function() {
+            return localMap.destroy();
+        });
+    });
+
+    it('False', function() {
+        return testPredicate(Predicates.falsePredicate(), []);
+    });
+
+    it('True', function () {
+        var assertionList = Array.apply(null, {length: 50}).map(Number.call, Number);
+        return testPredicate(Predicates.truePredicate(), assertionList);
+    });
+
+    it.skip('Paging first page should have first two items', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+
+        return testPredicate(paging, [40, 41]);
+    });
+
+    it.skip('Paging nextPage should have 3rd and 4th items', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.nextPage();
+
+        return testPredicate(paging, [42, 43]);
+    });
+
+    it.skip('Paging fourth page should have 7th and 8th items', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.setPage(4);
+
+        return testPredicate(paging, [46, 47]);
+    });
+
+    it.skip('Paging #getPage should return approprate value', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.setPage(4);
+        return expect(paging.getPage()).to.equal(4);
+    });
+
+    it.skip('Paging #getPageSize should return 2', function() {
+        var paging = PPredicates.paging(Predicates.greaterEqual('this', 40), 2);
+        return expect(paging.getPageSize()).to.equal(2);
+    });
+
+    it.skip('Paging previousPage', function () {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.setPage(4);
+        paging.previousPage();
+
+        return testPredicate(paging, [44, 45]);
+    });
+});


### PR DESCRIPTION
I added new methods with `withPredicate` suffix.

Making predicate optional in `addEntryListener` complicates the API very much. Because I added a new method for addEntryListener with predicate, I added new methods for others too for the sake of uniformity.