### PR TITLE
HazelcastError types added

### DIFF
--- a/src/HazelcastError.ts
+++ b/src/HazelcastError.ts
@@ -1,0 +1,35 @@
+export class HazelcastError extends Error {
+    constructor(msg: string) {
+        super(msg);
+        Error.captureStackTrace(this, HazelcastError);
+        Object.setPrototypeOf(this, HazelcastError);
+    }
+}
+
+export class AuthenticationError extends HazelcastError {
+    constructor(msg: string) {
+        super(msg);
+        Object.setPrototypeOf(this, AuthenticationError);
+    }
+}
+
+export class ClientNotActiveError extends HazelcastError {
+    constructor(msg: string) {
+        super(msg);
+        Object.setPrototypeOf(this, ClientNotActiveError);
+    }
+}
+
+export class IllegalStateError extends HazelcastError {
+    constructor(msg: string) {
+        super(msg);
+        Object.setPrototypeOf(this, IllegalStateError);
+    }
+}
+
+export class TopicOverloadError extends HazelcastError {
+    constructor(msg: string) {
+        super(msg);
+        Object.setPrototypeOf(this, TopicOverloadError);
+    }
+}

--- a/src/HazelcastError.ts
+++ b/src/HazelcastError.ts
@@ -1,35 +1,38 @@
-export class HazelcastError extends Error {
+export class HazelcastError {
+
+    message: string;
+    stack: string;
+
     constructor(msg: string) {
-        super(msg);
+        this.message = msg;
         Error.captureStackTrace(this, HazelcastError);
-        Object.setPrototypeOf(this, HazelcastError);
+    }
+
+    toString(): string {
+        return this.message;
     }
 }
 
 export class AuthenticationError extends HazelcastError {
     constructor(msg: string) {
         super(msg);
-        Object.setPrototypeOf(this, AuthenticationError);
     }
 }
 
 export class ClientNotActiveError extends HazelcastError {
     constructor(msg: string) {
         super(msg);
-        Object.setPrototypeOf(this, ClientNotActiveError);
     }
 }
 
 export class IllegalStateError extends HazelcastError {
     constructor(msg: string) {
         super(msg);
-        Object.setPrototypeOf(this, IllegalStateError);
     }
 }
 
 export class TopicOverloadError extends HazelcastError {
     constructor(msg: string) {
         super(msg);
-        Object.setPrototypeOf(this, TopicOverloadError);
     }
 }

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -63,7 +63,7 @@ class ClientConnectionManager extends EventEmitter {
                 this.establishedConnections[Address.encodeToString(clientConnection.address)] = clientConnection;
             } else {
                 throw new AuthenticationError('Invalid credentials. Address: ' +
-                     + Address.encodeToString(clientConnection.getAddress()));
+                     Address.encodeToString(clientConnection.getAddress()));
             }
         }).then(() => {
             this.onConnectionOpened(clientConnection);

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -139,7 +139,7 @@ class ClusterService extends EventEmitter {
             if (this.knownAddresses.length <= index) {
                 attemptLimit = attemptLimit - 1;
                 if (attemptLimit === 0) {
-                    var error = new Error('Unable to connect to any of the following addresses: ' +
+                    var error = new RangeError('Unable to connect to any of the following addresses: ' +
                         this.knownAddresses.map(Address.encodeToString).join(', '));
                     deferred.reject(error);
                     return;

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -1,10 +1,9 @@
 import ClientConnection = require('./ClientConnection');
 import ClientMessage = require('../ClientMessage');
-import * as Promise from 'bluebird';
 import Long = require('long');
-import {Data} from '../serialization/Data';
 import Address = require('../Address');
 import ExceptionCodec = require('../codec/ExceptionCodec');
+import * as Promise from 'bluebird';
 import {BitsUtil} from '../BitsUtil';
 import {LoggingService} from '../logging/LoggingService';
 import {EventEmitter} from 'events';

--- a/src/logging/LoggingService.ts
+++ b/src/logging/LoggingService.ts
@@ -1,6 +1,7 @@
-import HazelcastClient = require('../HazelcastClient');
 import {NoLogger} from './NoLogger';
 import {DefaultLogger} from './DefaultLogger';
+import {IllegalStateError} from '../HazelcastError';
+
 export enum LogLevel {
     ERROR = 0,
     WARN = 1,
@@ -31,7 +32,7 @@ export class LoggingService {
         if (LoggingService.loggingService != null) {
             return LoggingService.loggingService;
         } else {
-            throw new Error('LoggingService was not initialized');
+            throw new IllegalStateError('LoggingService was not initialized');
         }
     }
 
@@ -42,7 +43,7 @@ export class LoggingService {
             } else if (loggerModule === 'default') {
                 LoggingService.loggingService = new LoggingService();
             } else {
-                throw new Error('Logging type unknown: ' + loggerModule);
+                throw new RangeError('Logging type unknown: ' + loggerModule);
             }
         } else {
             LoggingService.loggingService = new LoggingService(<ILogger>loggerModule);

--- a/src/proxy/IQueue.ts
+++ b/src/proxy/IQueue.ts
@@ -1,12 +1,13 @@
 import * as Promise from 'bluebird';
 import {DistributedObject} from '../DistributedObject';
 import {ItemListener} from '../core/ItemListener';
+
 export interface IQueue<E> extends DistributedObject {
     /**
      * Adds given item to the end of the queue. Operation is successful only
      * if queue has required capacity.
      * @param item element to add.
-     * @throws `Error` if queue is full.
+     * @throws `IllegalStateError` if queue is full.
      * @return `true`.
      */
     add(item: E): Promise<boolean>;

--- a/src/proxy/IRingbuffer.ts
+++ b/src/proxy/IRingbuffer.ts
@@ -95,7 +95,7 @@ export interface IRingbuffer<E> extends DistributedObject {
      *
      * @param sequence the sequence number of the item to read.
      * @return the item that was read.
-     * @throws Error                if the sequence is:
+     * @throws `RangeError`         if the sequence is:
      *                              smaller then zero;
      *                              smaller than {@link #headSequence()};
      *                              more than {@link #tailSequence()} + 1
@@ -114,12 +114,12 @@ export interface IRingbuffer<E> extends DistributedObject {
      * @param sequence sequence number of the first item to be read.
      * @param minCount minimum number of items to be read.
      * @param maxCount maximum number of items to be read.
-     * @throws Error if startSequence is smaller than 0
-     *               or if startSequence larger than {@link #tailSequence()}
-     *               or if minCount smaller than 0
-     *               or if minCount larger than maxCount,
-     *               or if maxCount larger than the capacity of the ringbuffer
-     *               or if maxCount larger than 1000 (to prevent overload)
+     * @throws `RangeError` if startSequence is smaller than 0
+     *                      or if startSequence larger than {@link #tailSequence()}
+     *                      or if minCount smaller than 0
+     *                      or if minCount larger than maxCount,
+     *                      or if maxCount larger than the capacity of the ringbuffer
+     *                      or if maxCount larger than 1000 (to prevent overload)
      */
     readMany(sequence: number | Long, minCount: number, maxCount: number): Promise<Array<E>>;
 }

--- a/src/proxy/QueueProxy.ts
+++ b/src/proxy/QueueProxy.ts
@@ -1,5 +1,5 @@
 import {IQueue} from './IQueue';
-import {ItemListener, ItemEventType} from '../core/ItemListener';
+import {ItemEventType, ItemListener} from '../core/ItemListener';
 import {PartitionSpecificProxy} from './PartitionSpecificProxy';
 import {QueueSizeCodec} from '../codec/QueueSizeCodec';
 import {QueueOfferCodec} from '../codec/QueueOfferCodec';
@@ -22,8 +22,10 @@ import {QueuePutCodec} from '../codec/QueuePutCodec';
 import {QueueCompareAndRemoveAllCodec} from '../codec/QueueCompareAndRemoveAllCodec';
 import {QueueCompareAndRetainAllCodec} from '../codec/QueueCompareAndRetainAllCodec';
 import {QueueAddListenerCodec} from '../codec/QueueAddListenerCodec';
-import ClientMessage = require('../ClientMessage');
 import {QueueRemoveListenerCodec} from '../codec/QueueRemoveListenerCodec';
+import {IllegalStateError} from '../HazelcastError';
+import ClientMessage = require('../ClientMessage');
+
 export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
 
     add(item: E): Promise<boolean> {
@@ -31,7 +33,7 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
             if (ret) {
                 return true;
             } else {
-                throw new Error('Queue is full.');
+                throw new IllegalStateError('Queue is full.');
             }
         });
     }

--- a/src/proxy/RingbufferProxy.ts
+++ b/src/proxy/RingbufferProxy.ts
@@ -50,7 +50,7 @@ export class RingbufferProxy<E> extends PartitionSpecificProxy implements IRingb
 
     readOne(sequence: number|Long): Promise<E> {
         if (Long.fromValue(sequence).lessThan(0)) {
-            throw new Error('Sequence number should not be less than zero, was: ' + sequence);
+            throw new RangeError('Sequence number should not be less than zero, was: ' + sequence);
         }
 
         return this.encodeInvoke<E>(RingbufferReadOneCodec, sequence);
@@ -59,15 +59,15 @@ export class RingbufferProxy<E> extends PartitionSpecificProxy implements IRingb
     readMany(sequence: number|Long, minCount: number, maxCount: number): Promise<Array<E>> {
 
         if (Long.fromValue(sequence).lessThan(0)) {
-            throw new Error('Sequence number should not be less than zero, was: ' + sequence);
+            throw new RangeError('Sequence number should not be less than zero, was: ' + sequence);
         }
 
         if (minCount < 0) {
-            throw new Error('Min count should not be less than zero, was: ' + sequence);
+            throw new RangeError('Min count should not be less than zero, was: ' + sequence);
         }
 
         if (minCount > maxCount) {
-            throw new Error('Min count ' + minCount + 'was larger than max count ' + maxCount);
+            throw new RangeError('Min count ' + minCount + 'was larger than max count ' + maxCount);
         }
 
         return this

--- a/src/serialization/DefaultPredicates.ts
+++ b/src/serialization/DefaultPredicates.ts
@@ -1,6 +1,6 @@
 import {DataInput, DataOutput} from './Data';
 import {AbstractPredicate} from './PredicateFactory';
-import {Predicate, IterationType} from '../core/Predicate';
+import {IterationType, Predicate} from '../core/Predicate';
 import {enumFromString} from '../Util';
 import {Comparator} from '../core/Comparator';
 
@@ -433,7 +433,7 @@ export class PagingPredicate extends AbstractPredicate {
         } else if (page === anchorCount) {
             this.anchorList.push(anchorEntry);
         } else {
-            throw new Error('Anchor index is not correct, expected: ' + page + 'found: ' + anchorCount);
+            throw new RangeError('Anchor index is not correct, expected: ' + page + 'found: ' + anchorCount);
         }
     }
 

--- a/src/serialization/DefaultSerializer.ts
+++ b/src/serialization/DefaultSerializer.ts
@@ -1,8 +1,9 @@
 import {Serializer} from './SerializationService';
 import {DataInput, DataOutput} from './Data';
-import {IdentifiedDataSerializableFactory, IdentifiedDataSerializable} from './Serializable';
-import Long = require('long');
+import {IdentifiedDataSerializable, IdentifiedDataSerializableFactory} from './Serializable';
 import {BitsUtil} from '../BitsUtil';
+import Long = require('long');
+
 export class StringSerializer implements Serializer {
 
     getId(): number {
@@ -366,7 +367,7 @@ export class IdentifiedDataSerializableSerializer implements Serializer {
         var factory: IdentifiedDataSerializableFactory;
         factory = this.factories[factoryId];
         if (!factory) {
-            throw new ReferenceError('There is no Identified Data Serializer factory with id ' + factoryId + '.');
+            throw new RangeError('There is no Identified Data Serializer factory with id ' + factoryId + '.');
         }
         var object = factory.create(classId);
         object.readData(input);

--- a/src/serialization/HeapData.ts
+++ b/src/serialization/HeapData.ts
@@ -12,7 +12,7 @@ export class HeapData implements Data {
 
     constructor(buffer: Buffer) {
         if (buffer != null && buffer.length > 0 && buffer.length < HEAP_DATA_OVERHEAD) {
-            throw new Error('Data should be either empty or should contain more than ' + HEAP_DATA_OVERHEAD
+            throw new RangeError('Data should be either empty or should contain more than ' + HEAP_DATA_OVERHEAD
                 + ' bytes! -> '
                 + buffer);
         }

--- a/src/serialization/ObjectData.ts
+++ b/src/serialization/ObjectData.ts
@@ -530,7 +530,7 @@ export class ObjectDataInput implements DataInput {
                     charCode = (first2 | second2 | third2);
                     break;
                 default:
-                    throw new Error('Malformed UTF8 string');
+                    throw new RangeError('Malformed UTF8 string');
             }
             result += String.fromCharCode(charCode);
         }

--- a/src/serialization/portable/DefaultPortableReader.ts
+++ b/src/serialization/portable/DefaultPortableReader.ts
@@ -4,6 +4,7 @@ import {ClassDefinition, FieldDefinition, FieldType} from './ClassDefinition';
 import {BitsUtil} from '../../BitsUtil';
 import {Portable} from '../Serializable';
 import * as Long from 'long';
+import {IllegalStateError} from '../../HazelcastError';
 
 export class DefaultPortableReader implements PortableReader {
 
@@ -27,7 +28,7 @@ export class DefaultPortableReader implements PortableReader {
 
     private positionByFieldDefinition(field: FieldDefinition): number {
         if (this.raw) {
-            throw new Error('Cannot read portable fields after getRawDataInput called!');
+            throw new IllegalStateError('Cannot read portable fields after getRawDataInput called!');
         }
         var pos = this.input.readInt(this.offset + field.getIndex() * BitsUtil.INT_SIZE_IN_BYTES);
         var len = this.input.readShort(pos);
@@ -48,7 +49,7 @@ export class DefaultPortableReader implements PortableReader {
     }
 
     getFieldNames(): string[] {
-        throw new Error('Not implemented!');
+        throw new ReferenceError('Not implemented!');
     }
 
     getFieldType(fieldName: string): FieldType {


### PR DESCRIPTION
`HazelcastError` does not extend from `Error` because extending built-in classes in JS does not work well. Anyway,  any object can be thrown. Any object that is thrown is an `Exception` by definition. Therefore, there is no need to extend from `Error`.