### PR TITLE
Heartbeat Socket Unhandled Reject Error

### DIFF
--- a/src/HeartbeatService.ts
+++ b/src/HeartbeatService.ts
@@ -63,7 +63,10 @@ class Heartbeat {
                 }
                 if (timeSinceLastRead > this.heartbeatInterval) {
                     var req = ClientPingCodec.encodeRequest();
-                    this.client.getInvocationService().invokeOnConnection(conn, req);
+                    this.client.getInvocationService().invokeOnConnection(conn, req)
+                        .catch((error) => {
+                            this.logger.warn('HeartbeatService', error);
+                        });
                 } else {
                     if (!conn.heartbeating) {
                         setImmediate(this.onHeartbeatRestored.bind(this), conn);

--- a/test/HeartbeatTest.js
+++ b/test/HeartbeatTest.js
@@ -3,7 +3,7 @@ var HazelcastClient = require('../.').Client;
 var expect = require('chai').expect;
 var Config = require('../.').Config;
 
-describe('Hearbeat', function() {
+describe('Heartbeat', function() {
     this.timeout(30000);
 
     var cluster;


### PR DESCRIPTION
Catch 

> Unhandled rejection Error: This socket has been ended by the other party
>     at Socket.writeAfterFIN [as write] (net.js:270:12)
>     at ClientConnection.write (/Users/psmith/workspace/fountain/node_modules/hazelcast-client/lib/invocation/ClientConnection.js:37:21)
>     at InvocationService.send (/Users/psmith/workspace/fountain/node_modules/hazelcast-client/lib/invocation/InvocationService.js:103:20)
>     at InvocationService.invokeSmart (/Users/psmith/workspace/fountain/node_modules/hazelcast-client/lib/invocation/InvocationService.js:59:25)
>     at InvocationService.invokeOnConnection (/Users/psmith/workspace/fountain/node_modules/hazelcast-client/lib/invocation/InvocationService.js:42:21)
>     at Heartbeat.heartbeatFunction (/Users/psmith/workspace/fountain/node_modules/hazelcast-client/lib/HeartbeatService.js:37:56)
>     at Timer.listOnTimeout (timers.js:92:15)

Which happens when we disconnect from a client and still are doing a heartbeat check.