### PR TITLE
ListenerService refactor

### DIFF
--- a/src/ListenerMessageCodec.ts
+++ b/src/ListenerMessageCodec.ts
@@ -4,5 +4,4 @@ export interface ListenerMessageCodec {
     encodeAddRequest: (localOnly: boolean) => ClientMessage;
     decodeAddResponse: (msg: ClientMessage) => string;
     encodeRemoveRequest: (listenerId: string) => ClientMessage;
-    decodeRemoveResponse: (msg: ClientMessage) => boolean;
 }

--- a/src/ListenerMessageCodec.ts
+++ b/src/ListenerMessageCodec.ts
@@ -1,0 +1,8 @@
+import ClientMessage = require('./ClientMessage');
+
+export interface ListenerMessageCodec {
+    encodeAddRequest: (localOnly: boolean) => ClientMessage;
+    decodeAddResponse: (msg: ClientMessage) => string;
+    encodeRemoveRequest: (listenerId: string) => ClientMessage;
+    decodeRemoveResponse: (msg: ClientMessage) => boolean;
+}

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -19,6 +19,7 @@ class ClientConnection {
     private logging =  LoggingService.getLoggingService();
     private clientNetworkConfig: ClientNetworkConfig;
     private connectionManager: ClientConnectionManager;
+    private closedTime: number;
 
     constructor(connectionManager: ClientConnectionManager, address: Address, clientNetworkConfig: ClientNetworkConfig) {
         this.address = address;
@@ -26,6 +27,7 @@ class ClientConnection {
         this.readBuffer = new Buffer(0);
         this.lastRead = 0;
         this.connectionManager = connectionManager;
+        this.closedTime = 0;
     }
 
     /**
@@ -88,10 +90,14 @@ class ClientConnection {
     /**
      * Closes this connection.
      */
-    close() {
+    close(): void {
         this.socket.end();
+        this.closedTime = Date.now();
     }
 
+    isAlive(): boolean {
+        return this.closedTime === 0;
+    }
 
     toString(): string {
         return this.address.toString();

--- a/src/invocation/ClientEventRegistration.ts
+++ b/src/invocation/ClientEventRegistration.ts
@@ -1,15 +1,18 @@
 import * as Long from 'long';
 import ClientConnection = require('./ClientConnection');
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
 
 export class ClientEventRegistration {
     readonly serverRegistrationId: string;
     readonly correlationId: Long;
     readonly subscriber: ClientConnection;
+    readonly codec: ListenerMessageCodec;
 
-    constructor(serverRegistrationId: string, correlationId: Long, subscriber: ClientConnection) {
+    constructor(serverRegistrationId: string, correlationId: Long, subscriber: ClientConnection, codec: ListenerMessageCodec) {
         this.serverRegistrationId = serverRegistrationId;
         this.correlationId = correlationId;
         this.subscriber = subscriber;
+        this.codec = codec;
     }
 
     toString(): string {

--- a/src/invocation/RegistrationKey.ts
+++ b/src/invocation/RegistrationKey.ts
@@ -1,16 +1,17 @@
 import ClientMessage = require('../ClientMessage');
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
 
 export class RegistrationKey {
     private readonly userRegistrationId: string;
     private registerHandlerFunc: Function;
     private registerRequest: ClientMessage;
-    private registerDecodeFunc: Function;
+    private codec: ListenerMessageCodec;
 
-    constructor(regId: string, registerRequest?: ClientMessage, registerDecodeFunc?: Function, registerHandlerFunc?: Function) {
+    constructor(regId: string, codec: ListenerMessageCodec, registerRequest?: ClientMessage, registerHandlerFunc?: Function) {
         this.userRegistrationId = regId;
         this.registerHandlerFunc = registerHandlerFunc;
         this.registerRequest = registerRequest;
-        this.registerDecodeFunc = registerDecodeFunc;
+        this.codec = codec;
     }
 
     getRegisterRequest(): ClientMessage {
@@ -21,12 +22,12 @@ export class RegistrationKey {
         this.registerRequest = registerRequest;
     }
 
-    getDecoder(): Function {
-        return this.registerDecodeFunc;
+    getCodec(): ListenerMessageCodec {
+        return this.codec;
     }
 
-    setDecoder(decoder: Function): void {
-        this.registerDecodeFunc = decoder;
+    setCodec(value: ListenerMessageCodec) {
+        this.codec = value;
     }
 
     getHandler(): Function {

--- a/src/proxy/ListProxy.ts
+++ b/src/proxy/ListProxy.ts
@@ -139,9 +139,7 @@ export class ListProxy<E> extends PartitionSpecificProxy implements IList<E> {
         var deregisterEncodeFunc = (serverKey: string) => {
             return ListRemoveListenerCodec.encodeRequest(this.name, serverKey);
         };
-        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc,
-            ListRemoveListenerCodec.decodeResponse, registrationId
-        );
+        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, registrationId);
     }
 
     private serializeList(input: Array<E>): Array<Data> {

--- a/src/proxy/ListProxy.ts
+++ b/src/proxy/ListProxy.ts
@@ -25,6 +25,7 @@ import {ListSetCodec} from '../codec/ListSetCodec';
 import {ListLastIndexOfCodec} from '../codec/ListLastIndexOfCodec';
 import ClientMessage = require('../ClientMessage');
 import * as Promise from 'bluebird';
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
 
 export class ListProxy<E> extends PartitionSpecificProxy implements IList<E> {
 
@@ -114,8 +115,6 @@ export class ListProxy<E> extends PartitionSpecificProxy implements IList<E> {
     }
 
     addItemListener(listener: ItemListener<E>, includeValue: boolean): Promise<string> {
-        let localOnly = this.client.getListenerService().isLocalOnlyListener();
-        let listenerRequest = ListAddListenerCodec.encodeRequest(this.name, includeValue, localOnly);
         var listenerHandler = (message: ClientMessage) => {
             ListAddListenerCodec.handle(message, (element: Data, uuid: string, eventType: number) => {
                 var responseObject = element ? this.toObject(element) : null;
@@ -131,20 +130,34 @@ export class ListProxy<E> extends PartitionSpecificProxy implements IList<E> {
                 }
             });
         };
-        return this.client.getListenerService().registerListener(listenerRequest, listenerHandler,
-            ListAddListenerCodec.decodeResponse);
+        let codec = this.createItemListener(this.name, includeValue);
+        return this.client.getListenerService().registerListener(codec, listenerHandler);
     }
 
     removeItemListener(registrationId: string): Promise<boolean> {
-        var deregisterEncodeFunc = (serverKey: string) => {
-            return ListRemoveListenerCodec.encodeRequest(this.name, serverKey);
-        };
-        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, registrationId);
+        return this.client.getListenerService().deregisterListener(registrationId);
     }
 
     private serializeList(input: Array<E>): Array<Data> {
         return input.map((each) => {
             return this.toData(each);
         });
+    }
+
+    private createItemListener(name: string, includeValue: boolean): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return ListAddListenerCodec.encodeRequest(name, includeValue, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return ListAddListenerCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return ListRemoveListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return ListRemoveListenerCodec.decodeResponse(msg).response;
+            }
+        };
     }
 }

--- a/src/proxy/ListProxy.ts
+++ b/src/proxy/ListProxy.ts
@@ -154,9 +154,6 @@ export class ListProxy<E> extends PartitionSpecificProxy implements IList<E> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return ListRemoveListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return ListRemoveListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -593,10 +593,6 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
         var deregisterEncodeFunc = (serverId: string) => {
             return MapRemoveEntryListenerCodec.encodeRequest(this.name, serverId);
         };
-        return this.client.getListenerService().deregisterListener(
-            deregisterEncodeFunc,
-            MapRemoveEntryListenerCodec.decodeResponse,
-            listenerId
-        );
+        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, listenerId);
     }
 }

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -594,9 +594,6 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -613,9 +610,6 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -631,9 +625,6 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -648,9 +639,6 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/MultiMapProxy.ts
+++ b/src/proxy/MultiMapProxy.ts
@@ -166,11 +166,7 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
         var deregisterEncodeFunc = (serverKey: string) => {
             return MultiMapRemoveEntryListenerCodec.encodeRequest(this.name, serverKey);
         };
-        return this.client.getListenerService().deregisterListener(
-            deregisterEncodeFunc,
-            MultiMapRemoveEntryListenerCodec.decodeResponse,
-            listenerId
-        );
+        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, listenerId);
     }
 
     lock(key: K, leaseMillis: number = -1): Promise<void> {

--- a/src/proxy/MultiMapProxy.ts
+++ b/src/proxy/MultiMapProxy.ts
@@ -203,9 +203,6 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MultiMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MultiMapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -220,9 +217,6 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MultiMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MultiMapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/MultiMapProxy.ts
+++ b/src/proxy/MultiMapProxy.ts
@@ -18,7 +18,6 @@ import {MultiMapSizeCodec} from './../codec/MultiMapSizeCodec';
 import {MultiMapClearCodec} from './../codec/MultiMapClearCodec';
 import {MultiMapValueCountCodec} from './../codec/MultiMapValueCountCodec';
 import {EntryEventType} from '../core/EntryEventType';
-import ClientMessage = require('../ClientMessage');
 import {MultiMapAddEntryListenerToKeyCodec} from './../codec/MultiMapAddEntryListenerToKeyCodec';
 import {MultiMapAddEntryListenerCodec} from './../codec/MultiMapAddEntryListenerCodec';
 import {MultiMapRemoveEntryListenerCodec} from './../codec/MultiMapRemoveEntryListenerCodec';
@@ -29,6 +28,8 @@ import {MultiMapUnlockCodec} from '../codec/MultiMapUnlockCodec';
 import {MultiMapForceUnlockCodec} from '../codec/MultiMapForceUnlockCodec';
 import {LockReferenceIdGenerator} from '../LockReferenceIdGenerator';
 import * as Long from 'long';
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
+import ClientMessage = require('../ClientMessage');
 
 export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
 
@@ -139,34 +140,27 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
             }
         };
 
-        let localOnly = this.client.getListenerService().isLocalOnlyListener();
         let listenerRequest: ClientMessage;
         if (key) {
-            var keyData = this.toData(key);
-            listenerRequest = MultiMapAddEntryListenerToKeyCodec.encodeRequest(this.name, keyData, includeValue, localOnly);
-            var handler = (m: ClientMessage) => {
+            let keyData = this.toData(key);
+            let handler = (m: ClientMessage) => {
                 MultiMapAddEntryListenerToKeyCodec.handle(m, entryEventHandler, toObject);
             };
+            let codec = this.createEntryListenerToKey(this.name, keyData, includeValue);
 
-            return this.client.getListenerService().registerListener(listenerRequest, handler,
-                MultiMapAddEntryListenerToKeyCodec.decodeResponse);
+            return this.client.getListenerService().registerListener(codec, handler);
         } else {
-            listenerRequest = MultiMapAddEntryListenerCodec.encodeRequest(this.name, includeValue, localOnly);
             var listenerHandler = (m: ClientMessage) => {
                 MultiMapAddEntryListenerCodec.handle(m, entryEventHandler, toObject);
             };
+            let codec = this.createEntryListener(this.name, includeValue);
 
-            return this.client.getListenerService().registerListener(listenerRequest, listenerHandler,
-                MultiMapAddEntryListenerCodec.decodeResponse);
+            return this.client.getListenerService().registerListener(codec, listenerHandler);
         }
-
     }
 
     removeEntryListener(listenerId: string): Promise<boolean> {
-        var deregisterEncodeFunc = (serverKey: string) => {
-            return MultiMapRemoveEntryListenerCodec.encodeRequest(this.name, serverKey);
-        };
-        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, listenerId);
+        return this.client.getListenerService().deregisterListener(listenerId);
     }
 
     lock(key: K, leaseMillis: number = -1): Promise<void> {
@@ -197,5 +191,39 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
 
     private nextSequence(): Long {
         return this.lockReferenceIdGenerator.getNextReferenceId();
+    }
+
+    private createEntryListenerToKey(name: string, keyData: Data, includeValue: boolean): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return MultiMapAddEntryListenerToKeyCodec.encodeRequest(name, keyData, includeValue, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return MultiMapAddEntryListenerToKeyCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return MultiMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return MultiMapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
+    }
+
+    private createEntryListener(name: string, includeValue: boolean): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return MultiMapAddEntryListenerCodec.encodeRequest(name, includeValue, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return MultiMapAddEntryListenerCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return MultiMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return MultiMapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
     }
 }

--- a/src/proxy/NearCachedMapProxy.ts
+++ b/src/proxy/NearCachedMapProxy.ts
@@ -9,6 +9,8 @@ import ClientMessage = require('../ClientMessage');
 import {InvalidationAwareWrapper} from '../nearcache/InvalidationAwareWrapper';
 import {KeyStateMarker, TrueKeyStateMarker} from '../nearcache/KeyStateMarker';
 import {DataKeyedHashMap} from '../DataStoreHashMap';
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
+import {MapRemoveEntryListenerCodec} from '../codec/MapRemoveEntryListenerCodec';
 
 export class NearCachedMapProxy<K, V> extends MapProxy<K, V> {
 
@@ -226,13 +228,27 @@ export class NearCachedMapProxy<K, V> extends MapProxy<K, V> {
             });
         };
 
-        let localOnly = this.client.getListenerService().isLocalOnlyListener();
-        let listenerRequest = MapAddNearCacheEntryListenerCodec.encodeRequest(this.name, EntryEventType.INVALIDATION, localOnly);
-        return this.client.getListenerService().registerListener(
-            listenerRequest,
-            (m: ClientMessage) => { MapAddNearCacheEntryListenerCodec.handle(m, invalidationHandler, invalidationBatchHandler); },
-            (m: ClientMessage) => { return MapAddNearCacheEntryListenerCodec.decodeResponse(m)['response']; }
-        );
+        let codec = this.createInvalidationListenerCodec(this.name, EntryEventType.INVALIDATION);
+        return this.client.getListenerService().registerListener(codec,
+            (m: ClientMessage) => { MapAddNearCacheEntryListenerCodec.handle(m, invalidationHandler, invalidationBatchHandler); }
+            );
+    }
+
+    private createInvalidationListenerCodec(name: string, flags: number): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return MapAddNearCacheEntryListenerCodec.encodeRequest(name, flags, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return MapAddNearCacheEntryListenerCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return MapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return MapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
     }
 
 }

