### PR TITLE
changes client identified string in authentication phase, so hazelcas…

### DIFF
--- a/src/invocation/ConnectionAuthenticator.ts
+++ b/src/invocation/ConnectionAuthenticator.ts
@@ -24,7 +24,7 @@ class ConnectionAuthenticator {
 
 
         var clientMessage = ClientAuthenticationCodec.encodeRequest(
-            groupConfig.name, groupConfig.password, uuid, ownerUuid, ownerConnection, 'NodeJS', 1);
+            groupConfig.name, groupConfig.password, uuid, ownerUuid, ownerConnection, 'NJS', 1);
         return this.client.getInvocationService()
             .invokeOnConnection(this.connection, clientMessage)
             .then((msg: ClientMessage) => {


### PR DESCRIPTION
Changes identification string  in authentication phase to `NJS` so hazelcast server will recognize this client as official Node.js Client for Hazelcast starting from version 3.7.
Server side PR: https://github.com/hazelcast/hazelcast/pull/8556