### PR TITLE
Near cache

### DIFF
--- a/src/ClientMessage.ts
+++ b/src/ClientMessage.ts
@@ -231,6 +231,10 @@ class ClientMessage {
         return result;
     }
 
+    isComplete(): boolean {
+        return (this.cursor >= BitsUtil.HEADER_SIZE) && (this.cursor === this.getFrameLength());
+    }
+
     readMapEntry(): any {
         // TODO
     }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -151,11 +151,6 @@ export enum InMemoryFormat {
     BINARY
 }
 
-export enum LocalUpdatePolicy {
-    INVALIDATE,
-    CACHE
-}
-
 export class NearCacheConfig {
     name: string = 'default';
     /**

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -137,6 +137,66 @@ export interface LifecycleListener {
 }
 
 /**
+ * Represents the format that objects are kept in this client's memory.
+ */
+export enum InMemoryFormat {
+    /**
+     * Objects are in native JS objects
+     */
+    OBJECT,
+
+        /**
+         * Objects are in serialized form
+         */
+    BINARY
+}
+
+export enum LocalUpdatePolicy {
+    INVALIDATE,
+    CACHE
+}
+
+export class NearCacheConfig {
+    name: string = 'default';
+    /**
+     * 'true' to invalidate entries when they are changed in cluster,
+     * 'false' to invalidate entries only when they are accessed.
+     */
+    invalidateOnChange: boolean = true;
+    /**
+     * Max number of seconds that an entry can stay in the cache until it is acceessed
+     */
+    maxIdleSeconds: number = 0;
+    inMemoryFormat: InMemoryFormat = InMemoryFormat.BINARY;
+    /**
+     * Maximum number of seconds that an entry can stay in cache.
+     */
+    timeToLiveSeconds: number = 0;
+    evictionPolicy: EvictionPolicy = EvictionPolicy.NONE;
+    evictionMaxSize: number = Number.MAX_SAFE_INTEGER;
+    evictionSamplingCount: number = 8;
+    evictionSamplingPoolSize: number = 16;
+
+    toString(): string {
+        return 'NearCacheConfig[' +
+            'name: ' + this.name + ', ' +
+            'invalidateOnChange:' + this.invalidateOnChange + ', ' +
+            'inMemoryFormat: ' + this.inMemoryFormat + ', ' +
+            'ttl(sec): ' + this.timeToLiveSeconds + ', ' +
+            'evictionPolicy: ' + this.evictionPolicy + ', ' +
+            'evictionMaxSize: ' + this.evictionMaxSize + ', ' +
+            'maxIdleSeconds: ' + this.maxIdleSeconds + ']';
+    }
+}
+
+export enum EvictionPolicy {
+    NONE,
+    LRU,
+    LFU,
+    RANDOM
+}
+
+/**
  * Configurations for LifecycleListeners. These are registered as soon as client started.
  */
 export class ListenerConfig {
@@ -171,4 +231,5 @@ export class ClientConfig {
     reliableTopicConfigs: any = {
         'default': new ReliableTopicConfig()
     };
+    nearCacheConfigs: {[name: string]: NearCacheConfig} = {};
 }

--- a/src/DataStoreHashMap.ts
+++ b/src/DataStoreHashMap.ts
@@ -1,0 +1,104 @@
+import {Data} from './serialization/Data';
+export class DataKeyedHashMap<T> {
+
+    private internalStore: Map<number, Array<InternalRecord<T>>>;
+
+    size: number;
+
+    constructor() {
+        this.internalStore = new Map();
+        this.size = 0;
+    }
+
+    clear(): void {
+        this.size = 0;
+        this.internalStore = new Map();
+    }
+
+    delete(key: Data): boolean {
+        var existingIndex = this.findIndexInBucket(key);
+        if (existingIndex === -1) {
+            return false;
+        } else {
+            this.getOrCreateBucket(key.hashCode()).splice(existingIndex, 1);
+            this.size--;
+            return true;
+        }
+    }
+
+    has(key: Data): boolean {
+        return this.findIndexInBucket(key) !== -1;
+    }
+
+    get(key: Data): T {
+        var keyHash = key.hashCode();
+        var existingIndex = this.findIndexInBucket(key);
+        if (existingIndex !== -1) {
+            return this.getOrCreateBucket(keyHash)[existingIndex].value;
+        } else {
+            return undefined;
+        }
+    }
+
+    set(key: Data, value: any): this {
+        var keyHash = key.hashCode();
+        var existingIndex = this.findIndexInBucket(key);
+        if (existingIndex !== -1) {
+            this.getOrCreateBucket(keyHash)[existingIndex].value = value;
+        } else {
+            this.getOrCreateBucket(keyHash).push({key: key, value: value});
+            this.size++;
+        }
+        return this;
+    }
+
+    values(): Array<T> {
+        var snapshot: Array<T> = [];
+        this.internalStore.forEach((bucket: Array<InternalRecord<T>>) => {
+            snapshot.push(...(bucket.map((item: InternalRecord<T>) => { return item.value; })));
+        });
+        return snapshot;
+    }
+
+    entries(): Array<[Data, T]> {
+        var snapshot: Array<[Data, T]> = [];
+        this.internalStore.forEach((bucket: Array<InternalRecord<T>>) => {
+            snapshot.push(...(bucket.map((item: InternalRecord<T>) => {
+                return <[Data, T]>[item.key, item.value];
+            })));
+        });
+        return snapshot;
+    }
+
+    /**
+     *
+     * @param key
+     * @returns index of the key if it exists, -1 if either bucket or item does not exist
+     */
+    private findIndexInBucket(key: Data): number {
+        var keyHash = key.hashCode();
+        var bucket = this.internalStore.get(keyHash);
+        if (bucket === undefined) {
+            return -1;
+        } else {
+            return bucket.findIndex((item: InternalRecord<T> ) => {
+                return item.key.equals(key);
+            });
+        }
+    }
+
+    private getOrCreateBucket(key: number): Array<InternalRecord<T>> {
+        var bucket: Array<InternalRecord<T>>;
+        bucket = this.internalStore.get(key);
+        if (bucket === undefined) {
+            bucket = [];
+            this.internalStore.set(key, bucket);
+        }
+        return bucket;
+    }
+}
+
+class InternalRecord<T> {
+    key: Data;
+    value: T;
+}

--- a/src/NearCache.ts
+++ b/src/NearCache.ts
@@ -1,0 +1,230 @@
+import {Data} from './serialization/Data';
+import {EvictionPolicy, InMemoryFormat, NearCacheConfig} from './Config';
+import {shuffleArray} from './Util';
+import {SerializationService} from './serialization/SerializationService';
+export class DataRecord {
+    key: Data | any;
+    value: Data | any;
+    private creationTime: number;
+    private expirationTime: number;
+    private lastAccessTime: number;
+    private accessHit: number;
+
+    constructor(key: Data | any, value: Data | any, creationTime?: number, ttl?: number) {
+        this.key = key;
+        this.value = value;
+        if (creationTime) {
+            this.creationTime = creationTime;
+        } else {
+            this.creationTime = new Date().getTime();
+        }
+        if (ttl) {
+            this.expirationTime = this.creationTime + ttl * 1000;
+        } else {
+            this.expirationTime = undefined;
+        }
+        this.lastAccessTime = this.creationTime;
+        this.accessHit = 0;
+    }
+
+    public static lruComp(x: DataRecord, y: DataRecord) {
+        return x.lastAccessTime - y.lastAccessTime;
+    }
+
+    public static lfuComp(x: DataRecord, y: DataRecord) {
+        return x.accessHit - y.accessHit;
+    }
+
+    public static randomComp(x: DataRecord, y: DataRecord) {
+        return Math.random() - 0.5;
+    }
+
+    isExpired(maxIdleSeconds: number) {
+        var now = new Date().getTime();
+        if ( (this.expirationTime > 0 && this.expirationTime < now) ||
+            (maxIdleSeconds > 0 && this.lastAccessTime + maxIdleSeconds * 1000 < now)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    setAccessTime(): void {
+        this.lastAccessTime = new Date().getTime();
+    }
+
+    hitRecord(): void {
+        this.accessHit++;
+    }
+}
+
+export interface NearCacheStatistics {
+    evictedCount: number;
+    expiredCount: number;
+    missCount: number;
+    hitCount: number;
+    entryCount: number;
+}
+
+export class NearCache {
+
+    private serializationService: SerializationService;
+    private name: string;
+    private invalidateOnChange: boolean;
+    private maxIdleSeconds: number;
+    private inMemoryFormat: InMemoryFormat;
+    private timeToLiveSeconds: number;
+    private evictionPolicy: EvictionPolicy;
+    private evictionMaxSize: number;
+    private evictionSamplingCount: number;
+    private evictionSamplingPoolSize: number;
+    private evictionCandidatePool: Array<DataRecord>;
+
+    internalStore: Map<any | Data, DataRecord>;
+
+    private evictedCount: number = 0;
+    private expiredCount: number = 0;
+    private missCount: number = 0;
+    private hitCount: number = 0;
+    private compareFunc: (x: DataRecord, y: DataRecord) => number;
+
+    constructor(nearCacheConfig: NearCacheConfig, serializationService: SerializationService) {
+        this.serializationService = serializationService;
+        this.name = nearCacheConfig.name;
+        this.invalidateOnChange = nearCacheConfig.invalidateOnChange;
+        this.maxIdleSeconds = nearCacheConfig.maxIdleSeconds;
+        this.inMemoryFormat = nearCacheConfig.inMemoryFormat;
+        this.timeToLiveSeconds = nearCacheConfig.timeToLiveSeconds;
+        this.evictionPolicy = nearCacheConfig.evictionPolicy;
+        this.evictionMaxSize = nearCacheConfig.evictionMaxSize;
+        this.evictionSamplingCount = nearCacheConfig.evictionSamplingCount;
+        this.evictionSamplingPoolSize = nearCacheConfig.evictionSamplingPoolSize;
+        if (this.evictionPolicy === EvictionPolicy.LFU) {
+            this.compareFunc = DataRecord.lfuComp;
+        } else if (this.evictionPolicy === EvictionPolicy.LRU) {
+            this.compareFunc = DataRecord.lruComp;
+        } else if (this.evictionPolicy === EvictionPolicy.RANDOM) {
+            this.compareFunc = DataRecord.randomComp;
+        } else {
+            this.compareFunc = undefined;
+        }
+
+        this.evictionCandidatePool = [];
+        this.internalStore = new Map();
+    }
+
+    /**
+     * Creates a new {DataRecord} for given key and value. Then, puts the record in near cache.
+     * If the number of records in near cache exceeds {evictionMaxSize}, it removes expired items first.
+     * If there is no expired item, it triggers an invalidation process to create free space.
+     * @param key
+     * @param value
+     */
+    put(key: any, value: any): void {
+        this.doEvictionIfRequired();
+        if (this.inMemoryFormat === InMemoryFormat.OBJECT) {
+            value = this.serializationService.toObject(value);
+        } else {
+            value = this.serializationService.toData(value);
+        }
+        var dr = new DataRecord(key, value, undefined, this.timeToLiveSeconds);
+        this.internalStore.set(key, dr);
+    }
+
+    /**
+     *
+     * @param key
+     * @returns the value if present in near cache, 'undefined' if not
+     */
+    get(key: Data | any): Data | any {
+        var dr = this.internalStore.get(key);
+        if (dr === undefined) {
+            this.missCount++;
+            return undefined;
+        }
+        if (dr.isExpired(this.maxIdleSeconds)) {
+            this.expireRecord(key);
+            this.missCount++;
+            return undefined;
+        }
+        dr.setAccessTime();
+        dr.hitRecord();
+        this.hitCount++;
+        if (this.inMemoryFormat === InMemoryFormat.BINARY) {
+            return this.serializationService.toObject(dr.value);
+        } else {
+            return dr.value;
+        }
+    }
+
+    protected isEvictionRequired() {
+        return this.evictionPolicy !== EvictionPolicy.NONE && this.evictionMaxSize <= this.internalStore.size;
+    }
+
+    protected doEvictionIfRequired(): void {
+        if (!this.isEvictionRequired()) {
+            return;
+        }
+        var internalSize = this.internalStore.size;
+        if (this.recomputeEvictionPool() > 0) {
+            return;
+        } else {
+            this.evictRecord(this.evictionCandidatePool[0].key);
+            this.evictionCandidatePool = this.evictionCandidatePool.slice(1);
+        }
+    }
+
+    /**
+     * @returns number of expired elements.
+     */
+    protected recomputeEvictionPool(): number {
+        var arr: Array<DataRecord> = Array.from(this.internalStore, (v: [any, DataRecord]) => { return v[1]; } );
+
+        shuffleArray<DataRecord>(arr);
+        var newCandidates = arr.slice(0, this.evictionSamplingCount);
+        var cleanedNewCandidates = newCandidates.filter(this.filterExpiredRecord, this);
+        var expiredCount = newCandidates.length - cleanedNewCandidates.length;
+        if (expiredCount > 0) {
+            return expiredCount;
+        }
+
+        this.evictionCandidatePool.push(...cleanedNewCandidates);
+
+        this.evictionCandidatePool.sort(this.compareFunc);
+
+        this.evictionCandidatePool = this.evictionCandidatePool.slice(0, this.evictionSamplingPoolSize);
+        return 0;
+    }
+
+    protected filterExpiredRecord(candidate: DataRecord): boolean {
+        if (candidate.isExpired(this.maxIdleSeconds)) {
+            this.expireRecord(candidate.key);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    protected expireRecord(key: any | Data): void {
+        if (this.internalStore.delete(key) ) {
+            this.expiredCount++;
+        }
+    }
+
+    protected evictRecord(key: any | Data): void {
+        if (this.internalStore.delete(key)) {
+            this.evictedCount++;
+        }
+    }
+
+    getStatistics(): NearCacheStatistics {
+        var stats: NearCacheStatistics = {
+            evictedCount: this.evictedCount,
+            expiredCount: this.expiredCount,
+            missCount: this.missCount,
+            hitCount: this.hitCount,
+            entryCount: this.internalStore.size
+        };
+        return stats;
+    }
+}

--- a/src/PartitionService.ts
+++ b/src/PartitionService.ts
@@ -58,6 +58,10 @@ class PartitionService {
         }
         return Math.abs(partitionHash) % this.partitionCount;
     }
+
+    getPartitionCount(): number {
+        return this.partitionCount;
+    }
 }
 
 export = PartitionService;

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -9,6 +9,18 @@ export function assertNotNull(v: any) {
 export function assertArray(x: any) {
     assert(Array.isArray(x), 'Should be array.');
 }
+
+export function shuffleArray<T>(array: Array<T>): void {
+    var randomIndex: number;
+    var temp: T;
+    for (var i = array.length; i > 1; i--) {
+        randomIndex = Math.floor(Math.random() * i);
+        temp = array[i - 1];
+        array[i - 1] = array[randomIndex];
+        array[randomIndex] = temp;
+    }
+}
+
 export function getType(obj: any): string {
     assertNotNull(obj);
     if (Long.isLong(obj)) {

--- a/src/codec/UUIDCodec.ts
+++ b/src/codec/UUIDCodec.ts
@@ -1,0 +1,10 @@
+import ClientMessage = require('../ClientMessage');
+import {UUID} from '../core/UUID';
+export class UUIDCodec {
+    static decode(clientMessage: ClientMessage, toObject: Function): UUID  {
+        var uuid: UUID;
+        uuid.mostSignificant = clientMessage.readLong();
+        uuid.leastSignificant = clientMessage.readLong();
+        return uuid;
+    }
+}

--- a/src/core/UUID.ts
+++ b/src/core/UUID.ts
@@ -1,0 +1,5 @@
+import * as Long from 'long';
+export interface UUID {
+    leastSignificant: Long;
+    mostSignificant: Long;
+}

--- a/src/nearcache/InvalidationAwareWrapper.ts
+++ b/src/nearcache/InvalidationAwareWrapper.ts
@@ -1,0 +1,47 @@
+import {NearCache, NearCacheStatistics} from './NearCache';
+import {Data} from '../serialization/Data';
+import {KeyStateMarker, KeyStateMarkerImpl} from './KeyStateMarker';
+export class InvalidationAwareWrapper implements NearCache {
+
+    private nearCache: NearCache;
+    private keyStateMarker: KeyStateMarker;
+
+    public static asInvalidationAware(nearCache: NearCache, markerCount: number): InvalidationAwareWrapper {
+        return new InvalidationAwareWrapper(nearCache, markerCount);
+    }
+
+    private constructor(nearCache: NearCache, markerCount: number) {
+        this.nearCache = nearCache;
+        this.keyStateMarker = new KeyStateMarkerImpl(markerCount);
+    }
+
+    put(key: Data, value: any): void {
+        return this.nearCache.put(key, value);
+    }
+
+    get(key: Data): Data|any {
+        return this.nearCache.get(key);
+    }
+
+    invalidate(key: Data): void {
+        this.keyStateMarker.removeIfMarked(key);
+        return this.nearCache.invalidate(key);
+    }
+
+    clear(): void {
+        this.keyStateMarker.unmarkAllForcibly();
+        return this.nearCache.clear();
+    }
+
+    getStatistics(): NearCacheStatistics {
+        return this.nearCache.getStatistics();
+    }
+
+    isInvalidatedOnChange(): boolean {
+        return this.nearCache.isInvalidatedOnChange();
+    }
+
+    getKeyStateMarker(): KeyStateMarker {
+        return this.keyStateMarker;
+    }
+}

--- a/src/nearcache/KeyStateMarker.ts
+++ b/src/nearcache/KeyStateMarker.ts
@@ -1,0 +1,99 @@
+import {Data} from '../serialization/Data';
+export interface KeyStateMarker {
+    markIfUnmarked(key: Data): boolean;
+    unmarkIfMarked(key: Data): boolean;
+    removeIfMarked(key: Data): boolean;
+    unmarkForcibly(key: Data): void;
+    unmarkAllForcibly(): void;
+
+}
+
+enum KeyState {
+    UNMARKED = 0,
+    MARKED = 1,
+    REMOVED = 2
+}
+
+export class KeyStateMarkerImpl implements KeyStateMarker {
+
+    private marks: KeyState[];
+
+    constructor(markerCount: number) {
+        this.marks = [];
+        for (let i = markerCount - 1; i >= 0; i--) {
+            this.marks[i] = KeyState.UNMARKED;
+        }
+    }
+
+    markIfUnmarked(key: Data): boolean {
+        return this.compareAndSet(key, KeyState.UNMARKED, KeyState.MARKED);
+    }
+
+    unmarkIfMarked(key: Data): boolean {
+        return this.compareAndSet(key, KeyState.MARKED, KeyState.UNMARKED);
+    }
+
+    removeIfMarked(key: Data): boolean {
+        return this.compareAndSet(key, KeyState.MARKED, KeyState.REMOVED);
+    }
+
+    unmarkForcibly(key: Data): void {
+        let slot = this.getSlot(key);
+        this.marks[slot] = KeyState.UNMARKED;
+    }
+
+    unmarkAllForcibly(): void {
+        for (let i = 0; i < this.marks.length; i++) {
+            this.marks[i] = KeyState.UNMARKED;
+        }
+    }
+
+    private compareAndSet(key: Data, expect: KeyState, update: KeyState): boolean {
+        let slot = this.getSlot(key);
+        if (this.marks[slot] === expect) {
+            this.marks[slot] = update;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private getSlot(data: Data): number {
+        return this.hashToIndex(data.getPartitionHash(), this.marks.length);
+    }
+
+    private hashToIndex(hash: number, len: number): number {
+        return Math.abs(hash) % len;
+    }
+
+}
+
+export class TrueKeyStateMarker implements KeyStateMarker {
+
+    static INSTANCE = new TrueKeyStateMarker();
+
+    private constructor() {
+        //Empty method
+    }
+
+    markIfUnmarked(key: Data): boolean {
+        return true;
+    }
+
+    unmarkIfMarked(key: Data): boolean {
+        return true;
+    }
+
+    removeIfMarked(key: Data): boolean {
+        return true;
+    }
+
+    unmarkForcibly(key: Data): void {
+        //Empty method
+    }
+
+    unmarkAllForcibly(): void {
+        //Empty method
+    }
+
+}

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -60,6 +60,10 @@ import {MapExecuteWithPredicateCodec} from '../codec/MapExecuteWithPredicateCode
 import {MapExecuteOnKeyCodec} from '../codec/MapExecuteOnKeyCodec';
 import {MapExecuteOnKeysCodec} from '../codec/MapExecuteOnKeysCodec';
 import * as SerializationUtil from '../serialization/SerializationUtil';
+
+//TODO this is a temprorary reference to get NearCache compiled
+import {NearCache, DataRecord} from '../NearCache';
+
 export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
 
     executeOnKeys(keys: K[], entryProcessor: IdentifiedDataSerializable|Portable): Promise<any[]> {

--- a/src/proxy/NearCachedMapProxy.ts
+++ b/src/proxy/NearCachedMapProxy.ts
@@ -1,0 +1,237 @@
+import {MapProxy} from './MapProxy';
+import HazelcastClient from '../HazelcastClient';
+import {NearCacheImpl, NearCache} from '../nearcache/NearCache';
+import {Data} from '../serialization/Data';
+import * as Promise from 'bluebird';
+import {MapAddNearCacheEntryListenerCodec} from '../codec/MapAddNearCacheEntryListenerCodec';
+import {EntryEventType} from '../core/EntryEventType';
+import ClientMessage = require('../ClientMessage');
+import {InvalidationAwareWrapper} from '../nearcache/InvalidationAwareWrapper';
+import {KeyStateMarker, TrueKeyStateMarker} from '../nearcache/KeyStateMarker';
+import {DataKeyedHashMap} from '../DataStoreHashMap';
+
+export class NearCachedMapProxy<K, V> extends MapProxy<K, V> {
+
+    private nearCache: NearCache;
+    private invalidationListenerId: string;
+    private keyStateMarker: KeyStateMarker;
+
+    constructor(client: HazelcastClient, servicename: string, name: string) {
+        super(client, servicename, name);
+        this.nearCache = new NearCacheImpl(this.client.getConfig().nearCacheConfigs[name], this.client.getSerializationService());
+        this.keyStateMarker = TrueKeyStateMarker.INSTANCE;
+        if (this.nearCache.isInvalidatedOnChange()) {
+            let partitionCount = client.getPartitionService().getPartitionCount();
+            this.nearCache = InvalidationAwareWrapper.asInvalidationAware(this.nearCache, partitionCount);
+            this.keyStateMarker = this.getKeyStateMarker();
+            this.addNearCacheInvalidationListener().then((id: string) => {
+                this.invalidationListenerId = id;
+            });
+        }
+    }
+
+    private tryToPutNearCache(key: Data, value: V | Data) {
+        try {
+            this.nearCache.put(key, value);
+        } finally {
+            this.resetToUnmarkedState(key);
+        }
+    }
+
+    private resetToUnmarkedState(key: Data): void {
+        if (this.keyStateMarker.unmarkIfMarked(key)) {
+            return;
+        }
+        this.nearCache.invalidate(key);
+        this.keyStateMarker.unmarkForcibly(key);
+    }
+
+    private unmarkRemainingMarkedKeys(markers: DataKeyedHashMap<boolean>): void {
+        let entries: Array<[Data, boolean]> = markers.entries();
+        entries.forEach((entry: [Data, any]) => {
+            let marked = entry[1];
+            if (marked) {
+                this.keyStateMarker.unmarkForcibly(entry[0]);
+            }
+        });
+    }
+
+    private invalidatCacheEntryAndReturn<T>(keyData: Data, retVal: T): T {
+        this.nearCache.invalidate(keyData);
+        return retVal;
+    }
+
+    private invalidateCacheAndReturn<T>(retVal: T): T {
+        this.nearCache.clear();
+        return retVal;
+    }
+
+    getKeyStateMarker(): KeyStateMarker {
+        return (<InvalidationAwareWrapper>this.nearCache).getKeyStateMarker();
+    }
+
+    clear(): Promise<void> {
+        return super.clear().then<void>(this.invalidateCacheAndReturn.bind(this));
+    }
+
+    protected containsKeyInternal(keyData: Data): Promise<boolean> {
+        var cachedValue = this.nearCache.get(keyData);
+        if (cachedValue !== undefined) {
+            return Promise.resolve(cachedValue != null);
+        } else {
+            return super.containsKeyInternal(keyData);
+        }
+    }
+
+    protected deleteInternal(keyData: Data): Promise<void> {
+        this.nearCache.invalidate(keyData);
+        return super.deleteInternal(keyData).then<void>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    evictAll(): Promise<void> {
+        this.nearCache.clear();
+        return super.evictAll().then<void>(this.invalidateCacheAndReturn.bind(this));
+    }
+
+    protected evictInternal(key: Data): Promise<boolean> {
+        return super.evictInternal(key).then<boolean>(this.invalidatCacheEntryAndReturn.bind(this, key));
+    }
+
+    protected putAllInternal(partitionsToKeysData: {[id: string]: [Data, Data][]}): Promise<void> {
+        return super.putAllInternal(partitionsToKeysData).then(() => {
+            for (var partition in partitionsToKeysData) {
+                partitionsToKeysData[partition].forEach((entry: [Data, Data]) => {
+                    this.nearCache.invalidate(entry[0]);
+                });
+            }
+        });
+    }
+
+    protected putIfAbsentInternal(keyData: Data, valueData: Data, ttl: number): Promise<V> {
+        return super.putIfAbsentInternal(keyData, valueData, ttl).then<V>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected putTransientInternal(keyData: Data, valueData: Data, ttl: number): Promise<void> {
+        return super
+            .putTransientInternal(keyData, valueData, ttl).then<void>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected executeOnKeyInternal(keyData: Data, proData: Data): Promise<V> {
+        return super.executeOnKeyInternal(keyData, proData).then<V>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected putInternal(keyData: Data, valueData: Data, ttl: number): Promise<V> {
+        return super.putInternal(keyData, valueData, ttl).then<V>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected getInternal(keyData: Data): Promise<V> {
+        var cachedValue = this.nearCache.get(keyData);
+        if (cachedValue !== undefined) {
+            return Promise.resolve(cachedValue);
+        } else {
+            let marked = this.keyStateMarker.markIfUnmarked(keyData);
+            return super.getInternal(keyData).then((val: V) => {
+                if (marked) {
+                    this.tryToPutNearCache(keyData, val);
+                }
+                return val;
+            }).catch((err: any) => {
+                this.resetToUnmarkedState(keyData);
+                throw err;
+            });
+        }
+    }
+
+    protected tryRemoveInternal(keyData: Data, timeout: number): Promise<boolean> {
+        return super.tryRemoveInternal(keyData, timeout).then<boolean>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected removeInternal(keyData: Data, value: V): Promise<V> {
+        return super.removeInternal(keyData, value).then<V>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected getAllInternal(partitionsToKeys: {[id: string]: any}, result: any[] = []): Promise<any[]> {
+        let markers = new DataKeyedHashMap<boolean>();
+        try {
+            for (var partition in partitionsToKeys) {
+                var partitionArray = partitionsToKeys[partition];
+                for (var i = partitionArray.length - 1; i >= 0; i--) {
+                    let key = partitionArray[i];
+                    var cachedResult = this.nearCache.get(key);
+                    if (cachedResult !== undefined) {
+                        result.push([this.toObject(partitionArray[i]), cachedResult]);
+                        partitionArray = partitionArray.splice(i, 1);
+                    } else if (this.nearCache.isInvalidatedOnChange()) {
+                        markers.set(key, this.keyStateMarker.markIfUnmarked(key));
+                    }
+                }
+            }
+        } catch (err) {
+            this.unmarkRemainingMarkedKeys(markers);
+            return Promise.resolve([]);
+        }
+        return super.getAllInternal(partitionsToKeys, result).then((serializedEntryArray: [Data, Data][]) => {
+            try {
+                serializedEntryArray.forEach((serializedEntry: [Data, Data]) => {
+                    let key = serializedEntry[0];
+                    let value = serializedEntry[1];
+                    let marked = markers.get(key);
+                    markers.delete(key);
+                    if (marked !== undefined && marked) {
+                        this.tryToPutNearCache(key, value);
+                    } else if (!this.nearCache.isInvalidatedOnChange()) {
+                        this.nearCache.put(key, value);
+                    }
+                });
+            } finally {
+                this.unmarkRemainingMarkedKeys(markers);
+            }
+            return result;
+        });
+
+
+    }
+
+    protected replaceIfSameInternal(keyData: Data, oldValueData: Data, newValueData: Data): Promise<boolean> {
+        return super.replaceIfSameInternal(keyData, oldValueData, newValueData)
+            .then<boolean>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected replaceInternal(keyData: Data, valueData: Data): Promise<V> {
+        return super.replaceInternal(keyData, valueData).then<V>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    protected setInternal(keyData: Data, valueData: Data, ttl: number): Promise<void> {
+        return super.setInternal(keyData, valueData, ttl).then<void>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+
+    protected tryPutInternal(keyData: Data, valueData: Data, timeout: number): Promise<boolean> {
+        return super.tryPutInternal(keyData, valueData, timeout)
+            .then<boolean>(this.invalidatCacheEntryAndReturn.bind(this, keyData));
+    }
+
+    private addNearCacheInvalidationListener(): Promise<string> {
+        var nearCache = this.nearCache;
+        var invalidationHandler = function(keyData: Data) {
+            if (keyData == null) {
+                nearCache.clear();
+            } else {
+                nearCache.invalidate(keyData);
+            }
+        };
+        var invalidationBatchHandler = function (keys: Array<Data>) {
+            keys.forEach((key: Data) => {
+                nearCache.invalidate(key);
+            });
+        };
+
+        var request = MapAddNearCacheEntryListenerCodec.encodeRequest(this.name, EntryEventType.INVALIDATION, false);
+        return this.client.getListenerService().registerListener(
+            request,
+            (m: ClientMessage) => { MapAddNearCacheEntryListenerCodec.handle(m, invalidationHandler, invalidationBatchHandler); },
+            (m: ClientMessage) => { return MapAddNearCacheEntryListenerCodec.decodeResponse(m)['response']; }
+        );
+    }
+
+}

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -14,6 +14,7 @@ import {ListProxy} from './ListProxy';
 import {LockProxy} from './LockProxy';
 import {MultiMapProxy} from './MultiMapProxy';
 import {RingbufferProxy} from './RingbufferProxy';
+import {NearCachedMapProxy} from './NearCachedMapProxy';
 
 class ProxyManager {
     public MAP_SERVICE: string = 'hz:impl:mapService';
@@ -45,7 +46,12 @@ class ProxyManager {
         if (this.proxies[name]) {
             return this.proxies[name];
         } else {
-            var newProxy: DistributedObject = new this.service[serviceName](this.client, serviceName, name);
+            var newProxy: DistributedObject;
+            if (serviceName === this.MAP_SERVICE && this.client.getConfig().nearCacheConfigs[name]) {
+                newProxy = new NearCachedMapProxy(this.client, serviceName, name);
+            } else {
+                newProxy = new this.service[serviceName](this.client, serviceName, name);
+            }
             if (createAtServer) {
                 this.createProxy(name, serviceName);
             }

--- a/src/serialization/Data.ts
+++ b/src/serialization/Data.ts
@@ -36,6 +36,13 @@ export interface Data {
     hasPartitionHash() : boolean;
 
     /**
+     * Returns hashcode for this data
+     */
+    hashCode(): number;
+
+    equals(other: Data): boolean;
+
+    /**
      * Returns true if the object is a portable object
      */
     isPortable() : boolean;

--- a/src/serialization/HeapData.ts
+++ b/src/serialization/HeapData.ts
@@ -69,8 +69,16 @@ export class HeapData implements Data {
         if (this.hasPartitionHash()) {
             return this.payload.readIntBE(PARTITION_HASH_OFFSET, 4);
         } else {
-            return murmur(this.payload.slice(DATA_OFFSET));
+            return this.hashCode();
         }
+    }
+
+    hashCode(): number {
+        return murmur(this.payload.slice(DATA_OFFSET));
+    }
+
+    equals(other: Data): boolean {
+        return this.payload.compare(other.toBuffer(), DATA_OFFSET, other.toBuffer().length, DATA_OFFSET) === 0;
     }
 
     /**

--- a/src/serialization/SerializationService.ts
+++ b/src/serialization/SerializationService.ts
@@ -50,7 +50,18 @@ export class SerializationServiceV1 implements SerializationService {
         this.registerGlobalSerializer(serializationConfig.globalSerializer);
     }
 
+    private isData(object: any): boolean {
+        if (object instanceof HeapData ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     toData(object: any, partitioningStrategy: any = this.defaultPartitionStrategy): Data {
+        if (this.isData(object)) {
+            return <Data>object;
+        }
         var dataOutput: DataOutput = new PositionalObjectDataOutput(1, this, this.serialiationConfig.isBigEndian);
         var serializer = this.findSerializerFor(object);
         //Check if object is partition aware

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -1,792 +1,822 @@
 var expect = require("chai").expect;
-var HazelcastClient = require("../../lib/index.js").Client;
-var Predicates = require("../../lib/index.js").Predicates;
+var HazelcastClient = require("../../").Client;
+var Predicates = require("../../").Predicates;
+var Config = require('../../').Config;
 var Promise = require("bluebird");
 var Controller = require('./../RC');
 var Util = require('./../Util');
 var fs = require('fs');
 var _fillMap = require('../Util').fillMap;
 
-describe("MapProxy Test", function() {
 
-    var cluster;
-    var client;
-    var map;
-
-    before(function () {
-        this.timeout(32000);
-        return Controller.createCluster(null, null).then(function(res) {
-            cluster = res;
-            return Controller.startMember(cluster.id);
-        }).then(function(member) {
-            return HazelcastClient.newHazelcastClient().then(function(hazelcastClient) {
-                client = hazelcastClient;
-            });
-        });
-    });
-
-    beforeEach(function() {
-        map = client.getMap('test');
-        return _fillMap(map);
-    });
-
-    afterEach(function() {
-        return map.destroy();
-    });
-
-    after(function() {
-        client.shutdown();
-        return Controller.shutdownCluster(cluster.id);
-    });
-
-    function _generateLockScript(mapName, keyName) {
-        return 'function lockByServer() {' +
-            '   var map = instance_0.getMap("' + mapName + '");' +
-            '   map.lock(' + keyName + ');' +
-            '   return map.isLocked(' + keyName + ');' +
-            '}' +
-            'result=""+lockByServer();';
+function createController(nearCacheEnabled) {
+    if (nearCacheEnabled) {
+        return Controller.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'))
+    } else {
+        return Controller.createCluster(null, null);
     }
+}
 
-    function _generateUnlockScript(mapName, keyName) {
-        return 'function lockByServer() {' +
-            '   var map = instance_0.getMap("' + mapName + '");' +
-            '   map.unlock(' + keyName + ');' +
-            '   return map.isLocked(' + keyName + ');' +
-            '}' +
-            'result=""+lockByServer();';
+function createClient(nearCacheEnabled) {
+    if (nearCacheEnabled) {
+        var cfg = new Config.ClientConfig();
+        var ncc = new Config.NearCacheConfig();
+        ncc.name = 'test';
+        ncc.timeToLiveSeconds = 1;
+        cfg.nearCacheConfigs['test'] = ncc;
+        return HazelcastClient.newHazelcastClient(cfg);
+    } else {
+        return HazelcastClient.newHazelcastClient()
     }
+}
 
-    it('get_basic', function() {
-        return map.get('key0').then(function(v) {
-            return expect(v).to.equal('val0');
-        })
-    });
+describe('MapProxy', function() {
+    [false, true].forEach(function (nearCacheEnabled) {
 
-    it('get_return_null_on_non_existent', function() {
-        return map.get('non-existent').then(function(val) {
-            return expect(val).to.be.null;
-        });
-    });
+        describe("Near Cache: " + nearCacheEnabled, function() {
 
-    it('put_return_value_not_null', function() {
-        return map.put('key0','new-val').then(function(val) {
-            return expect(val).to.equal('val0');
-        });
-    });
+            var cluster;
+            var client;
+            var map;
 
-    it('put with ttl puts value to map', function() {
-        return map.put('key-with-ttl', 'val-with-ttl', 3000).then(function() {
-            return map.get('key-with-ttl').then(function(val) {
-                return expect(val).to.equal('val-with-ttl');
+            before(function () {
+                this.timeout(32000);
+                return createController(nearCacheEnabled).then(function(res) {
+                    cluster = res;
+                    return Controller.startMember(cluster.id);
+                }).then(function(member) {
+                    return createClient(nearCacheEnabled).then(function(hazelcastClient) {
+                        client = hazelcastClient;
+                    });
+                });
             });
-        });
-    });
 
-    it('put with ttl removes value after ttl', function() {
-        return map.put('key10', 'val10', 1000).then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('val10');
-        }).then(function() {
-            return Util.promiseLater(1000, map.get.bind(map, 'key10'));
-        }).then(function(val) {
-            return expect(val).to.be.null;
-        });
-    });
+            beforeEach(function() {
+                map = client.getMap('test');
+                return _fillMap(map);
+            });
 
-    it('clear', function() {
-        return map.clear().then(function() {
-            return map.isEmpty();
-        }).then(function(val) {
-            return expect(val).to.be.true;
-        });
-    });
+            afterEach(function() {
+                return map.destroy();
+            });
 
-    it('size', function() {
-        return map.size().then(function(size) {
-            expect(size).to.equal(10);
-        })
-    });
+            after(function() {
+                client.shutdown();
+                return Controller.shutdownCluster(cluster.id);
+            });
 
-    it('basic_remove_return_value', function() {
-        return map.remove('key9').then(function(val) {
-            return expect(val).to.equal('val9');
-        });
-    });
+            function _generateLockScript(mapName, keyName) {
+                return 'function lockByServer() {' +
+                    '   var map = instance_0.getMap("' + mapName + '");' +
+                    '   map.lock(' + keyName + ');' +
+                    '   return map.isLocked(' + keyName + ');' +
+                    '}' +
+                    'result=""+lockByServer();';
+            }
 
-    it('basic_remove', function() {
-        return map.remove('key1').then(function() {
-            return map.get('key1');
-        }).then(function(val) {
-            return expect(val).to.be.null;
-        });
-    });
+            function _generateUnlockScript(mapName, keyName) {
+                return 'function lockByServer() {' +
+                    '   var map = instance_0.getMap("' + mapName + '");' +
+                    '   map.unlock(' + keyName + ');' +
+                    '   return map.isLocked(' + keyName + ');' +
+                    '}' +
+                    'result=""+lockByServer();';
+            }
 
-    it('remove_if_equal_false', function() {
-        return map.remove('key1', 'wrong').then(function(val) {
-            return expect(val).to.be.false;
-        });
-    });
+            it('get_basic', function() {
+                return map.get('key0').then(function(v) {
+                    return expect(v).to.equal('val0');
+                })
+            });
 
-    it('remove_if_equal_true', function() {
-        return map.remove('key1', 'val1').then(function(val) {
-            return expect(val).to.be.true;
-        });
-    });
+            it('get_return_null_on_non_existent', function() {
+                return map.get('non-existent').then(function(val) {
+                    return expect(val).to.be.null;
+                });
+            });
 
-    it('containsKey_true', function() {
-        return map.containsKey('key1').then(function(val) {
-           return expect(val).to.be.true;
-        });
-    });
+            it('put_return_value_not_null', function() {
+                return map.put('key0','new-val').then(function(val) {
+                    return expect(val).to.equal('val0');
+                });
+            });
 
-    it('containsKey_false', function() {
-        return map.containsKey('non-existent').then(function(val) {
-            return expect(val).to.be.false;
-        });
-    });
+            it('put with ttl puts value to map', function() {
+                return map.put('key-with-ttl', 'val-with-ttl', 3000).then(function() {
+                    return map.get('key-with-ttl').then(function(val) {
+                        return expect(val).to.equal('val-with-ttl');
+                    });
+                });
+            });
 
-    it('containsValue_true', function() {
-        return map.containsValue('val1').then(function(val) {
-            return expect(val).to.be.true;
-        });
-    });
+            it('put with ttl removes value after ttl', function() {
+                return map.put('key10', 'val10', 1000).then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('val10');
+                }).then(function() {
+                    return Util.promiseLater(1000, map.get.bind(map, 'key10'));
+                }).then(function(val) {
+                    return expect(val).to.be.null;
+                });
+            });
 
-    it('containsValue_false', function() {
-        return map.containsValue('non-existent').then(function(val) {
-            return expect(val).to.be.false;
-        });
-    });
+            it('clear', function() {
+                return map.clear().then(function() {
+                    return map.isEmpty();
+                }).then(function(val) {
+                    return expect(val).to.be.true;
+                });
+            });
 
-    it('putAll', function(done) {
-        var arr = [
-            ['pa_k0', 'pa_v0'],
-            ['pa_k1', 'pa_v1'],
-            ['pa_k2', 'pa_v2'],
-            ['pa_k3', 'pa_v3'],
-            ['pa_k4', 'pa_v4']
-        ];
-        var returnedCorrectly = 0;
-        var verify = function (expected) {
-            return function(val) {
-                try {
-                    expect(val).to.equal(expected);
-                    returnedCorrectly++;
-                    if (returnedCorrectly === 5) {
+            it('size', function() {
+                return map.size().then(function(size) {
+                    expect(size).to.equal(10);
+                })
+            });
+
+            it('basic_remove_return_value', function() {
+                return map.remove('key9').then(function(val) {
+                    return expect(val).to.equal('val9');
+                });
+            });
+
+            it('basic_remove', function() {
+                return map.remove('key1').then(function() {
+                    return map.get('key1');
+                }).then(function(val) {
+                    return expect(val).to.be.null;
+                });
+            });
+
+            it('remove_if_equal_false', function() {
+                return map.remove('key1', 'wrong').then(function(val) {
+                    return expect(val).to.be.false;
+                });
+            });
+
+            it('remove_if_equal_true', function() {
+                return map.remove('key1', 'val1').then(function(val) {
+                    return expect(val).to.be.true;
+                });
+            });
+
+            it('containsKey_true', function() {
+                return map.containsKey('key1').then(function(val) {
+                    return expect(val).to.be.true;
+                });
+            });
+
+            it('containsKey_false', function() {
+                return map.containsKey('non-existent').then(function(val) {
+                    return expect(val).to.be.false;
+                });
+            });
+
+            it('containsValue_true', function() {
+                return map.containsValue('val1').then(function(val) {
+                    return expect(val).to.be.true;
+                });
+            });
+
+            it('containsValue_false', function() {
+                return map.containsValue('non-existent').then(function(val) {
+                    return expect(val).to.be.false;
+                });
+            });
+
+            it('putAll', function(done) {
+                var arr = [
+                    ['pa_k0', 'pa_v0'],
+                    ['pa_k1', 'pa_v1'],
+                    ['pa_k2', 'pa_v2'],
+                    ['pa_k3', 'pa_v3'],
+                    ['pa_k4', 'pa_v4']
+                ];
+                var returnedCorrectly = 0;
+                var verify = function (expected) {
+                    return function(val) {
+                        try {
+                            expect(val).to.equal(expected);
+                            returnedCorrectly++;
+                            if (returnedCorrectly === 5) {
+                                done();
+
+                            }
+                        } catch (e) {
+                            done(e);
+                        }
+                    };
+                };
+                map.putAll(arr).then(function() {
+                    map.get(arr[0][0]).then(verify(arr[0][1]));
+                    map.get(arr[1][0]).then(verify(arr[1][1]));
+                    map.get(arr[2][0]).then(verify(arr[2][1]));
+                    map.get(arr[3][0]).then(verify(arr[3][1]));
+                    map.get(arr[4][0]).then(verify(arr[4][1]));
+                })
+            });
+
+            it('getAll', function() {
+                return map.getAll([
+                    'key0', 'key1', 'key2', 'key3', 'key4',
+                    'key5', 'key6', 'key7', 'key8', 'key9'
+                ]).then(function (values) {
+                    return expect(values).to.deep.have.members([
+                        ['key0', 'val0'], ['key1', 'val1'],
+                        ['key2', 'val2'], ['key3', 'val3'],
+                        ['key4', 'val4'], ['key5', 'val5'],
+                        ['key6', 'val6'], ['key7', 'val7'],
+                        ['key8', 'val8'], ['key9', 'val9']
+                    ]);
+                })
+            });
+
+            it('delete', function() {
+                return map.put('key-to-delete', 'value').then(function() {
+                    return map.delete('key-to-delete');
+                }).then(function() {
+                    return map.get('key-to-delete');
+                }).then(function(val) {
+                    return expect(val).to.be.null;
+                })
+            });
+
+            it('entrySet_notNull', function() {
+                var entryMap = client.getMap('entry-map');
+                var samples = [
+                    ['k1', 'v1'],
+                    ['k2', 'v2'],
+                    ['k3', 'v3']
+                ];
+                return Promise.all([
+                    entryMap.put(samples[0][0], samples[0][1]),
+                    entryMap.put(samples[1][0], samples[1][1]),
+                    entryMap.put(samples[2][0], samples[2][1])
+                ]).then(function() {
+                    return entryMap.entrySet();
+                }).then(function(entrySet) {
+                    return expect(entrySet).to.deep.have.members(samples);
+                });
+            });
+
+            it('entrySet_null', function() {
+                var entryMap = client.getMap('null-entry-map');
+                return entryMap.entrySet().then(function(entrySet) {
+                    return expect(entrySet).to.be.empty;
+                });
+            });
+
+            it('flush', function() {
+                return map.flush();
+            });
+
+            it('lock', function() {
+                return map.lock('key0').then(function() {
+                    return map.isLocked('key0');
+                }).then(function(isLocked) {
+                    return expect(isLocked).to.be.true;
+                }).finally(function() {
+                    return map.unlock('key0');
+                });
+            });
+
+            it('unlock', function() {
+                return map.lock('key0').then(function() {
+                    return map.unlock('key0');
+                }).then(function() {
+                    return map.isLocked('key0');
+                }).then(function(isLocked) {
+                    return expect(isLocked).to.be.false;
+                });
+            });
+
+            it('forceUnlock', function() {
+                var script =
+                    'function lockByServer() {' +
+                    '   var map = instance_0.getMap("' + map.getName() + '");' +
+                    '   map.lock("key0");' +
+                    '   return map.isLocked("key0")' +
+                    '}' +
+                    'result=""+lockByServer();';
+                return Controller.executeOnController(cluster.id, script, 1).then(function(s) {
+                    return map.forceUnlock('key0');
+                }).then(function() {
+                    return map.isLocked('key0');
+                }).then(function(isLocked) {
+                    return expect(isLocked).to.be.false;
+                });
+            });
+
+            it('keySet', function() {
+                return map.keySet().then(function(keySet) {
+                    return expect(keySet).to.deep.have.members([
+                        'key0', 'key1', 'key2', 'key3', 'key4',
+                        'key5', 'key6', 'key7', 'key8', 'key9'
+                    ]);
+                });
+            });
+
+            it('putIfAbsent_success', function() {
+                return map.putIfAbsent('key10', 'new-val').then(function(oldVal) {
+                    return expect(oldVal).to.be.null;
+                }).then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('new-val');
+                });
+            });
+
+            it('putIfAbsent_fail', function() {
+                return map.putIfAbsent('key9', 'new-val').then(function() {
+                    return map.get('key9');
+                }).then(function(val) {
+                    return expect(val).to.equal('val9');
+                });
+            });
+
+            it('putIfAbsent_with_ttl', function () {
+                return map.putIfAbsent('key10', 'new-val', 1000).then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('new-val');
+                }).then(function() {
+                    return Util.promiseLater(1000, map.get.bind(map, 'key10'));
+                }).then(function(val) {
+                    return expect(val).to.be.null;
+                });
+
+            });
+
+            it('putTransient', function() {
+                return map.putTransient('key10', 'val10').then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('val10');
+                });
+            });
+
+            it('putTransient_withTTL', function() {
+                return map.putTransient('key10', 'val10', 1000).then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('val10');
+                }).then(function() {
+                    return Util.promiseLater(1000, map.get.bind(map, 'key10'))
+                }).then(function(val) {
+                    return expect(val).to.be.null;
+                });
+            });
+
+            it('replace', function() {
+                return map.replace('key9', 'new-val').then(function(oldVal) {
+                    return expect(oldVal).to.equal('val9');
+                }).then(function() {
+                    return map.get('key9');
+                }).then(function(val) {
+                    return expect(val).to.equal('new-val');
+                });
+            });
+
+            it('replaceIfSame_success', function() {
+                return map.replaceIfSame('key9', 'val9', 'new-val').then(function(success) {
+                    return expect(success).to.be.true;
+                }).then(function() {
+                    return map.get('key9');
+                }).then(function(val) {
+                    return expect(val).to.equal('new-val');
+                });
+            });
+
+            it('replaceIfSame_fail', function() {
+                return map.replaceIfSame('key9', 'wrong', 'new-val', function(success) {
+                    return expect(success).to.be.false;
+                }).then(function() {
+                    return map.get('key9');
+                }).then(function(val) {
+                    return expect(val).to.equal('val9');
+                });
+            });
+
+            it('set', function() {
+                return map.set('key10', 'val10').then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('val10');
+                })
+            });
+
+            it('set_withTTL', function() {
+                return map.set('key10', 'val10', 1000).then(function() {
+                    return map.get('key10');
+                }).then(function(val) {
+                    return expect(val).to.equal('val10');
+                }).then(function() {
+                    return Util.promiseLater(1000, map.get.bind(map, 'key10'));
+                }).then(function(val) {
+                    return expect(val).to.be.null;
+                })
+            });
+
+            it('values', function() {
+                return map.values().then(function(vals) {
+                    return expect(vals).to.deep.have.members([
+                        'val0', 'val1', 'val2', 'val3', 'val4',
+                        'val5', 'val6', 'val7', 'val8', 'val9'
+                    ]);
+                });
+            });
+
+            it('values_null', function() {
+                return map.clear().then(function() {
+                    return map.values();
+                }).then(function(vals) {
+                    return expect(vals).to.have.lengthOf(0);
+                })
+            });
+
+            it('getEntryView', function(done) {
+                map.getEntryView('key0').then(function(entry) {
+                    try {
+                        expect(entry.key).to.equal('key0');
+                        expect(entry.value).to.equal('val0');
+                        expect(entry.cost).to.be.above(0);
+                        expect(entry.creationTime).to.not.equal(0);
+                        expect(entry.expirationTime).to.not.equal(0);
+                        expect(entry.hits).to.not.equal(0);
+                        expect(entry.lastAccessTime).to.not.equal(0);
+                        expect(entry.lastStoreTime).to.not.equal(0);
+                        expect(entry.lastUpdateTime).to.not.equal(0);
+                        expect(entry.version).to.not.equal(0);
+                        expect(entry.evictionCriteriaNumber).to.not.equal(0);
+                        expect(entry.ttl).to.not.equal(0);
                         done();
-
+                    } catch (e) {
+                        done(e);
                     }
-                } catch (e) {
-                    done(e);
-                }
-            };
-        };
-        map.putAll(arr).then(function() {
-            map.get(arr[0][0]).then(verify(arr[0][1]));
-            map.get(arr[1][0]).then(verify(arr[1][1]));
-            map.get(arr[2][0]).then(verify(arr[2][1]));
-            map.get(arr[3][0]).then(verify(arr[3][1]));
-            map.get(arr[4][0]).then(verify(arr[4][1]));
-        })
-    });
+                });
+            });
 
-    it('getAll', function() {
-        return map.getAll([
-            'key0', 'key1', 'key2', 'key3', 'key4',
-            'key5', 'key6', 'key7', 'key8', 'key9'
-        ]).then(function (values) {
-            return expect(values).to.deep.have.members([
-                ['key0', 'val0'], ['key1', 'val1'],
-                ['key2', 'val2'], ['key3', 'val3'],
-                ['key4', 'val4'], ['key5', 'val5'],
-                ['key6', 'val6'], ['key7', 'val7'],
-                ['key8', 'val8'], ['key9', 'val9']
-            ]);
-        })
-    });
+            it('getEntryView_null', function() {
+                return map.getEntryView('non-exist').then(function(entry) {
+                    return expect(entry).to.be.null;
+                });
+            });
 
-    it('delete', function() {
-        return map.put('key-to-delete', 'value').then(function() {
-            return map.delete('key-to-delete');
-        }).then(function() {
-            return map.get('key-to-delete');
-        }).then(function(val) {
-            return expect(val).to.be.null;
-        })
-    });
+            it('addIndex', function() {
+                return Promise.all([
+                    map.addIndex('length', false),
+                    map.addIndex('length', true)
+                ]);
+            });
 
-    it('entrySet_notNull', function() {
-        var entryMap = client.getMap('entry-map');
-        var samples = [
-            ['k1', 'v1'],
-            ['k2', 'v2'],
-            ['k3', 'v3']
-        ];
-        return Promise.all([
-            entryMap.put(samples[0][0], samples[0][1]),
-            entryMap.put(samples[1][0], samples[1][1]),
-            entryMap.put(samples[2][0], samples[2][1])
-        ]).then(function() {
-            return entryMap.entrySet();
-        }).then(function(entrySet) {
-            return expect(entrySet).to.deep.have.members(samples);
+            it('tryLock_success', function() {
+                return map.tryLock('key0').then(function(success) {
+                    return expect(success).to.be.true;
+                });
+            });
+
+            it('tryLock_fail', function() {
+                return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function(s) {
+                    return map.tryLock('key0');
+                }).then(function(success) {
+                    return expect(success).to.be.false;
+                });
+            });
+
+            it('tryLock_success with timeout', function() {
+                return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
+                    var promise = map.tryLock('key0', 1000);
+                    Controller.executeOnController(cluster.id, _generateUnlockScript(map.getName(), '"key0"'), 1);
+                    return promise;
+                }).then(function(success) {
+                    return expect(success).to.be.true;
+                });
+            });
+
+            it('tryLock_fail with timeout', function() {
+                return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
+                    return map.tryLock('key0', 1000);
+                }).then(function(success) {
+                    return expect(success).to.be.false;
+                });
+            });
+
+            it('tryPut success', function() {
+                return map.tryPut('key0', 'val0', 1000).then(function(success) {
+                    return expect(success).to.be.true;
+                })
+            });
+
+            it('tryPut fail', function() {
+                return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
+                    return map.tryPut('key0', 'val0', 200);
+                }).then(function(success) {
+                    return expect(success).to.be.false;
+                })
+            });
+
+            it('tryRemove success', function() {
+                return map.tryRemove('key0', 1000).then(function(success) {
+                    return expect(success).to.be.true;
+                })
+            });
+
+            it('tryRemove fail', function() {
+                return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
+                    return map.tryRemove('key0', 200);
+                }).then(function(success) {
+                    return expect(success).to.be.false;
+                })
+            });
+
+            it('addEntryListener on map, entryAdded fires because predicate returns true for that entry', function(done) {
+                var listenerObject = {
+                    added: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key10');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10')).then(function() {
+                    map.put('key10', 'val10');
+                });
+            });
+
+            it('addEntryListener on key, entryAdded fires because predicate returns true for that entry', function(done) {
+                var listenerObject = {
+                    added: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key10');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10'), 'key10').then(function() {
+                    map.put('key10', 'val10');
+                });
+            });
+
+            it('addEntryListener on key, entryAdded fires because predicate returns true for that entry, inlVal=yes', function(done) {
+                var listenerObject = {
+                    added: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key10');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.equal('val10');
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10'), 'key10', true).then(function() {
+                    map.put('key10', 'val10');
+                });
+            });
+
+            it('addEntryListener on map entryAdded', function(done) {
+                var listenerObject = {
+                    added: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key10');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject).then(function() {
+                    map.put('key10', 'val10');
+                });
+            });
+
+            it('addEntryListener on map entryAdded', function(done) {
+                var listenerObject = {
+                    added: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key10');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.equal('val10');
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject, undefined, true).then(function() {
+                    map.put('key10', 'val10');
+                });
+            });
+
+            it('addEntryListener on map entryUpdated', function(done) {
+                var listenerObject = {
+                    updated: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key0');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject).then(function() {
+                    map.put('key0', 'new-val');
+                });
+            });
+
+            it('addEntryListener on key entryRemoved', function(done) {
+                var listenerObject = {
+                    removed: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key1');
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject, 'key1', false).then(function() {
+                    map.remove('key1');
+                });
+            });
+
+            it('addEntryListener on key entryRemoved includeValue=yes', function(done) {
+                var listenerObject = {
+                    removed: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key1');
+                            expect(oldValue).to.equal('val1');
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject, 'key1', true).then(function() {
+                    map.remove('key1');
+                });
+            });
+
+            it('addEntryListener on key evicted includeValue=yes', function(done) {
+                var listenerObject = {
+                    evicted: function(key, oldValue, value, mergingValue) {
+                        try {
+                            expect(key).to.equal('key1');
+                            expect(oldValue).to.equal('val1');
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject, 'key1', true).then(function() {
+                    map.evict('key1')
+                });
+            });
+
+            it('addEntryListener on map evictAll', function(done) {
+                var listenerObject = {
+                    evictedAll: function(key, oldValue, value, mergingValue, numberOfAffectedEntries) {
+                        try {
+                            expect(key).to.be.undefined;
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            expect(numberOfAffectedEntries).to.equal(10);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject).then(function() {
+                    map.evictAll();
+                });
+            });
+
+            it('addEntryListener on map clearAll', function(done) {
+                var listenerObject = {
+                    clearedAll: function(key, oldValue, value, mergingValue, numberOfAffectedEntries) {
+                        try {
+                            expect(key).to.be.undefined;
+                            expect(oldValue).to.be.undefined;
+                            expect(value).to.be.undefined;
+                            expect(mergingValue).to.be.undefined;
+                            expect(numberOfAffectedEntries).to.equal(10);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
+                };
+                map.addEntryListener(listenerObject).then(function() {
+                    map.clear();
+                });
+            });
+
+            it('removeEntryListener with correct id', function() {
+                return map.addEntryListener({}).then(function(listenerId) {
+                    return map.removeEntryListener(listenerId);
+                }).then(function(success) {
+                    return expect(success).to.be.true;
+                });
+            });
+
+            it('removeEntryListener with wrong id', function() {
+                return map.removeEntryListener('aaa').then(function(success) {
+                    return expect(success).to.be.false;
+                });
+            });
+
+            it('entrySetWithPredicate', function() {
+                return map.entrySetWithPredicate(Predicates.sql('this == val3')).then(function(entrySet) {
+                    expect(entrySet.length).to.equal(1);
+                    expect(entrySet[0][0]).to.equal('key3');
+                    expect(entrySet[0][1]).to.equal('val3');
+                });
+            });
+
+            it('keySetWithPredicate', function() {
+                return map.keySetWithPredicate(Predicates.sql('this == val3')).then(function(keySet) {
+                    expect(keySet.length).to.equal(1);
+                    expect(keySet[0]).to.equal('key3');
+                });
+            });
+
+            it('keySetWithPredicate null response', function() {
+                return map.keySetWithPredicate(Predicates.sql('this == nonexisting')).then(function(keySet) {
+                    expect(keySet.length).to.equal(0);
+                });
+            });
+
+            it('valuesWithPredicate', function() {
+                return map.valuesWithPredicate(Predicates.sql('this == val3')).then(function(valueSet) {
+                    expect(valueSet.length).to.equal(1);
+                    expect(valueSet[0]).to.equal('val3');
+                });
+            });
+
+            it('entrySetWithPredicate paging', function() {
+                return map.entrySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(entrySet) {
+                    expect(entrySet.length).to.equal(1);
+                    expect(entrySet[0]).to.deep.equal(['key3', 'val3']);
+                });
+            });
+
+            it('keySetWithPredicate paging', function() {
+                return map.keySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(keySet) {
+                    expect(keySet.length).to.equal(1);
+                    expect(keySet[0]).to.equal('key3');
+                });
+            });
+
+            it('valuesWithPredicate paging', function() {
+                return map.valuesWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(values) {
+                    expect(values.length).to.equal(1);
+                    expect(values[0]).to.equal('val3');
+                });
+            });
+
+            it('destroy', function() {
+                var dmap = client.getMap('map-to-be-destroyed');
+                return dmap.put('key', 'val').then(function() {
+                    return dmap.destroy();
+                }).then(function() {
+                    var newMap = client.getMap('map-to-be-destroyed');
+                    return newMap.size();
+                }).then(function(s) {
+                    expect(s).to.equal(0);
+                })
+            });
         });
-    });
 
-    it('entrySet_null', function() {
-        var entryMap = client.getMap('null-entry-map');
-        return entryMap.entrySet().then(function(entrySet) {
-            return expect(entrySet).to.be.empty;
-        });
-    });
-
-    it('flush', function() {
-        return map.flush();
-    });
-
-    it('lock', function() {
-        return map.lock('key0').then(function() {
-            return map.isLocked('key0');
-        }).then(function(isLocked) {
-            return expect(isLocked).to.be.true;
-        }).finally(function() {
-            return map.unlock('key0');
-        });
-    });
-
-    it('unlock', function() {
-        return map.lock('key0').then(function() {
-            return map.unlock('key0');
-        }).then(function() {
-            return map.isLocked('key0');
-        }).then(function(isLocked) {
-            return expect(isLocked).to.be.false;
-        });
-    });
-
-    it('forceUnlock', function() {
-        var script =
-            'function lockByServer() {' +
-            '   var map = instance_0.getMap("' + map.getName() + '");' +
-            '   map.lock("key0");' +
-            '   return map.isLocked("key0")' +
-            '}' +
-            'result=""+lockByServer();';
-        return Controller.executeOnController(cluster.id, script, 1).then(function(s) {
-            return map.forceUnlock('key0');
-        }).then(function() {
-            return map.isLocked('key0');
-        }).then(function(isLocked) {
-            return expect(isLocked).to.be.false;
-        });
-    });
-
-    it('keySet', function() {
-        return map.keySet().then(function(keySet) {
-            return expect(keySet).to.deep.have.members([
-                'key0', 'key1', 'key2', 'key3', 'key4',
-                'key5', 'key6', 'key7', 'key8', 'key9'
-            ]);
-        });
-    });
-
-    it('putIfAbsent_success', function() {
-        return map.putIfAbsent('key10', 'new-val').then(function(oldVal) {
-            return expect(oldVal).to.be.null;
-        }).then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('new-val');
-        });
-    });
-
-    it('putIfAbsent_fail', function() {
-        return map.putIfAbsent('key9', 'new-val').then(function() {
-            return map.get('key9');
-        }).then(function(val) {
-            return expect(val).to.equal('val9');
-        });
-    });
-
-    it('putIfAbsent_with_ttl', function () {
-        return map.putIfAbsent('key10', 'new-val', 1000).then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('new-val');
-        }).then(function() {
-            return Util.promiseLater(1000, map.get.bind(map, 'key10'));
-        }).then(function(val) {
-            return expect(val).to.be.null;
-        });
-
-    });
-
-    it('putTransient', function() {
-        return map.putTransient('key10', 'val10').then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('val10');
-        });
-    });
-
-    it('putTransient_withTTL', function() {
-        return map.putTransient('key10', 'val10', 1000).then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('val10');
-        }).then(function() {
-            return Util.promiseLater(1000, map.get.bind(map, 'key10'))
-        }).then(function(val) {
-            return expect(val).to.be.null;
-        });
-    });
-
-    it('replace', function() {
-        return map.replace('key9', 'new-val').then(function(oldVal) {
-            return expect(oldVal).to.equal('val9');
-        }).then(function() {
-            return map.get('key9');
-        }).then(function(val) {
-            return expect(val).to.equal('new-val');
-        });
-    });
-
-    it('replaceIfSame_success', function() {
-        return map.replaceIfSame('key9', 'val9', 'new-val').then(function(success) {
-            return expect(success).to.be.true;
-        }).then(function() {
-            return map.get('key9');
-        }).then(function(val) {
-            return expect(val).to.equal('new-val');
-        });
-    });
-
-    it('replaceIfSame_fail', function() {
-        return map.replaceIfSame('key9', 'wrong', 'new-val', function(success) {
-            return expect(success).to.be.false;
-        }).then(function() {
-            return map.get('key9');
-        }).then(function(val) {
-            return expect(val).to.equal('val9');
-        });
-    });
-
-    it('set', function() {
-        return map.set('key10', 'val10').then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('val10');
-        })
-    });
-
-    it('set_withTTL', function() {
-        return map.set('key10', 'val10', 1000).then(function() {
-            return map.get('key10');
-        }).then(function(val) {
-            return expect(val).to.equal('val10');
-        }).then(function() {
-            return Util.promiseLater(1000, map.get.bind(map, 'key10'));
-        }).then(function(val) {
-            return expect(val).to.be.null;
-        })
-    });
-
-    it('values', function() {
-        return map.values().then(function(vals) {
-            return expect(vals).to.deep.have.members([
-                'val0', 'val1', 'val2', 'val3', 'val4',
-                'val5', 'val6', 'val7', 'val8', 'val9'
-            ]);
-        });
-    });
-
-    it('values_null', function() {
-        return map.clear().then(function() {
-            return map.values();
-        }).then(function(vals) {
-            return expect(vals).to.have.lengthOf(0);
-        })
-    });
-
-    it('getEntryView', function(done) {
-        map.getEntryView('key0').then(function(entry) {
-            try {
-                expect(entry.key).to.equal('key0');
-                expect(entry.value).to.equal('val0');
-                expect(entry.cost).to.be.above(0);
-                expect(entry.creationTime).to.not.equal(0);
-                expect(entry.expirationTime).to.not.equal(0);
-                expect(entry.hits).to.not.equal(0);
-                expect(entry.lastAccessTime).to.not.equal(0);
-                expect(entry.lastStoreTime).to.not.equal(0);
-                expect(entry.lastUpdateTime).to.not.equal(0);
-                expect(entry.version).to.not.equal(0);
-                expect(entry.evictionCriteriaNumber).to.not.equal(0);
-                expect(entry.ttl).to.not.equal(0);
-                done();
-            } catch (e) {
-                done(e);
-            }
-        });
-    });
-
-    it('getEntryView_null', function() {
-        return map.getEntryView('non-exist').then(function(entry) {
-            return expect(entry).to.be.null;
-        });
-    });
-
-    it('addIndex', function() {
-        return Promise.all([
-            map.addIndex('length', false),
-            map.addIndex('length', true)
-        ]);
-    });
-
-    it('tryLock_success', function() {
-        return map.tryLock('key0').then(function(success) {
-            return expect(success).to.be.true;
-        });
-    });
-
-    it('tryLock_fail', function() {
-        return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function(s) {
-            return map.tryLock('key0');
-        }).then(function(success) {
-            return expect(success).to.be.false;
-        });
-    });
-
-    it('tryLock_success with timeout', function() {
-        return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
-            var promise = map.tryLock('key0', 1000);
-            Controller.executeOnController(cluster.id, _generateUnlockScript(map.getName(), '"key0"'), 1);
-            return promise;
-        }).then(function(success) {
-            return expect(success).to.be.true;
-        });
-    });
-
-    it('tryLock_fail with timeout', function() {
-        return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
-            return map.tryLock('key0', 1000);
-        }).then(function(success) {
-            return expect(success).to.be.false;
-        });
-    });
-
-    it('tryPut success', function() {
-        return map.tryPut('key0', 'val0', 1000).then(function(success) {
-            return expect(success).to.be.true;
-        })
-    });
-
-    it('tryPut fail', function() {
-        return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
-            return map.tryPut('key0', 'val0', 200);
-        }).then(function(success) {
-            return expect(success).to.be.false;
-        })
-    });
-
-    it('tryRemove success', function() {
-        return map.tryRemove('key0', 1000).then(function(success) {
-            return expect(success).to.be.true;
-        })
-    });
-
-    it('tryRemove fail', function() {
-        return Controller.executeOnController(cluster.id, _generateLockScript(map.getName(), '"key0"'), 1).then(function() {
-            return map.tryRemove('key0', 200);
-        }).then(function(success) {
-            return expect(success).to.be.false;
-        })
-    });
-
-    it('addEntryListener on map, entryAdded fires because predicate returns true for that entry', function(done) {
-        var listenerObject = {
-            added: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key10');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10')).then(function() {
-            map.put('key10', 'val10');
-        });
-    });
-
-    it('addEntryListener on key, entryAdded fires because predicate returns true for that entry', function(done) {
-        var listenerObject = {
-            added: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key10');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10'), 'key10').then(function() {
-            map.put('key10', 'val10');
-        });
-    });
-
-    it('addEntryListener on key, entryAdded fires because predicate returns true for that entry, inlVal=yes', function(done) {
-        var listenerObject = {
-            added: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key10');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.equal('val10');
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListenerWithPredicate(listenerObject, Predicates.sql('this == val10'), 'key10', true).then(function() {
-            map.put('key10', 'val10');
-        });
-    });
-
-    it('addEntryListener on map entryAdded', function(done) {
-        var listenerObject = {
-            added: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key10');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject).then(function() {
-            map.put('key10', 'val10');
-        });
-    });
-
-    it('addEntryListener on map entryAdded', function(done) {
-        var listenerObject = {
-            added: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key10');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.equal('val10');
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject, undefined, true).then(function() {
-            map.put('key10', 'val10');
-        });
-    });
-
-    it('addEntryListener on map entryUpdated', function(done) {
-        var listenerObject = {
-            updated: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key0');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject).then(function() {
-            map.put('key0', 'new-val');
-        });
-    });
-
-    it('addEntryListener on key entryRemoved', function(done) {
-        var listenerObject = {
-            removed: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key1');
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject, 'key1', false).then(function() {
-            map.remove('key1');
-        });
-    });
-
-    it('addEntryListener on key entryRemoved includeValue=yes', function(done) {
-        var listenerObject = {
-            removed: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key1');
-                    expect(oldValue).to.equal('val1');
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject, 'key1', true).then(function() {
-            map.remove('key1');
-        });
-    });
-
-    it('addEntryListener on key evicted includeValue=yes', function(done) {
-        var listenerObject = {
-            evicted: function(key, oldValue, value, mergingValue) {
-                try {
-                    expect(key).to.equal('key1');
-                    expect(oldValue).to.equal('val1');
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject, 'key1', true).then(function() {
-            map.evict('key1')
-        });
-    });
-
-    it('addEntryListener on map evictAll', function(done) {
-        var listenerObject = {
-            evictedAll: function(key, oldValue, value, mergingValue, numberOfAffectedEntries) {
-                try {
-                    expect(key).to.be.undefined;
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    expect(numberOfAffectedEntries).to.equal(10);
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject).then(function() {
-            map.evictAll();
-        });
-    });
-
-    it('addEntryListener on map clearAll', function(done) {
-        var listenerObject = {
-            clearedAll: function(key, oldValue, value, mergingValue, numberOfAffectedEntries) {
-                try {
-                    expect(key).to.be.undefined;
-                    expect(oldValue).to.be.undefined;
-                    expect(value).to.be.undefined;
-                    expect(mergingValue).to.be.undefined;
-                    expect(numberOfAffectedEntries).to.equal(10);
-                    done();
-                } catch (err) {
-                    done(err);
-                }
-            }
-        };
-        map.addEntryListener(listenerObject).then(function() {
-            map.clear();
-        });
-    });
-
-    it('removeEntryListener with correct id', function() {
-        return map.addEntryListener({}).then(function(listenerId) {
-            return map.removeEntryListener(listenerId);
-        }).then(function(success) {
-            return expect(success).to.be.true;
-        });
-    });
-
-    it('removeEntryListener with wrong id', function() {
-        return map.removeEntryListener('aaa').then(function(success) {
-            return expect(success).to.be.false;
-        });
-    });
-
-    it('entrySetWithPredicate', function() {
-        return map.entrySetWithPredicate(Predicates.sql('this == val3')).then(function(entrySet) {
-            expect(entrySet.length).to.equal(1);
-            expect(entrySet[0][0]).to.equal('key3');
-            expect(entrySet[0][1]).to.equal('val3');
-        });
-    });
-
-    it('keySetWithPredicate', function() {
-        return map.keySetWithPredicate(Predicates.sql('this == val3')).then(function(keySet) {
-            expect(keySet.length).to.equal(1);
-            expect(keySet[0]).to.equal('key3');
-        });
-    });
-
-    it('keySetWithPredicate null response', function() {
-        return map.keySetWithPredicate(Predicates.sql('this == nonexisting')).then(function(keySet) {
-            expect(keySet.length).to.equal(0);
-        });
-    });
-
-    it('valuesWithPredicate', function() {
-        return map.valuesWithPredicate(Predicates.sql('this == val3')).then(function(valueSet) {
-            expect(valueSet.length).to.equal(1);
-            expect(valueSet[0]).to.equal('val3');
-        });
-    });
-
-    it('entrySetWithPredicate paging', function() {
-        return map.entrySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(entrySet) {
-            expect(entrySet.length).to.equal(1);
-            expect(entrySet[0]).to.deep.equal(['key3', 'val3']);
-        });
-    });
-
-    it('keySetWithPredicate paging', function() {
-        return map.keySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(keySet) {
-            expect(keySet.length).to.equal(1);
-            expect(keySet[0]).to.equal('key3');
-        });
-    });
-
-    it('valuesWithPredicate paging', function() {
-        return map.valuesWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(values) {
-            expect(values.length).to.equal(1);
-            expect(values[0]).to.equal('val3');
-        });
-    });
-
-    it('destroy', function() {
-        var dmap = client.getMap('map-to-be-destroyed');
-        return dmap.put('key', 'val').then(function() {
-            return dmap.destroy();
-        }).then(function() {
-            var newMap = client.getMap('map-to-be-destroyed');
-            return newMap.size();
-        }).then(function(s) {
-            expect(s).to.equal(0);
-        })
     });
 });
+

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -1,0 +1,284 @@
+var expect = require("chai").expect;
+var HazelcastClient = require("../../lib/index.js").Client;
+var Predicates = require("../../lib/index.js").Predicates;
+var Promise = require("bluebird");
+var Controller = require('./../RC');
+var Util = require('./../Util');
+var Config = require('../../.').Config;
+var fs = require('fs');
+var _fillMap = require('../Util').fillMap;
+
+[true, false].forEach(function(invalidateOnChange) {
+    describe("NearCachedMap", function() {
+
+        var cluster;
+        var client1;
+        var client2;
+        var map1;
+        var map2;
+
+        before(function () {
+            this.timeout(32000);
+            var cfg = new Config.ClientConfig();
+            var ncc = new Config.NearCacheConfig();
+            ncc.name = 'nc-map';
+            ncc.invalidateOnChange = invalidateOnChange;
+            cfg.nearCacheConfigs['ncc-map'] = ncc;
+            return Controller.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8')).then(function(res) {
+                cluster = res;
+                return Controller.startMember(cluster.id);
+            }).then(function(member) {
+                return HazelcastClient.newHazelcastClient(cfg).then(function(hazelcastClient) {
+                    client1 = hazelcastClient;
+                });
+            }).then(function () {
+                return HazelcastClient.newHazelcastClient(cfg).then(function (hazelcastClient) {
+                    client2 = hazelcastClient;
+                });
+            });
+        });
+
+        beforeEach(function() {
+            this.timeout(10000);
+            map1 = client1.getMap('ncc-map');
+            map2 = client2.getMap('ncc-map');
+            return _fillMap(map1);
+        });
+
+        afterEach(function() {
+            return map1.destroy();
+        });
+
+        after(function() {
+            client1.shutdown();
+            client2.shutdown();
+            return Controller.shutdownCluster(cluster.id);
+        });
+
+        function getNearCacheStats(map) {
+            return map.nearCache.getStatistics();
+        }
+
+        function expectStats(map, hit, miss, entryCount) {
+            var stats = getNearCacheStats(map);
+            expect(stats.hitCount).to.equal(hit);
+            expect(stats.missCount).to.equal(miss);
+            return expect(stats.entryCount).to.equal(entryCount);
+        }
+
+        it('second get should hit', function() {
+            return map1.get('key0').then(function () {
+                return map1.get('key0');
+            }).then(function (val) {
+                var stats = getNearCacheStats(map1);
+                expect(val).to.equal('val0');
+                expect(stats.missCount).to.equal(1);
+                expect(stats.entryCount).to.equal(1);
+                expect(stats.hitCount).to.equal(1);
+            })
+        });
+
+        it('remove operation removes entry from near cache', function () {
+            return map1.get('key1').then(function () {
+                return map1.remove('key1');
+            }).then(function() {
+                return map1.get('key1');
+            }).then(function (val) {
+                var stats = getNearCacheStats(map1);
+                expect(val).to.be.be.null;
+                expect(stats.hitCount).to.equal(0);
+                expect(stats.missCount).to.equal(2);
+                expect(stats.entryCount).to.equal(1);
+            });
+        });
+
+        it('update invalidates the near cache', function () {
+            return map1.get('key1').then(function () {
+                return map1.put('key1', 'something else');
+            }).then(function() {
+                return map1.get('key1');
+            }).then(function (val) {
+                var stats = getNearCacheStats(map1);
+                expect(val).to.be.equal('something else');
+                expect(stats.hitCount).to.equal(0);
+                expect(stats.missCount).to.equal(2);
+                expect(stats.entryCount).to.equal(1);
+            });
+        });
+
+        it('get returns null if the entry was removed by another client', function () {
+            if (!invalidateOnChange) {
+                this.skip();
+            }
+            return map1.get('key1').then(function () {
+                return map2.remove('key1');
+            }).then(function () {
+                return Util.promiseLater(1000, map1.get.bind(map1, 'key1'));
+            }).then(function (val) {
+                expectStats(map1, 0, 2, 1);
+                return expect(val).to.be.null;
+            });
+        });
+
+        it('clear clears nearcache', function () {
+            return map1.get('key1').then(function () {
+                return map1.clear();
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('containsKey true(in near cache)', function () {
+            return map1.get('key1').then(function () {
+                return map1.containsKey('key1');
+            }).then(function (c) {
+                expectStats(map1, 1, 1, 1);
+                return expect(c).to.be.true;
+            });
+        });
+
+        it('containsKey false(in near cache)', function () {
+            return map1.get('exx').then(function () {
+                return map1.containsKey('exx');
+            }).then(function (c) {
+                expectStats(map1, 1, 1, 1);
+                return expect(c).to.be.false;
+            });
+        });
+
+        it('containsKey true', function () {
+            return map1.containsKey('key1').then(function (c) {
+                expectStats(map1, 0, 1, 0);
+                return expect(c).to.be.true;
+            });
+        });
+
+        it('containsKey false', function () {
+            return map1.containsKey('exx').then(function (c) {
+                expectStats(map1, 0, 1, 0);
+                return expect(c).to.be.false;
+            });
+        });
+
+        it('delete invalidates the cache', function () {
+            return map1.get('key1').then(function () {
+                return map1.delete('key1');
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('evictAll evicts near cache', function () {
+            return map1.get('key1').then(function () {
+                return map1.evictAll();
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('evict evicts the entry', function () {
+            return map1.getAll(['key1', 'key2']).then(function () {
+                return map1.evict('key1');
+            }).then(function () {
+                return expectStats(map1, 0, 2, 1);
+            });
+        });
+
+        it('getAll', function () {
+            return map1.getAll(['key1', 'key2']).then(function (vals) {
+                expect(vals).to.deep.have.members([
+                    ['key1', 'val1'],
+                    ['key2', 'val2']
+                ]);
+                return expectStats(map1, 0, 2, 2);
+            });
+        });
+
+        it('getAll second call should hit', function () {
+            return map1.getAll(['key1', 'key2']).then(function (vals) {
+                return map1.getAll(['key1', 'key2', 'key3']);
+            }).then(function(vals) {
+                expect(vals).to.deep.have.members([
+                    ['key1', 'val1'],
+                    ['key2', 'val2'],
+                    ['key3', 'val3']
+                ]);
+                return expectStats(map1, 2, 3, 3);
+            });
+        });
+
+        it('executeOnKey invalidates the entry');
+
+        it('executeOnKeys invalidates entries');
+
+        it('loadAll invalidates the cache');
+
+        it('putAll invalidates entries', function() {
+            return map1.getAll(['key1', 'key2']).then(function () {
+                return map1.putAll([
+                    ['key1', 'newVal1'],
+                    ['key2', 'newVal2']
+                ]);
+            }).then(function () {
+                return expectStats(map1, 0, 2, 0);
+            });
+        });
+
+        it('putIfAbsent (existing key) invalidates the entry', function () {
+            return map1.get('key1').then(function () {
+                return map1.putIfAbsent('key1', 'valnew');
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('putTransient invalidates the entry', function () {
+            return map1.get('key1').then(function () {
+                return map1.putTransient('key1', 'vald');
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('replace invalidates the entry', function () {
+            return map1.get('key1').then(function () {
+                return map1.replace('key1', 'newVal');
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('replaceIfSame invalidates the entry', function () {
+            return map1.get('key1').then(function () {
+                return map1.replaceIfSame('key1', 'val1', 'newVal');
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('set invalidates the entry', function() {
+            return map1.get('key1').then(function () {
+                return map1.set('key1', 'newVal');
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('tryPut invalidates the entry', function() {
+            return map1.get('key1').then(function () {
+                return map1.tryPut('key1', 'newVal', 1000);
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+        it('tryRemove invalidates the entry', function() {
+            return map1.get('key1').then(function () {
+                return map1.tryRemove('key1', 1000);
+            }).then(function () {
+                return expectStats(map1, 0, 1, 0);
+            });
+        });
+
+    });
+});

--- a/test/map/hazelcast_nearcache_batchinvalidation_false.xml
+++ b/test/map/hazelcast_nearcache_batchinvalidation_false.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    The default Hazelcast configuration. This is used when no hazelcast.xml is present.
+    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.7.xsd
+    or the documentation at https://hazelcast.org/documentation/
+-->
+<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
+           xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <properties>
+        <property name="hazelcast.map.invalidation.batch.enabled">false</property>
+    </properties>
+</hazelcast>

--- a/test/nearcache/NearCacheTest.js
+++ b/test/nearcache/NearCacheTest.js
@@ -5,12 +5,12 @@ var expect = chai.expect;
 var Config = require('../../.').Config;
 var Controller = require('../RC');
 var HazelcastClient = require('../../.').Client;
-var DataRecord = require('../../lib/NearCache').DataRecord;
-var NearCache = require('../../lib/NearCache').NearCache;
+var DataRecord = require('../../lib/nearcache/NearCache').DataRecord;
+var NearCacheImpl = require('../../lib/nearcache/NearCache').NearCacheImpl;
 var EvictionPolicy = Config.EvictionPolicy;
 var promiseLater = require('../Util').promiseLater;
 var SerializationService = require('../../lib/serialization/SerializationService').SerializationServiceV1;
-describe('NearCache', function() {
+describe('NearCacheImpl', function() {
     var cluster;
     var client;
 
@@ -33,6 +33,18 @@ describe('NearCache', function() {
         });
     });
 
+    function ds(str) {
+        return {
+            val: str,
+            hashCode: function () {
+                return str[0] - 'a';
+            },
+            equals(other) {
+                return this.val === other.val;
+            }
+        }
+    }
+
     before(function() {
         return Controller.createCluster(null, null).then(function(res) {
             cluster = res;
@@ -52,10 +64,10 @@ describe('NearCache', function() {
     describe('CacheRecord', function () {
 
         it('does not expire if ttl is 0', function (done) {
-            var rec = new DataRecord('key', 'value', undefined, 0);
+            var rec = new DataRecord(ds('key'), 'value', undefined, 0);
             setTimeout(function () {
                 if (rec.isExpired()) {
-                    done('Unlimited ttl record expired');
+                    done(new Error('Unlimited ttl record expired'));
                 } else {
                     done();
                 }
@@ -63,21 +75,21 @@ describe('NearCache', function() {
         });
 
         it('expires after ttl', function (done) {
-            var rec = new DataRecord('key', 'value', undefined, 1);
+            var rec = new DataRecord(ds('key'), 'value', undefined, 1);
             setTimeout(function () {
                 if (rec.isExpired()) {
                     done();
                 } else {
-                    done('Record did not expire after ttl');
+                    done(new Error('Record did not expire after ttl'));
                 }
-            }, 1000);
+            }, 1100);
         });
 
         it('does not expire before ttl', function (done) {
-            var rec = new DataRecord('key', 'value', undefined, 10);
+            var rec = new DataRecord(ds('key'), 'value', undefined, 10);
             setTimeout(function () {
                 if (rec.isExpired()) {
-                    done('Record expired before ttl');
+                    done(new Error('Record expired before ttl'));
                 } else {
                     done();
                 }
@@ -86,22 +98,22 @@ describe('NearCache', function() {
 
         it('expires after maxIdleSeconds', function(done) {
             this.timeout(4000);
-            var rec = new DataRecord('key', 'value', undefined, 100);
+            var rec = new DataRecord(ds('key'), 'value', undefined, 100);
             setTimeout(function () {
                 if (rec.isExpired(1)) {
                     done();
                 } else {
-                    done('did not expire after maxIdleSeconds');
+                    done(new Error('did not expire after maxIdleSeconds'));
                 }
             }, 2000);
         });
 
         it('does not expire while active', function(done) {
-            var rec = new DataRecord('key', 'value', undefined, 100);
+            var rec = new DataRecord(ds('key'), 'value', undefined, 100);
             setTimeout(function () {
                 rec.setAccessTime();
                 if (rec.isExpired(1)) {
-                    done('expired');
+                    done(new Error('expired'));
                 } else {
                     done();
                 }
@@ -116,18 +128,19 @@ describe('NearCache', function() {
             var nearCache;
 
             beforeEach(function () {
-                nearCache = new NearCache(testConfig, createSerializationService());
+                this.timeout(10);
+                nearCache = new NearCacheImpl(testConfig, createSerializationService());
             });
 
 
             it('simple put/get', function () {
-                nearCache.put('key', 'val');
-                return expect(nearCache.get('key')).to.equal('val');
+                nearCache.put(ds('key'), 'val');
+                return expect(nearCache.get(ds('key'))).to.equal('val');
             });
 
 
             it('returns undefined for non existing value', function () {
-                nearCache.get('random');
+                nearCache.get(ds('random'));
                 return expect(nearCache.getStatistics().missCount).to.equal(1);
             });
 
@@ -135,42 +148,42 @@ describe('NearCache', function() {
                 if (nearCache.timeToLiveSeconds != 0) {
                     this.skip();
                 }
-                nearCache.put('key', 'val');
-                return expect(promiseAfter(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+                nearCache.put(ds('key'), 'val');
+                return expect(promiseAfter(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, ds('key')))).to.eventually.equal('val');
             });
 
             it('ttl expire', function () {
                 if (nearCache.timeToLiveSeconds == 0) {
                     this.skip();
                 }
-                nearCache.put('key', 'val');
-                return expect(promiseAfter(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.be.undefined;
+                nearCache.put(ds('key'), 'val');
+                return expect(promiseAfter(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, ds('key')))).to.eventually.be.undefined;
             });
 
             it('ttl does not expire early', function() {
-                nearCache.put('key', 'val');
-                return expect(promiseBefore(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+                nearCache.put(ds('key'), 'val');
+                return expect(promiseBefore(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, ds('key')))).to.eventually.equal('val');
             });
 
             it('evicted after maxIdleSeconds', function() {
                 if (nearCache.maxIdleSeconds == 0) {
                     this.skip();
                 }
-                nearCache.put('key', 'val');
-                return expect(promiseAfter(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.be.undefined;
+                nearCache.put(ds('key'), 'val');
+                return expect(promiseAfter(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, ds('key')))).to.eventually.be.undefined;
             });
 
             it('not evicted after maxIdleSeconds if maxIdleSeconds is 0(unlimited)', function() {
                 if (nearCache.maxIdleSeconds != 0) {
                     this.skip();
                 }
-                nearCache.put('key', 'val');
-                return expect(promiseAfter(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+                nearCache.put(ds('key'), 'val');
+                return expect(promiseAfter(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, ds('key')))).to.eventually.equal('val');
             });
 
             it('not evicted before maxIdleSeconds', function() {
-                nearCache.put('key', 'val');
-                return expect(promiseBefore(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+                nearCache.put(ds('key'), 'val');
+                return expect(promiseBefore(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, ds('key')))).to.eventually.equal('val');
             });
 
             it('evicts entries after eviction max size is reached', function () {
@@ -179,7 +192,7 @@ describe('NearCache', function() {
                 }
                 var i;
                 for (i = 0; i<nearCache.evictionMaxSize + 1; i++) {
-                    nearCache.put('k' + i, 'v' + i);
+                    nearCache.put(ds('k' + i), 'v' + i);
                 }
                 expect(nearCache.getStatistics().evictedCount).to.equal(1);
                 expect(nearCache.getStatistics().entryCount).to.equal(100);
@@ -191,11 +204,11 @@ describe('NearCache', function() {
                 }
                 var i;
                 for (i = 0; i<nearCache.evictionMaxSize; i++) {
-                    nearCache.put('k' + i, 'v' + i);
+                    nearCache.put(ds('k' + i), 'v' + i);
                 }
                 promiseAfter(nearCache.timeToLiveSeconds, function() {
                     try {
-                        nearCache.put('laterentry', 'laterval');
+                        nearCache.put(ds('laterentry'), 'laterval');
                         expect(nearCache.getStatistics().evictedCount).to.equal(0);
                         expect(nearCache.getStatistics().expiredCount).to.greaterThan(0);
                         expect(nearCache.getStatistics().entryCount).to.lessThan(100);
@@ -213,17 +226,17 @@ describe('NearCache', function() {
         it('Object', function() {
             var nearCacheConfig = new Config.NearCacheConfig();
             nearCacheConfig.inMemoryFormat = Config.InMemoryFormat.OBJECT;
-            var nearCache = new NearCache(nearCacheConfig, createSerializationService());
-            nearCache.put('k', 'v');
-            expect(nearCache.internalStore.get('k').value).to.be.a('string');
+            var nearCache = new NearCacheImpl(nearCacheConfig, createSerializationService());
+            nearCache.put(ds('k'), 'v');
+            expect(nearCache.internalStore.get(ds('k')).value).to.be.a('string');
         });
 
         it('Binary', function() {
             var nearCacheConfig = new Config.NearCacheConfig();
             nearCacheConfig.inMemoryFormat = Config.InMemoryFormat.BINARY;
-            var nearCache = new NearCache(nearCacheConfig, createSerializationService());
-            nearCache.put('k', 'v');
-            expect(nearCache.internalStore.get('k').value).to.not.be.a('string');
+            var nearCache = new NearCacheImpl(nearCacheConfig, createSerializationService());
+            nearCache.put(ds('k'), 'v');
+            expect(nearCache.internalStore.get(ds('k')).value).to.not.be.a('string');
         });
     });
 

--- a/test/nearcache/NearCacheTest.js
+++ b/test/nearcache/NearCacheTest.js
@@ -1,0 +1,243 @@
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+var Config = require('../../.').Config;
+var Controller = require('../RC');
+var HazelcastClient = require('../../.').Client;
+var DataRecord = require('../../lib/NearCache').DataRecord;
+var NearCache = require('../../lib/NearCache').NearCache;
+var EvictionPolicy = Config.EvictionPolicy;
+var promiseLater = require('../Util').promiseLater;
+var SerializationService = require('../../lib/serialization/SerializationService').SerializationServiceV1;
+describe('NearCache', function() {
+    var cluster;
+    var client;
+
+    var invalidateOnChange = [false, true];
+    var ttls = [0, 1];
+    var evictionPolicy = [EvictionPolicy.LFU, EvictionPolicy.LRU, EvictionPolicy.RANDOM, EvictionPolicy.NONE];
+
+    var testConfigs = [];
+
+    evictionPolicy.forEach(function (evictionPolicy) {
+        invalidateOnChange.forEach(function (ioc) {
+            ttls.forEach(function (ttl) {
+                var ncc = new Config.NearCacheConfig();
+                ncc.invalidateOnChange = ioc;
+                ncc.timeToLiveSeconds = ttl;
+                ncc.evictionMaxSize = 100;
+                ncc.evictionPolicy = evictionPolicy;
+                testConfigs.push(ncc);
+            });
+        });
+    });
+
+    before(function() {
+        return Controller.createCluster(null, null).then(function(res) {
+            cluster = res;
+            return Controller.startMember(cluster.id);
+        }).then(function () {
+            return HazelcastClient.newHazelcastClient();
+        }).then(function (cl) {
+            client = cl;
+        });
+    });
+
+    after(function() {
+        client.shutdown();
+        return Controller.shutdownCluster(cluster.id);
+    });
+
+    describe('CacheRecord', function () {
+
+        it('does not expire if ttl is 0', function (done) {
+            var rec = new DataRecord('key', 'value', undefined, 0);
+            setTimeout(function () {
+                if (rec.isExpired()) {
+                    done('Unlimited ttl record expired');
+                } else {
+                    done();
+                }
+            }, 1000);
+        });
+
+        it('expires after ttl', function (done) {
+            var rec = new DataRecord('key', 'value', undefined, 1);
+            setTimeout(function () {
+                if (rec.isExpired()) {
+                    done();
+                } else {
+                    done('Record did not expire after ttl');
+                }
+            }, 1000);
+        });
+
+        it('does not expire before ttl', function (done) {
+            var rec = new DataRecord('key', 'value', undefined, 10);
+            setTimeout(function () {
+                if (rec.isExpired()) {
+                    done('Record expired before ttl');
+                } else {
+                    done();
+                }
+            }, 100);
+        });
+
+        it('expires after maxIdleSeconds', function(done) {
+            this.timeout(4000);
+            var rec = new DataRecord('key', 'value', undefined, 100);
+            setTimeout(function () {
+                if (rec.isExpired(1)) {
+                    done();
+                } else {
+                    done('did not expire after maxIdleSeconds');
+                }
+            }, 2000);
+        });
+
+        it('does not expire while active', function(done) {
+            var rec = new DataRecord('key', 'value', undefined, 100);
+            setTimeout(function () {
+                rec.setAccessTime();
+                if (rec.isExpired(1)) {
+                    done('expired');
+                } else {
+                    done();
+                }
+            }, 100);
+        });
+    });
+
+    testConfigs.forEach(function (testConfig) {
+
+        describe(testConfig.toString(), function () {
+
+            var nearCache;
+
+            beforeEach(function () {
+                nearCache = new NearCache(testConfig, createSerializationService());
+            });
+
+
+            it('simple put/get', function () {
+                nearCache.put('key', 'val');
+                return expect(nearCache.get('key')).to.equal('val');
+            });
+
+
+            it('returns undefined for non existing value', function () {
+                nearCache.get('random');
+                return expect(nearCache.getStatistics().missCount).to.equal(1);
+            });
+
+            it('record does not expire if ttl is 0', function () {
+                if (nearCache.timeToLiveSeconds != 0) {
+                    this.skip();
+                }
+                nearCache.put('key', 'val');
+                return expect(promiseAfter(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+            });
+
+            it('ttl expire', function () {
+                if (nearCache.timeToLiveSeconds == 0) {
+                    this.skip();
+                }
+                nearCache.put('key', 'val');
+                return expect(promiseAfter(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.be.undefined;
+            });
+
+            it('ttl does not expire early', function() {
+                nearCache.put('key', 'val');
+                return expect(promiseBefore(testConfig.timeToLiveSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+            });
+
+            it('evicted after maxIdleSeconds', function() {
+                if (nearCache.maxIdleSeconds == 0) {
+                    this.skip();
+                }
+                nearCache.put('key', 'val');
+                return expect(promiseAfter(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.be.undefined;
+            });
+
+            it('not evicted after maxIdleSeconds if maxIdleSeconds is 0(unlimited)', function() {
+                if (nearCache.maxIdleSeconds != 0) {
+                    this.skip();
+                }
+                nearCache.put('key', 'val');
+                return expect(promiseAfter(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+            });
+
+            it('not evicted before maxIdleSeconds', function() {
+                nearCache.put('key', 'val');
+                return expect(promiseBefore(testConfig.maxIdleSeconds, nearCache.get.bind(nearCache, 'key'))).to.eventually.equal('val');
+            });
+
+            it('evicts entries after eviction max size is reached', function () {
+                if (nearCache.evictionPolicy == EvictionPolicy.NONE){
+                    this.skip();
+                }
+                var i;
+                for (i = 0; i<nearCache.evictionMaxSize + 1; i++) {
+                    nearCache.put('k' + i, 'v' + i);
+                }
+                expect(nearCache.getStatistics().evictedCount).to.equal(1);
+                expect(nearCache.getStatistics().entryCount).to.equal(100);
+            });
+
+            it('no need for eviction when some entries are already expired', function (done) {
+                if (nearCache.evictionPolicy === EvictionPolicy.NONE || nearCache.timeToLiveSeconds === 0){
+                    this.skip();
+                }
+                var i;
+                for (i = 0; i<nearCache.evictionMaxSize; i++) {
+                    nearCache.put('k' + i, 'v' + i);
+                }
+                promiseAfter(nearCache.timeToLiveSeconds, function() {
+                    try {
+                        nearCache.put('laterentry', 'laterval');
+                        expect(nearCache.getStatistics().evictedCount).to.equal(0);
+                        expect(nearCache.getStatistics().expiredCount).to.greaterThan(0);
+                        expect(nearCache.getStatistics().entryCount).to.lessThan(100);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            });
+        });
+    });
+
+    describe('InMemory format', function () {
+
+        it('Object', function() {
+            var nearCacheConfig = new Config.NearCacheConfig();
+            nearCacheConfig.inMemoryFormat = Config.InMemoryFormat.OBJECT;
+            var nearCache = new NearCache(nearCacheConfig, createSerializationService());
+            nearCache.put('k', 'v');
+            expect(nearCache.internalStore.get('k').value).to.be.a('string');
+        });
+
+        it('Binary', function() {
+            var nearCacheConfig = new Config.NearCacheConfig();
+            nearCacheConfig.inMemoryFormat = Config.InMemoryFormat.BINARY;
+            var nearCache = new NearCache(nearCacheConfig, createSerializationService());
+            nearCache.put('k', 'v');
+            expect(nearCache.internalStore.get('k').value).to.not.be.a('string');
+        });
+    });
+
+    function createSerializationService() {
+        var cfg = new Config.ClientConfig().serializationConfig;
+        return new SerializationService(cfg);
+    }
+
+    function promiseBefore(boundaryInSec, func) {
+        return promiseLater(boundaryInSec * 250, func);
+    }
+
+    function promiseAfter(boundaryInSec, func) {
+        return promiseLater(boundaryInSec * 1500, func);
+    }
+
+});


### PR DESCRIPTION
NearCache for Map before 3.8.

Implementation follows the Java implementation.
Since Javascript does not hava a generic Map implementation, I implemented `DataKeyedHashMap`. (Native Map in Javascript uses only strings and numbers as keys)