--- a/src/proxy/NearCachedMapProxy.ts
+++ b/src/proxy/NearCachedMapProxy.ts
@@ -244,9 +244,6 @@ export class NearCachedMapProxy<K, V> extends MapProxy<K, V> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return MapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return MapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -154,11 +154,7 @@ class ProxyManager {
         let encodeFunc = (serverKey: string) => {
             return ClientRemoveDistributedObjectListenerCodec.encodeRequest(serverKey);
         };
-        return this.client.getListenerService().deregisterListener(
-            encodeFunc,
-            ClientRemoveDistributedObjectListenerCodec.decodeResponse,
-            listenerId
-        );
+        return this.client.getListenerService().deregisterListener(encodeFunc, listenerId);
     }
 }
 export = ProxyManager;

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -162,9 +162,6 @@ class ProxyManager {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return ClientRemoveDistributedObjectListenerCodec.encodeRequest(listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return ClientRemoveDistributedObjectListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/QueueProxy.ts
+++ b/src/proxy/QueueProxy.ts
@@ -25,6 +25,7 @@ import {QueueAddListenerCodec} from '../codec/QueueAddListenerCodec';
 import {QueueRemoveListenerCodec} from '../codec/QueueRemoveListenerCodec';
 import {IllegalStateError} from '../HazelcastError';
 import ClientMessage = require('../ClientMessage');
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
 
 export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
 
@@ -48,8 +49,6 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
     }
 
     addItemListener(listener: ItemListener<E>, includeValue: boolean): Promise<string> {
-        let localOnly = this.client.getListenerService().isLocalOnlyListener();
-        let listenerRequest = QueueAddListenerCodec.encodeRequest(this.name, includeValue, localOnly);
         var handler = (message: ClientMessage) => {
             QueueAddListenerCodec.handle(message, (item: Data, uuid: string, eventType: number) => {
                 var responseObject: E;
@@ -65,7 +64,8 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
                 }
             });
         };
-        return this.client.getListenerService().registerListener(listenerRequest, handler, QueueAddListenerCodec.decodeResponse);
+        let codec = this.createEntryListener(this.name, includeValue);
+        return this.client.getListenerService().registerListener(codec, handler);
     }
 
     clear(): Promise<void> {
@@ -137,10 +137,7 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
     }
 
     removeItemListener(registrationId: string): Promise<boolean> {
-        var encodeFunc = (serverKey: string) => {
-            return QueueRemoveListenerCodec.encodeRequest(this.name, serverKey);
-        };
-        return this.client.getListenerService().deregisterListener(encodeFunc, registrationId);
+        return this.client.getListenerService().deregisterListener(registrationId);
     }
 
     retainAll(items: E[]): Promise<boolean> {
@@ -166,5 +163,22 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
             });
             return arr;
         });
