### PR TITLE
Paging Predicate implementation

### DIFF
--- a/code_samples/paging_predicate.js
+++ b/code_samples/paging_predicate.js
@@ -1,0 +1,72 @@
+var Client = require('../.').Client;
+var Config = require('../.').Config;
+var Predicates = require('../.').Predicates;
+var cfg = new Config.ClientConfig();
+
+//This comparator is both a comparator and an IdentifiedDataSerializable.
+//Note that a comparator should be a serializable object( IdentifiedDataSerializable or Portable)
+//because Hazelcast server should be able to deserialize the comparator in order to sort entries.
+//So the same class should be registered to Hazelcast server instance.
+var comparator = {
+    getFactoryId: function() {
+        return 1;
+    },
+
+    getClassId: function() {
+        return 10;
+    },
+
+    //This comparator sorts entries according to their keys in reverse alphabetical order.
+    sort: function(a, b) {
+        if (a[0] > b[0]) return -1;
+        if (a[0] < b[0]) return 1;
+        return 0;
+    },
+
+    readData: function() {
+
+    },
+
+    writeData: function() {
+
+    }
+};
+
+//We register our comparator object as IdentifiedDataSerializable.
+cfg.serializationConfig.dataSerializableFactories[1] = {
+    create: function() {
+        return comparator;
+    }
+};
+
+var predicate = Predicates.paging(Predicates.truePredicate(), 2, comparator);
+Client.newHazelcastClient(cfg).then(function (client) {
+    var map = client.getMap('test');
+    map.putAll([['a', 1], ['b', 2], ['c', 3], ['d', 4], ['e', 5], ['f', 6], ['g', 7]]).then(function () {
+        return map.size();
+    }).then(function(mapSize) {
+        console.log('Added ' + mapSize + ' elements.');
+
+        predicate.setPage(0);
+        return map.valuesWithPredicate(predicate);
+    }).then(function (values) {
+        console.log('Page: ' + 0);
+        console.log(values);
+        predicate.setPage(1);
+        return map.valuesWithPredicate(predicate);
+    }).then(function (values) {
+        console.log('Page: ' + 1);
+        console.log(values);
+        predicate.setPage(2);
+        return map.valuesWithPredicate(predicate);
+    }).then(function (values) {
+        console.log('Page: ' + 2);
+        console.log(values);
+        predicate.setPage(3);
+        return map.valuesWithPredicate(predicate);
+    }).then(function (values) {
+        console.log('Page: ' + 3);
+        console.log(values);
+        return client.shutdown();
+    });
+});

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -30,6 +30,10 @@ export function getSortedQueryResultSet(list: Array<any>, predicate: PagingPredi
     if (list.length === 0) {
         return list;
     }
+    var comparatorObject = predicate.getComparator();
+    if (comparatorObject != null) {
+        list.sort(comparatorObject.sort.bind(comparatorObject));
+    }
     var nearestAnchorEntry = (predicate == null) ? null : predicate.getNearestAnchorEntry();
     var nearestPage = nearestAnchorEntry[0];
     var page = predicate.getPage();

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -1,4 +1,7 @@
 import Long = require('long');
+import {PagingPredicate} from './serialization/DefaultPredicates';
+import {IterationType} from './core/Predicate';
+import * as assert from 'assert';
 export function assertNotNull(v: any) {
     if (v == null) {
         throw new RangeError('Null or undefined is not allowed here.');
@@ -16,5 +19,50 @@ export function getType(obj: any): string {
         } else {
             return ({}).toString.call(obj).match(/\s([a-zA-Z]+)/)[1].toLowerCase();
         }
+    }
+}
+
+export function enumFromString<T>(enumType: any, value: string): T {
+    return enumType[value];
+}
+
+export function getSortedQueryResultSet(list: Array<any>, predicate: PagingPredicate) {
+    if (list.length === 0) {
+        return list;
+    }
+    var nearestAnchorEntry = (predicate == null) ? null : predicate.getNearestAnchorEntry();
+    var nearestPage = nearestAnchorEntry[0];
+    var page = predicate.getPage();
+    var pageSize = predicate.getPageSize();
+    var begin = pageSize * (page - nearestPage - 1);
+    var size = list.length;
+    if (begin > size ) {
+        return [];
+    }
+    var end = begin + pageSize;
+    if (end > size) {
+        end = size;
+    }
+
+    setAnchor(list, predicate, nearestPage);
+    var iterationType = predicate.getIterationType();
+    return list.slice(begin, end).map(function(item) {
+        switch (iterationType) {
+            case IterationType.ENTRY: return item;
+            case IterationType.KEY: return item[0];
+            case IterationType.VALUE: return item[1];
+        }
+    });
+}
+
+function setAnchor(list: Array<any>, predicate: PagingPredicate, nearestPage: number) {
+    assert(list.length > 0);
+    var size = list.length;
+    var pageSize = predicate.getPageSize();
+    var page = predicate.getPage();
+    for (var i = pageSize; i <= size && nearestPage < page; i += pageSize ) {
+        var anchor = list[i - 1];
+        nearestPage++;
+        predicate.setAnchor(nearestPage, anchor);
     }
 }

--- a/src/core/Comparator.ts
+++ b/src/core/Comparator.ts
@@ -1,0 +1,21 @@
+/**
+ * Comparator is used to compare two map entries in a distributed map.
+ * A comparator class with the same functionality should be registered
+ * on Hazelcast server in order to be used in {PagingPredicate}s.
+ *
+ */
+export interface Comparator {
+    /**
+     * This method is used to determine order of entries when sorting.
+     *  - If return value is a negative value, {a} comes after {b},
+     *  - If return value is a positive value, {a} comes before {b},
+     *  - If return value is 0, {a} and {b} are indistinguishable in this sorting mechanism.
+     *      Their order with respect to each other is undefined.
+     * This method must always return the same result given the same pair of keys.
+     * @param a first entry
+     * @param b second entry
+     * @return order index
+     * 
+     */
+    sort(a: [any, any], b: [any, any]): number;
+}

--- a/src/core/Predicate.ts
+++ b/src/core/Predicate.ts
@@ -4,6 +4,7 @@ import {
     GreaterLessPredicate, LikePredicate, ILikePredicate, InPredicate, InstanceOfPredicate, NotEqualPredicate, NotPredicate,
     OrPredicate, RegexPredicate, TruePredicate, PagingPredicate
 } from '../serialization/DefaultPredicates';
+import {Comparator} from './Comparator';
 export interface Predicate extends IdentifiedDataSerializable {
 }
 
@@ -83,8 +84,8 @@ export function falsePredicate() {
     return FalsePredicate.INSTANCE;
 }
 
-export function paging(predicate: Predicate, pageSize: number) {
-    return new PagingPredicate(predicate, pageSize);
+export function paging(predicate: Predicate, pageSize: number, comparator: Comparator = null) {
+    return new PagingPredicate(predicate, pageSize, comparator);
 }
 
 export enum IterationType {

--- a/src/core/Predicate.ts
+++ b/src/core/Predicate.ts
@@ -2,7 +2,7 @@ import {IdentifiedDataSerializable} from '../serialization/Serializable';
 import {
     SqlPredicate, AndPredicate, FalsePredicate, BetweenPredicate, EqualPredicate,
     GreaterLessPredicate, LikePredicate, ILikePredicate, InPredicate, InstanceOfPredicate, NotEqualPredicate, NotPredicate,
-    OrPredicate, RegexPredicate, TruePredicate
+    OrPredicate, RegexPredicate, TruePredicate, PagingPredicate
 } from '../serialization/DefaultPredicates';
 export interface Predicate extends IdentifiedDataSerializable {
 }
@@ -81,4 +81,14 @@ export function truePredicate() {
 
 export function falsePredicate() {
     return FalsePredicate.INSTANCE;
+}
+
+export function paging(predicate: Predicate, pageSize: number) {
+    return new PagingPredicate(predicate, pageSize);
+}
+
+export enum IterationType {
+    KEY,
+    VALUE,
+    ENTRY
 }

--- a/src/serialization/DefaultPredicates.ts
+++ b/src/serialization/DefaultPredicates.ts
@@ -2,6 +2,7 @@ import {DataInput, DataOutput} from './Data';
 import {AbstractPredicate} from './PredicateFactory';
 import {Predicate, IterationType} from '../core/Predicate';
 import {enumFromString} from '../Util';
+import {Comparator} from '../core/Comparator';
 
 export class SqlPredicate extends AbstractPredicate {
 
@@ -359,20 +360,21 @@ export class PagingPredicate extends AbstractPredicate {
 
     private internalPredicate: Predicate;
     private pageSize: number;
-    private comparatorClass: any = null;
+    private comparatorObject: Comparator;
     private page: number = 0;
     private iterationType: IterationType = IterationType.ENTRY;
     private anchorList: [number, [any, any]][] = [];
 
-    constructor(internalPredicate: Predicate, pageSize: number) {
+    constructor(internalPredicate: Predicate, pageSize: number, comparator: Comparator) {
         super();
         this.internalPredicate = internalPredicate;
         this.pageSize = pageSize;
+        this.comparatorObject = comparator;
     }
 
     readData(input: DataInput): any {
         this.internalPredicate = input.readObject();
-        this.comparatorClass = input.readObject();
+        this.comparatorObject = input.readObject();
         this.page = input.readInt();
         this.pageSize = input.readInt();
         this.iterationType = enumFromString<IterationType>(IterationType, input.readUTF());
@@ -388,7 +390,7 @@ export class PagingPredicate extends AbstractPredicate {
 
     writeData(output: DataOutput): void {
         output.writeObject(this.internalPredicate);
-        output.writeObject(this.comparatorClass);
+        output.writeObject(this.comparatorObject);
         output.writeInt(this.page);
         output.writeInt(this.pageSize);
         output.writeUTF(IterationType[this.iterationType]);
@@ -459,6 +461,10 @@ export class PagingPredicate extends AbstractPredicate {
 
     getIterationType(): IterationType {
         return this.iterationType;
+    }
+
+    getComparator(): Comparator {
+        return this.comparatorObject;
     }
 }
 

--- a/src/serialization/DefaultPredicates.ts
+++ b/src/serialization/DefaultPredicates.ts
@@ -1,6 +1,7 @@
 import {DataInput, DataOutput} from './Data';
 import {AbstractPredicate} from './PredicateFactory';
-import {Predicate} from '../core/Predicate';
+import {Predicate, IterationType} from '../core/Predicate';
+import {enumFromString} from '../Util';
 
 export class SqlPredicate extends AbstractPredicate {
 
@@ -351,3 +352,113 @@ export class TruePredicate extends AbstractPredicate {
         return 14;
     }
 }
+
+export class PagingPredicate extends AbstractPredicate {
+
+    private static NULL_ANCHOR: [number, [any, any]] = [-1, null];
+
+    private internalPredicate: Predicate;
+    private pageSize: number;
+    private comparatorClass: any = null;
+    private page: number = 0;
+    private iterationType: IterationType = IterationType.ENTRY;
+    private anchorList: [number, [any, any]][] = [];
+
+    constructor(internalPredicate: Predicate, pageSize: number) {
+        super();
+        this.internalPredicate = internalPredicate;
+        this.pageSize = pageSize;
+    }
+
+    readData(input: DataInput): any {
+        this.internalPredicate = input.readObject();
+        this.comparatorClass = input.readObject();
+        this.page = input.readInt();
+        this.pageSize = input.readInt();
+        this.iterationType = enumFromString<IterationType>(IterationType, input.readUTF());
+        this.anchorList = [];
+        var size = input.readInt();
+        for (var i = 0; i < size; i++) {
+            var p = input.readInt();
+            var k = input.readObject();
+            var v = input.readObject();
+            this.anchorList.push([p, [k, v]]);
+        }
+    }
+
+    writeData(output: DataOutput): void {
+        output.writeObject(this.internalPredicate);
+        output.writeObject(this.comparatorClass);
+        output.writeInt(this.page);
+        output.writeInt(this.pageSize);
+        output.writeUTF(IterationType[this.iterationType]);
+        output.writeInt(this.anchorList.length);
+        this.anchorList.forEach(function(anchorEntry: [number, [any, any]]) {
+            output.writeInt(anchorEntry[0]);
+            output.writeObject(anchorEntry[1][0]);
+            output.writeObject(anchorEntry[1][1]);
+        });
+    }
+
+    getClassId(): number {
+        return 15;
+    }
+
+    setIterationType(iterationType: IterationType) {
+        this.iterationType = iterationType;
+    }
+
+    nextPage(): PagingPredicate {
+        this.page++;
+        return this;
+    }
+
+    previousPage(): PagingPredicate {
+        this.page--;
+        return this;
+    }
+
+    setPage(page: number): PagingPredicate {
+        this.page = page;
+        return this;
+    }
+
+    setAnchor(page: number, anchor: [any, any]) {
+        var anchorEntry: [number, [any, any]] = [page, anchor];
+        var anchorCount = this.anchorList.length;
+        if (page < anchorCount) {
+            this.anchorList[page] = anchorEntry;
+        } else if (page === anchorCount) {
+            this.anchorList.push(anchorEntry);
+        } else {
+            throw new Error('Anchor index is not correct, expected: ' + page + 'found: ' + anchorCount);
+        }
+    }
+
+    getPage(): number {
+        return this.page;
+    }
+
+    getPageSize(): number {
+        return this.pageSize;
+    }
+
+    getNearestAnchorEntry(): [number, [any, any]] {
+        var anchorCount = this.anchorList.length;
+        if (this.page === 0 || anchorCount === 0) {
+            return PagingPredicate.NULL_ANCHOR;
+        }
+        var anchoredEntry: [number, [any, any]];
+        if (this.page < anchorCount) {
+            anchoredEntry = this.anchorList[this.page - 1];
+        } else {
+            anchoredEntry = this.anchorList[anchorCount - 1];
+        }
+        return anchoredEntry;
+    }
+
+    getIterationType(): IterationType {
+        return this.iterationType;
+    }
+}
+

--- a/test/MapProxyTest.js
+++ b/test/MapProxyTest.js
@@ -792,6 +792,27 @@ describe("MapProxy Test", function() {
         });
     });
 
+    it('entrySetWithPredicate paging', function() {
+        return map.entrySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(entrySet) {
+            expect(entrySet.length).to.equal(1);
+            expect(entrySet[0]).to.deep.equal(['key3', 'val3']);
+        });
+    });
+
+    it('keySetWithPredicate paging', function() {
+        return map.keySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(keySet) {
+            expect(keySet.length).to.equal(1);
+            expect(keySet[0]).to.equal('key3');
+        });
+    });
+
+    it('valuesWithPredicate paging', function() {
+        return map.valuesWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(values) {
+            expect(values.length).to.equal(1);
+            expect(values[0]).to.equal('val3');
+        });
+    });
+
     it('destroy', function() {
         var dmap = client.getMap('map-to-be-destroyed');
         return dmap.put('key', 'val').then(function() {

--- a/test/PredicateTest.js
+++ b/test/PredicateTest.js
@@ -1,8 +1,6 @@
 var expect = require("chai").expect;
 var HazelcastClient = require("../.").Client;
 var Predicates = require("../.").Predicates;
-var FalsePredicate = require("../lib/serialization/DefaultPredicates").FalsePredicate;
-var TruePredicate = require("../lib/serialization/DefaultPredicates").TruePredicate;
 var Promise = require("bluebird");
 var Controller = require('./RC');
 var Util = require('./Util');
@@ -144,42 +142,73 @@ describe("Predicates", function() {
         return testPredicate(Predicates.truePredicate(), assertionList);
     });
 
-    it.skip('Paging first page should have first two items', function() {
+    it('Paging first page should have first two items', function() {
         var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
-
         return testPredicate(paging, [40, 41]);
     });
 
-    it.skip('Paging nextPage should have 3rd and 4th items', function() {
+    it('Paging nextPage should have 3rd and 4th items', function() {
         var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
         paging.nextPage();
 
         return testPredicate(paging, [42, 43]);
     });
 
-    it.skip('Paging fourth page should have 7th and 8th items', function() {
+    it('Paging fourth page should have 7th and 8th items', function() {
         var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
         paging.setPage(4);
 
-        return testPredicate(paging, [46, 47]);
+        return testPredicate(paging, [48, 49]);
     });
 
-    it.skip('Paging #getPage should return approprate value', function() {
+    it('Paging #getPage should return approprate value', function() {
         var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
         paging.setPage(4);
         return expect(paging.getPage()).to.equal(4);
     });
 
-    it.skip('Paging #getPageSize should return 2', function() {
-        var paging = PPredicates.paging(Predicates.greaterEqual('this', 40), 2);
+    it('Paging #getPageSize should return 2', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
         return expect(paging.getPageSize()).to.equal(2);
     });
 
-    it.skip('Paging previousPage', function () {
+    it('Paging previousPage', function () {
         var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
         paging.setPage(4);
         paging.previousPage();
 
-        return testPredicate(paging, [44, 45]);
+        return testPredicate(paging, [46, 47]);
+    });
+
+    it('Get 4th page, then previous page', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.setPage(4);
+        return map.valuesWithPredicate(paging).then(function() {
+            paging.previousPage();
+            return testPredicate(paging, [46, 47]);
+        });
+    });
+
+    it('Get 3rd page, then next page', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.setPage(3);
+        return map.valuesWithPredicate(paging).then(function() {
+            paging.nextPage();
+            return testPredicate(paging, [48, 49]);
+        });
+    });
+
+    it('Get 10th page (which does not exist) should return empty list', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 40), 2);
+        paging.setPage(10);
+
+        return testPredicate(paging, []);
+    });
+
+    it('Last page has only one element although page size is 2', function() {
+        var paging = Predicates.paging(Predicates.greaterEqual('this', 41), 2);
+        paging.setPage(4);
+
+        return testPredicate(paging, [49]);
     });
 });

--- a/test/serialization/DefaultSerializersTest.js
+++ b/test/serialization/DefaultSerializersTest.js
@@ -2,6 +2,7 @@ var expect = require('chai').expect;
 var Long = require('long');
 var Config = require('../../.').Config;
 var SerializationService = require('../../lib/serialization/SerializationService');
+var Predicates = require('../../.').Predicates;
 describe('Default serializers Test', function() {
 
     var serializationService;
@@ -26,7 +27,27 @@ describe('Default serializers Test', function() {
         [43546.6, 2343.4, 8988,4],
         [23545798.6],
         null,
-        {abc: 'abc', 'five': 5}
+        {abc: 'abc', 'five': 5},
+        Predicates.sql('test'),
+        Predicates.and(Predicates.truePredicate(), Predicates.truePredicate()),
+        Predicates.isBetween('this', 0, 1),
+        Predicates.isFalse(),
+        Predicates.isEqualTo('this', 10),
+        Predicates.greaterThan('this', 10),
+        Predicates.greaterEqual('this', 10),
+        Predicates.lessThan('this', 10),
+        Predicates.lessEqual('this', 10),
+        Predicates.like('this', '*'),
+        Predicates.ilike('this', '*'),
+        Predicates.inPredicate('this', 10, 11, 12),
+        Predicates.instanceOf('java.lang.Serializable'),
+        Predicates.notEqual('this', 10),
+        Predicates.not(Predicates.truePredicate()),
+        Predicates.or(Predicates.truePredicate(), Predicates.truePredicate()),
+        Predicates.regex('this', '/abc/'),
+        Predicates.truePredicate(),
+        Predicates.falsePredicate(),
+        Predicates.paging(Predicates.greaterEqual('this', 10), 10)
     ];
 
     parameters.forEach(function (obj) {


### PR DESCRIPTION
Full PagingPredicate support.
An IdentifiedDataSerializable or Portable Comparator class should be registered to both Hazelcast server and client in order to test PagingPredicate with custom comparator. Hazelcast Remote Controller does not have this capability for now. Therefore I could not test custom comparator option formally. However I created a code sample for that and I tried the functionality by hand.
If you want to reproduce the test you can start hazelcast server with following snippet:
```
package com.hazelcast.client;

import com.hazelcast.config.Config;
import com.hazelcast.config.GroupConfig;
import com.hazelcast.config.NetworkConfig;
import com.hazelcast.config.SerializationConfig;
import com.hazelcast.core.Hazelcast;
import com.hazelcast.core.HazelcastInstance;
import com.hazelcast.nio.ObjectDataInput;
import com.hazelcast.nio.ObjectDataOutput;
import com.hazelcast.nio.serialization.DataSerializableFactory;
import com.hazelcast.nio.serialization.IdentifiedDataSerializable;

import java.io.IOException;
import java.util.Comparator;
import java.util.Map;

/**
 * Created by mustafa on 19/07/16.
 */
public class UT {
    public static void main(String[] args) {
        Config config = new Config();
        SerializationConfig serializationConfig = new SerializationConfig();
        serializationConfig.addDataSerializableFactory(1, new DataSerializableFactory() {
            @Override
            public IdentifiedDataSerializable create(int typeId) {
                return new ReverseComparator();
            }
        });
        config.setSerializationConfig(serializationConfig);
        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);

    }

    public static class ReverseComparator implements Comparator<Map.Entry>, IdentifiedDataSerializable {

        @Override
        public int getFactoryId() {
            return 1;
        }

        @Override
        public int getId() {
            return 10;
        }

        @Override
        public void writeData(ObjectDataOutput out) throws IOException {

        }

        @Override
        public void readData(ObjectDataInput in) throws IOException {

        }

        @Override
        public int compare(Map.Entry o1, Map.Entry o2) {
            return (((String)o1.getKey()).compareTo(((String)o2.getKey()))) * -1;
        }
    }
}
```
Then you can run `code_samples/paging_predicate.js`. You will see entries are reverse oredered and paged as it should be.