### PR TITLE
Fix heartbeat test

### DIFF
--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -158,7 +158,7 @@ class ClusterService extends EventEmitter {
                         deferred.resolve();
                     });
                 }).catch((e) => {
-                    this.logger.warn('ClusterService', e);
+                    this.logger.warn('ClusterService', e.className, e);
                     this.tryAddressIndex(index + 1, attemptLimit, attemptPeriod, deferred);
                 });
             }

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -67,7 +67,7 @@ export class Invocation {
  * Sends requests to appropriate nodes. Resolves waiting promises with responses.
  */
 export class InvocationService {
-    private correlationCounter = 0;
+    private correlationCounter = 1;
     private eventHandlers: {[id: number]: Invocation} = {};
     private pending: {[id: number]: Invocation} = {};
     private client: HazelcastClient;
@@ -231,7 +231,7 @@ export class InvocationService {
                     this.invoke(pendingInvocation);
                 }, INVOCATION_RETRY_DELAY);
             } else {
-                this.logger.error('InvocationService', 'Received exception as response', remoteException);
+                this.logger.trace('InvocationService', 'Received exception as response', remoteException);
                 deferred.reject(remoteException);
             }
         } else {

--- a/test/HeartbeatTest.js
+++ b/test/HeartbeatTest.js
@@ -45,7 +45,7 @@ describe('Heartbeat', function() {
         }).then(function() {
             return RC.startMember(cluster.id);
         }).then(function(member2) {
-            RC.terminateMember(cluster.id, member2.uuid);
+            simulateHeartbeatLost(client, member2.host + ':' + member2.port, 2000);
         }).catch(done);
     });
 


### PR DESCRIPTION
Heatbeat test used to use RemoteController.terminateMember method. The client recognized that server died and stopped listening for heartbeat. This is expected behavior. Now, the client simulates a lost heartbeat in the test.