+    }
+
+    private createEntryListener(name: string, includeValue: boolean): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return QueueAddListenerCodec.encodeRequest(name, includeValue, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return QueueAddListenerCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return QueueRemoveListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return QueueRemoveListenerCodec.decodeResponse(msg).response;
+            }
+        };
     }
 }

--- a/src/proxy/QueueProxy.ts
+++ b/src/proxy/QueueProxy.ts
@@ -175,9 +175,6 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return QueueRemoveListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return QueueRemoveListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/QueueProxy.ts
+++ b/src/proxy/QueueProxy.ts
@@ -140,11 +140,7 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
         var encodeFunc = (serverKey: string) => {
             return QueueRemoveListenerCodec.encodeRequest(this.name, serverKey);
         };
-        return this.client.getListenerService().deregisterListener(
-            encodeFunc,
-            QueueRemoveListenerCodec.decodeResponse,
-            registrationId
-        );
+        return this.client.getListenerService().deregisterListener(encodeFunc, registrationId);
     }
 
     retainAll(items: E[]): Promise<boolean> {

--- a/src/proxy/ReplicatedMapProxy.ts
+++ b/src/proxy/ReplicatedMapProxy.ts
@@ -141,11 +141,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
         var deregisterEncodeFunc = (serverKey: string) => {
             return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(this.name, serverKey);
         };
-        return this.client.getListenerService().deregisterListener(
-            deregisterEncodeFunc,
-            ReplicatedMapRemoveEntryListenerCodec.decodeResponse,
-            listenerId
-        );
+        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, listenerId);
     }
 
     private addEntryListenerInternal(listener: IMapListener<K, V>, predicate: Predicate,

--- a/src/proxy/ReplicatedMapProxy.ts
+++ b/src/proxy/ReplicatedMapProxy.ts
@@ -28,6 +28,7 @@ import {PartitionSpecificProxy} from './PartitionSpecificProxy';
 /* tslint:enable:max-line-length */
 import Long = require('long');
 import {ArrayComparator} from '../util/ArrayComparator';
+import {ListenerMessageCodec} from '../ListenerMessageCodec';
 
 export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements IReplicatedMap<K, V> {
 
@@ -138,10 +139,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
     }
 
     removeEntryListener(listenerId: string): Promise<boolean> {
-        var deregisterEncodeFunc = (serverKey: string) => {
-            return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(this.name, serverKey);
-        };
-        return this.client.getListenerService().deregisterListener(deregisterEncodeFunc, listenerId);
+        return this.client.getListenerService().deregisterListener(listenerId);
     }
 
     private addEntryListenerInternal(listener: IMapListener<K, V>, predicate: Predicate,
@@ -164,39 +162,96 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
                 listener[eventMethod].apply(null, eventParams);
             }
         };
