### PR TITLE
fixes #168

### DIFF
--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -158,7 +158,7 @@ class ClusterService extends EventEmitter {
                         deferred.resolve();
                     });
                 }).catch((e) => {
-                    this.logger.warn('ClusterService', e);
+                    this.logger.warn('ClusterService', e.className, e);
                     this.tryAddressIndex(index + 1, attemptLimit, attemptPeriod, deferred);
                 });
             }

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -67,7 +67,7 @@ export class Invocation {
  * Sends requests to appropriate nodes. Resolves waiting promises with responses.
  */
 export class InvocationService {
-    private correlationCounter = 0;
+    private correlationCounter = 1;
     private eventHandlers: {[id: number]: Invocation} = {};
     private pending: {[id: number]: Invocation} = {};
     private client: HazelcastClient;
@@ -231,7 +231,7 @@ export class InvocationService {
                     this.invoke(pendingInvocation);
                 }, INVOCATION_RETRY_DELAY);
             } else {
-                this.logger.error('InvocationService', 'Received exception as response', remoteException);
+                this.logger.trace('InvocationService', 'Received exception as response', remoteException);
                 deferred.reject(remoteException);
             }
         } else {


### PR DESCRIPTION
Correlation id starts from 1 instead of 0.
Invocation service logs remote exceptions as TRACE instead of ERROR. Invocation service delegates errors to respctive error handler.
ClusterService logs remote exceptions as WARNING because they are already re-tried.