### PR TITLE
adds partition-map refresh task

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -269,6 +269,7 @@ export default class HazelcastClient {
      * Shuts down this client instance.
      */
     shutdown(): void {
+        this.partitionService.shutdown();
         this.lifecycleService.emitLifecycleEvent(LifecycleEvent.shuttingDown);
         this.heartbeat.cancel();
         this.connectionManager.shutdown();

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -341,7 +341,7 @@ describe('MapProxy', function() {
                 }).then(function(val) {
                     return expect(val).to.equal('new-val');
                 }).then(function() {
-                    return Util.promiseLater(1000, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(1050, map.get.bind(map, 'key10'));
                 }).then(function(val) {
                     return expect(val).to.be.null;
                 });
@@ -362,7 +362,7 @@ describe('MapProxy', function() {
                 }).then(function(val) {
                     return expect(val).to.equal('val10');
                 }).then(function() {
-                    return Util.promiseLater(1000, map.get.bind(map, 'key10'))
+                    return Util.promiseLater(1050, map.get.bind(map, 'key10'))
                 }).then(function(val) {
                     return expect(val).to.be.null;
                 });


### PR DESCRIPTION
PartitionService updated partition-map only when a server is added or a server is down. Now it runs a periodic task to update partition mapping so that it is eventually up-to-date. (mimicking Java client)

fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/193