-        let registerListenerRequest: ClientMessage;
         let listenerHandler: Function;
-        let registerDecodeFunc: Function;
-        let localOnly = this.client.getListenerService().isLocalOnlyListener();
+        let codec: ListenerMessageCodec;
         if (key && predicate) {
             let keyData = this.toData(key);
             let predicateData = this.toData(predicate);
-            registerListenerRequest = ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(this.name, keyData,
-                    predicateData, localOnly);
+            codec = this.createEntryListenerToKeyWithPredicate(this.name, keyData, predicateData);
             listenerHandler = ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.handle;
-            registerDecodeFunc = ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.decodeResponse;
         } else if (key && !predicate) {
             let keyData = this.toData(key);
-            registerListenerRequest = ReplicatedMapAddEntryListenerToKeyCodec.encodeRequest(this.name, keyData, localOnly);
+            codec = this.createEntryListenerToKey(this.name, keyData);
             listenerHandler = ReplicatedMapAddEntryListenerToKeyCodec.handle;
-            registerDecodeFunc = ReplicatedMapAddEntryListenerToKeyCodec.decodeResponse;
         } else if (!key && predicate) {
             let predicateData = this.toData(predicate);
-            registerListenerRequest = ReplicatedMapAddEntryListenerWithPredicateCodec.encodeRequest(this.name, predicateData,
-                localOnly);
+            codec = this.createEntryListenerWithPredicate(this.name, predicateData);
             listenerHandler = ReplicatedMapAddEntryListenerWithPredicateCodec.handle;
-            registerDecodeFunc = ReplicatedMapAddEntryListenerWithPredicateCodec.decodeResponse;
         } else {
-            registerListenerRequest = ReplicatedMapAddEntryListenerCodec.encodeRequest(this.name, localOnly);
+            codec = this.createEntryListener(this.name);
             listenerHandler = ReplicatedMapAddEntryListenerCodec.handle;
-            registerDecodeFunc = ReplicatedMapAddEntryListenerCodec.decodeResponse;
         }
-        return this.client.getListenerService().registerListener(
-            registerListenerRequest,
-            (m: ClientMessage) => {
-                listenerHandler(m, entryEventHandler, toObject);
+        return this.client.getListenerService().registerListener(codec,
+            (m: ClientMessage) => {listenerHandler(m, entryEventHandler, toObject); });
+    }
+
+    private createEntryListener(name: string): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return ReplicatedMapAddEntryListenerCodec.encodeRequest(name, localOnly);
             },
-            registerDecodeFunc
-        );
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return ReplicatedMapAddEntryListenerCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
+    }
+
+    private createEntryListenerToKey(name: string, keyData: Data): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return ReplicatedMapAddEntryListenerToKeyCodec.encodeRequest(name, keyData, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return ReplicatedMapAddEntryListenerToKeyCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
+    }
+
+    private createEntryListenerWithPredicate(name: string, predicateData: Data): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return ReplicatedMapAddEntryListenerWithPredicateCodec.encodeRequest(name, predicateData, localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return ReplicatedMapAddEntryListenerWithPredicateCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
+    }
+
+
+    private createEntryListenerToKeyWithPredicate(name: string, keyData: Data, predicateData: Data): ListenerMessageCodec {
+        return {
+            encodeAddRequest: function(localOnly: boolean): ClientMessage {
+                return ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.encodeRequest(name, keyData, predicateData,
+                    localOnly);
+            },
+            decodeAddResponse: function(msg: ClientMessage): string {
+                return ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.decodeResponse(msg).response;
+            },
+            encodeRemoveRequest: function(listenerId: string): ClientMessage {
+                return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
+            },
+            decodeRemoveResponse: function(msg: ClientMessage): boolean {
+                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
+            }
+        };
     }
 }

--- a/src/proxy/ReplicatedMapProxy.ts
+++ b/src/proxy/ReplicatedMapProxy.ts
@@ -195,9 +195,6 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -212,9 +209,6 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -229,9 +223,6 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }
@@ -248,9 +239,6 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return ReplicatedMapRemoveEntryListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return ReplicatedMapRemoveEntryListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/SetProxy.ts
+++ b/src/proxy/SetProxy.ts
@@ -111,9 +111,6 @@ export class SetProxy<E> extends PartitionSpecificProxy implements ISet<E> {
             },
             encodeRemoveRequest: function(listenerId: string): ClientMessage {
                 return SetRemoveListenerCodec.encodeRequest(name, listenerId);
-            },
-            decodeRemoveResponse: function(msg: ClientMessage): boolean {
-                return SetRemoveListenerCodec.decodeResponse(msg).response;
             }
         };
     }

--- a/src/proxy/SetProxy.ts
+++ b/src/proxy/SetProxy.ts
@@ -95,11 +95,7 @@ export class SetProxy<E> extends PartitionSpecificProxy implements ISet<E> {
         let encodeFunc = (serverKey: string) => {
             return SetRemoveListenerCodec.encodeRequest(this.name, serverKey);
         };
-        return this.client.getListenerService().deregisterListener(
-            encodeFunc,
-            SetRemoveListenerCodec.decodeResponse,
-            registrationId
-        );
+        return this.client.getListenerService().deregisterListener(encodeFunc, registrationId);
     }
 
     private serializeList(input: Array<any>): Array<Data> {


### PR DESCRIPTION
ListenerService does not check the result of RemoveListener request coming from the server.
I also refactored the code to follow Java client. So addListener method of each proxy creates a ListenerMessageCodec which has methods like encodeAddRequest. We pass this object around. It makes the interface much clearer.

One difference is that this implementation creates AddListener client-message only once, when proxy's method is invoked. It re-uses the same message for sending requests to all members.