### PR TITLE
compatibility-fix

### DIFF
--- a/src/codec/AtomicLongAddAndGetCodec.ts
+++ b/src/codec/AtomicLongAddAndGetCodec.ts
@@ -38,11 +38,14 @@ export class AtomicLongAddAndGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongAlterAndGetCodec.ts
+++ b/src/codec/AtomicLongAlterAndGetCodec.ts
@@ -38,11 +38,14 @@ export class AtomicLongAlterAndGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongApplyCodec.ts
+++ b/src/codec/AtomicLongApplyCodec.ts
@@ -38,14 +38,17 @@ export class AtomicLongApplyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongCompareAndSetCodec.ts
+++ b/src/codec/AtomicLongCompareAndSetCodec.ts
@@ -40,11 +40,14 @@ export class AtomicLongCompareAndSetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongDecrementAndGetCodec.ts
+++ b/src/codec/AtomicLongDecrementAndGetCodec.ts
@@ -36,11 +36,14 @@ export class AtomicLongDecrementAndGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongGetAndAddCodec.ts
+++ b/src/codec/AtomicLongGetAndAddCodec.ts
@@ -38,11 +38,14 @@ export class AtomicLongGetAndAddCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongGetAndAlterCodec.ts
+++ b/src/codec/AtomicLongGetAndAlterCodec.ts
@@ -38,11 +38,14 @@ export class AtomicLongGetAndAlterCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongGetAndIncrementCodec.ts
+++ b/src/codec/AtomicLongGetAndIncrementCodec.ts
@@ -36,11 +36,14 @@ export class AtomicLongGetAndIncrementCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongGetAndSetCodec.ts
+++ b/src/codec/AtomicLongGetAndSetCodec.ts
@@ -38,11 +38,14 @@ export class AtomicLongGetAndSetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongGetCodec.ts
+++ b/src/codec/AtomicLongGetCodec.ts
@@ -36,11 +36,14 @@ export class AtomicLongGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicLongIncrementAndGetCodec.ts
+++ b/src/codec/AtomicLongIncrementAndGetCodec.ts
@@ -36,11 +36,14 @@ export class AtomicLongIncrementAndGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceAlterAndGetCodec.ts
+++ b/src/codec/AtomicReferenceAlterAndGetCodec.ts
@@ -38,14 +38,17 @@ export class AtomicReferenceAlterAndGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceApplyCodec.ts
+++ b/src/codec/AtomicReferenceApplyCodec.ts
@@ -38,14 +38,17 @@ export class AtomicReferenceApplyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceCompareAndSetCodec.ts
+++ b/src/codec/AtomicReferenceCompareAndSetCodec.ts
@@ -52,11 +52,14 @@ export class AtomicReferenceCompareAndSetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceContainsCodec.ts
+++ b/src/codec/AtomicReferenceContainsCodec.ts
@@ -44,11 +44,14 @@ export class AtomicReferenceContainsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceGetAndAlterCodec.ts
+++ b/src/codec/AtomicReferenceGetAndAlterCodec.ts
@@ -38,14 +38,17 @@ export class AtomicReferenceGetAndAlterCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceGetAndSetCodec.ts
+++ b/src/codec/AtomicReferenceGetAndSetCodec.ts
@@ -44,14 +44,17 @@ export class AtomicReferenceGetAndSetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceGetCodec.ts
+++ b/src/codec/AtomicReferenceGetCodec.ts
@@ -36,14 +36,17 @@ export class AtomicReferenceGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceIsNullCodec.ts
+++ b/src/codec/AtomicReferenceIsNullCodec.ts
@@ -36,11 +36,14 @@ export class AtomicReferenceIsNullCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/AtomicReferenceSetAndGetCodec.ts
+++ b/src/codec/AtomicReferenceSetAndGetCodec.ts
@@ -44,14 +44,17 @@ export class AtomicReferenceSetAndGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheAddEntryListenerCodec.ts
+++ b/src/codec/CacheAddEntryListenerCodec.ts
@@ -38,11 +38,14 @@ export class CacheAddEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventCache: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/CacheAddInvalidationListenerCodec.ts
+++ b/src/codec/CacheAddInvalidationListenerCodec.ts
@@ -38,11 +38,14 @@ export class CacheAddInvalidationListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventCacheinvalidation: any, handleEventCachebatchinvalidation: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/CacheAddNearCacheInvalidationListenerCodec.ts
+++ b/src/codec/CacheAddNearCacheInvalidationListenerCodec.ts
@@ -38,11 +38,17 @@ export class CacheAddNearCacheInvalidationListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventCacheinvalidation: any, handleEventCachebatchinvalidation: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/CacheAddPartitionLostListenerCodec.ts
+++ b/src/codec/CacheAddPartitionLostListenerCodec.ts
@@ -38,11 +38,14 @@ export class CacheAddPartitionLostListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventCachepartitionlost: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/CacheAssignAndGetUuidsCodec.ts
+++ b/src/codec/CacheAssignAndGetUuidsCodec.ts
@@ -34,8 +34,14 @@ export class CacheAssignAndGetUuidsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'partitionUuidList': null};
+        // Decode response from client message
+        var parameters: any = {
+            'partitionUuidList': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var partitionUuidListSize = clientMessage.readInt32();
         var partitionUuidList: any = [];
@@ -49,8 +55,8 @@ export class CacheAssignAndGetUuidsCodec {
             partitionUuidList.push(partitionUuidListItem)
         }
         parameters['partitionUuidList'] = partitionUuidList;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheContainsKeyCodec.ts
+++ b/src/codec/CacheContainsKeyCodec.ts
@@ -38,11 +38,14 @@ export class CacheContainsKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheCreateConfigCodec.ts
+++ b/src/codec/CacheCreateConfigCodec.ts
@@ -38,14 +38,17 @@ export class CacheCreateConfigCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheEntryProcessorCodec.ts
+++ b/src/codec/CacheEntryProcessorCodec.ts
@@ -53,14 +53,17 @@ export class CacheEntryProcessorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheEventJournalReadCodec.ts
+++ b/src/codec/CacheEventJournalReadCodec.ts
@@ -58,9 +58,18 @@ export class CacheEventJournalReadCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'readCount': null, 'items': null, 'itemSeqs': null};
+        // Decode response from client message
+        var parameters: any = {
+            'readCount': null,
+            'items': null,
+            'itemSeqs': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['readCount'] = clientMessage.readInt32();
+
 
         var itemsSize = clientMessage.readInt32();
         var items: any = [];
@@ -70,6 +79,7 @@ export class CacheEventJournalReadCodec {
             items.push(itemsItem)
         }
         parameters['items'] = items;
+
 
         if (clientMessage.readBoolean() !== true) {
 
@@ -82,8 +92,8 @@ export class CacheEventJournalReadCodec {
             }
             parameters['itemSeqs'] = itemSeqs;
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheEventJournalSubscribeCodec.ts
+++ b/src/codec/CacheEventJournalSubscribeCodec.ts
@@ -36,12 +36,20 @@ export class CacheEventJournalSubscribeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'oldestSequence': null, 'newestSequence': null};
-        parameters['oldestSequence'] = clientMessage.readLong();
-        parameters['newestSequence'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'oldestSequence': null,
+            'newestSequence': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['oldestSequence'] = clientMessage.readLong();
+
+        parameters['newestSequence'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheFetchNearCacheInvalidationMetadataCodec.ts
+++ b/src/codec/CacheFetchNearCacheInvalidationMetadataCodec.ts
@@ -47,8 +47,15 @@ export class CacheFetchNearCacheInvalidationMetadataCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'namePartitionSequenceList': null, 'partitionUuidList': null};
+        // Decode response from client message
+        var parameters: any = {
+            'namePartitionSequenceList': null,
+            'partitionUuidList': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var namePartitionSequenceListSize = clientMessage.readInt32();
         var namePartitionSequenceList: any = [];
@@ -74,6 +81,7 @@ export class CacheFetchNearCacheInvalidationMetadataCodec {
         }
         parameters['namePartitionSequenceList'] = namePartitionSequenceList;
 
+
         var partitionUuidListSize = clientMessage.readInt32();
         var partitionUuidList: any = [];
         for (var partitionUuidListIndex = 0; partitionUuidListIndex < partitionUuidListSize; partitionUuidListIndex++) {
@@ -86,8 +94,8 @@ export class CacheFetchNearCacheInvalidationMetadataCodec {
             partitionUuidList.push(partitionUuidListItem)
         }
         parameters['partitionUuidList'] = partitionUuidList;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheGetAllCodec.ts
+++ b/src/codec/CacheGetAllCodec.ts
@@ -55,8 +55,11 @@ export class CacheGetAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -70,8 +73,8 @@ export class CacheGetAllCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheGetAndRemoveCodec.ts
+++ b/src/codec/CacheGetAndRemoveCodec.ts
@@ -40,14 +40,17 @@ export class CacheGetAndRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheGetAndReplaceCodec.ts
+++ b/src/codec/CacheGetAndReplaceCodec.ts
@@ -50,14 +50,17 @@ export class CacheGetAndReplaceCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheGetCodec.ts
+++ b/src/codec/CacheGetCodec.ts
@@ -46,14 +46,17 @@ export class CacheGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheGetConfigCodec.ts
+++ b/src/codec/CacheGetConfigCodec.ts
@@ -38,14 +38,17 @@ export class CacheGetConfigCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheIterateCodec.ts
+++ b/src/codec/CacheIterateCodec.ts
@@ -42,9 +42,14 @@ export class CacheIterateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'tableIndex': null, 'keys': null};
+        // Decode response from client message
+        var parameters: any = {
+            'tableIndex': null,
+            'keys': null
+        };
+
         parameters['tableIndex'] = clientMessage.readInt32();
+
 
         var keysSize = clientMessage.readInt32();
         var keys: any = [];
@@ -54,8 +59,8 @@ export class CacheIterateCodec {
             keys.push(keysItem)
         }
         parameters['keys'] = keys;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheIterateEntriesCodec.ts
+++ b/src/codec/CacheIterateEntriesCodec.ts
@@ -42,9 +42,17 @@ export class CacheIterateEntriesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'tableIndex': null, 'entries': null};
+        // Decode response from client message
+        var parameters: any = {
+            'tableIndex': null,
+            'entries': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['tableIndex'] = clientMessage.readInt32();
+
 
         var entriesSize = clientMessage.readInt32();
         var entries: any = [];
@@ -58,8 +66,8 @@ export class CacheIterateEntriesCodec {
             entries.push(entriesItem)
         }
         parameters['entries'] = entries;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CachePutCodec.ts
+++ b/src/codec/CachePutCodec.ts
@@ -52,14 +52,17 @@ export class CachePutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CachePutIfAbsentCodec.ts
+++ b/src/codec/CachePutIfAbsentCodec.ts
@@ -50,11 +50,14 @@ export class CachePutIfAbsentCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheRemoveCodec.ts
+++ b/src/codec/CacheRemoveCodec.ts
@@ -48,11 +48,14 @@ export class CacheRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheRemoveEntryListenerCodec.ts
+++ b/src/codec/CacheRemoveEntryListenerCodec.ts
@@ -38,11 +38,14 @@ export class CacheRemoveEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheRemoveInvalidationListenerCodec.ts
+++ b/src/codec/CacheRemoveInvalidationListenerCodec.ts
@@ -38,11 +38,14 @@ export class CacheRemoveInvalidationListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheRemovePartitionLostListenerCodec.ts
+++ b/src/codec/CacheRemovePartitionLostListenerCodec.ts
@@ -38,11 +38,14 @@ export class CacheRemovePartitionLostListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CacheReplaceCodec.ts
+++ b/src/codec/CacheReplaceCodec.ts
@@ -58,14 +58,17 @@ export class CacheReplaceCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/CacheSizeCodec.ts
+++ b/src/codec/CacheSizeCodec.ts
@@ -36,11 +36,14 @@ export class CacheSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/CardinalityEstimatorEstimateCodec.ts
+++ b/src/codec/CardinalityEstimatorEstimateCodec.ts
@@ -36,11 +36,17 @@ export class CardinalityEstimatorEstimateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/ClientAddDistributedObjectListenerCodec.ts
+++ b/src/codec/ClientAddDistributedObjectListenerCodec.ts
@@ -36,11 +36,14 @@ export class ClientAddDistributedObjectListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventDistributedobject: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ClientAddMembershipListenerCodec.ts
+++ b/src/codec/ClientAddMembershipListenerCodec.ts
@@ -36,11 +36,14 @@ export class ClientAddMembershipListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventMember: any, handleEventMemberlist: any, handleEventMemberattributechange: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ClientAddPartitionLostListenerCodec.ts
+++ b/src/codec/ClientAddPartitionLostListenerCodec.ts
@@ -36,11 +36,14 @@ export class ClientAddPartitionLostListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventPartitionlost: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ClientAuthenticationCodec.ts
+++ b/src/codec/ClientAuthenticationCodec.ts
@@ -62,7 +62,7 @@ export class ClientAuthenticationCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
+        // Decode response from client message
         var parameters: any = {
             'status': null,
             'address': null,
@@ -72,21 +72,31 @@ export class ClientAuthenticationCodec {
             'serverHazelcastVersion': null,
             'clientUnregisteredMembers': null
         };
+
         parameters['status'] = clientMessage.readByte();
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['address'] = AddressCodec.decode(clientMessage, toObjectFunction);
         }
 
+
         if (clientMessage.readBoolean() !== true) {
             parameters['uuid'] = clientMessage.readString();
         }
 
+
         if (clientMessage.readBoolean() !== true) {
             parameters['ownerUuid'] = clientMessage.readString();
         }
+
         parameters['serializationVersion'] = clientMessage.readByte();
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['serverHazelcastVersion'] = clientMessage.readString();
+        parameters.serverHazelcastVersionExist = true;
 
         if (clientMessage.readBoolean() !== true) {
 
@@ -99,8 +109,8 @@ export class ClientAuthenticationCodec {
             }
             parameters['clientUnregisteredMembers'] = clientUnregisteredMembers;
         }
+        parameters.clientUnregisteredMembersExist = true;
         return parameters;
-
     }
 
 

--- a/src/codec/ClientAuthenticationCustomCodec.ts
+++ b/src/codec/ClientAuthenticationCustomCodec.ts
@@ -60,7 +60,7 @@ export class ClientAuthenticationCustomCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
+        // Decode response from client message
         var parameters: any = {
             'status': null,
             'address': null,
@@ -70,21 +70,31 @@ export class ClientAuthenticationCustomCodec {
             'serverHazelcastVersion': null,
             'clientUnregisteredMembers': null
         };
+
         parameters['status'] = clientMessage.readByte();
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['address'] = AddressCodec.decode(clientMessage, toObjectFunction);
         }
 
+
         if (clientMessage.readBoolean() !== true) {
             parameters['uuid'] = clientMessage.readString();
         }
 
+
         if (clientMessage.readBoolean() !== true) {
             parameters['ownerUuid'] = clientMessage.readString();
         }
+
         parameters['serializationVersion'] = clientMessage.readByte();
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['serverHazelcastVersion'] = clientMessage.readString();
+        parameters.serverHazelcastVersionExist = true;
 
         if (clientMessage.readBoolean() !== true) {
 
@@ -97,8 +107,8 @@ export class ClientAuthenticationCustomCodec {
             }
             parameters['clientUnregisteredMembers'] = clientUnregisteredMembers;
         }
+        parameters.clientUnregisteredMembersExist = true;
         return parameters;
-
     }
 
 

--- a/src/codec/ClientGetDistributedObjectsCodec.ts
+++ b/src/codec/ClientGetDistributedObjectsCodec.ts
@@ -34,8 +34,11 @@ export class ClientGetDistributedObjectsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -45,8 +48,8 @@ export class ClientGetDistributedObjectsCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ClientGetPartitionsCodec.ts
+++ b/src/codec/ClientGetPartitionsCodec.ts
@@ -34,8 +34,12 @@ export class ClientGetPartitionsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'partitions': null, 'partitionStateVersion': null};
+        // Decode response from client message
+        var parameters: any = {
+            'partitions': null,
+            'partitionStateVersion': null
+        };
+
 
         var partitionsSize = clientMessage.readInt32();
         var partitions: any = [];
@@ -56,9 +60,13 @@ export class ClientGetPartitionsCodec {
             partitions.push(partitionsItem)
         }
         parameters['partitions'] = partitions;
-        parameters['partitionStateVersion'] = clientMessage.readInt32();
-        return parameters;
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['partitionStateVersion'] = clientMessage.readInt32();
+        parameters.partitionStateVersionExist = true;
+        return parameters;
     }
 
 

--- a/src/codec/ClientRemoveDistributedObjectListenerCodec.ts
+++ b/src/codec/ClientRemoveDistributedObjectListenerCodec.ts
@@ -36,11 +36,14 @@ export class ClientRemoveDistributedObjectListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ClientRemovePartitionLostListenerCodec.ts
+++ b/src/codec/ClientRemovePartitionLostListenerCodec.ts
@@ -36,11 +36,14 @@ export class ClientRemovePartitionLostListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ConditionAwaitCodec.ts
+++ b/src/codec/ConditionAwaitCodec.ts
@@ -44,11 +44,14 @@ export class ConditionAwaitCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ContinuousQueryAddListenerCodec.ts
+++ b/src/codec/ContinuousQueryAddListenerCodec.ts
@@ -38,11 +38,14 @@ export class ContinuousQueryAddListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventQuerycachesingle: any, handleEventQuerycachebatch: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ContinuousQueryDestroyCacheCodec.ts
+++ b/src/codec/ContinuousQueryDestroyCacheCodec.ts
@@ -38,11 +38,14 @@ export class ContinuousQueryDestroyCacheCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ContinuousQueryMadePublishableCodec.ts
+++ b/src/codec/ContinuousQueryMadePublishableCodec.ts
@@ -38,11 +38,14 @@ export class ContinuousQueryMadePublishableCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ContinuousQueryPublisherCreateCodec.ts
+++ b/src/codec/ContinuousQueryPublisherCreateCodec.ts
@@ -50,8 +50,11 @@ export class ContinuousQueryPublisherCreateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -61,8 +64,8 @@ export class ContinuousQueryPublisherCreateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ContinuousQueryPublisherCreateWithValueCodec.ts
+++ b/src/codec/ContinuousQueryPublisherCreateWithValueCodec.ts
@@ -50,8 +50,11 @@ export class ContinuousQueryPublisherCreateWithValueCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -65,8 +68,8 @@ export class ContinuousQueryPublisherCreateWithValueCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ContinuousQuerySetReadCursorCodec.ts
+++ b/src/codec/ContinuousQuerySetReadCursorCodec.ts
@@ -40,11 +40,14 @@ export class ContinuousQuerySetReadCursorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CountDownLatchAwaitCodec.ts
+++ b/src/codec/CountDownLatchAwaitCodec.ts
@@ -38,11 +38,14 @@ export class CountDownLatchAwaitCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/CountDownLatchGetCountCodec.ts
+++ b/src/codec/CountDownLatchGetCountCodec.ts
@@ -36,11 +36,14 @@ export class CountDownLatchGetCountCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/CountDownLatchTrySetCountCodec.ts
+++ b/src/codec/CountDownLatchTrySetCountCodec.ts
@@ -38,11 +38,14 @@ export class CountDownLatchTrySetCountCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/DurableExecutorIsShutdownCodec.ts
+++ b/src/codec/DurableExecutorIsShutdownCodec.ts
@@ -36,11 +36,17 @@ export class DurableExecutorIsShutdownCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/DurableExecutorRetrieveAndDisposeResultCodec.ts
+++ b/src/codec/DurableExecutorRetrieveAndDisposeResultCodec.ts
@@ -38,14 +38,20 @@ export class DurableExecutorRetrieveAndDisposeResultCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/DurableExecutorRetrieveResultCodec.ts
+++ b/src/codec/DurableExecutorRetrieveResultCodec.ts
@@ -38,14 +38,20 @@ export class DurableExecutorRetrieveResultCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/DurableExecutorSubmitToPartitionCodec.ts
+++ b/src/codec/DurableExecutorSubmitToPartitionCodec.ts
@@ -38,11 +38,17 @@ export class DurableExecutorSubmitToPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/ExecutorServiceCancelOnAddressCodec.ts
+++ b/src/codec/ExecutorServiceCancelOnAddressCodec.ts
@@ -40,11 +40,14 @@ export class ExecutorServiceCancelOnAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ExecutorServiceCancelOnPartitionCodec.ts
+++ b/src/codec/ExecutorServiceCancelOnPartitionCodec.ts
@@ -40,11 +40,14 @@ export class ExecutorServiceCancelOnPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ExecutorServiceIsShutdownCodec.ts
+++ b/src/codec/ExecutorServiceIsShutdownCodec.ts
@@ -36,11 +36,14 @@ export class ExecutorServiceIsShutdownCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ExecutorServiceSubmitToAddressCodec.ts
+++ b/src/codec/ExecutorServiceSubmitToAddressCodec.ts
@@ -42,14 +42,17 @@ export class ExecutorServiceSubmitToAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ExecutorServiceSubmitToPartitionCodec.ts
+++ b/src/codec/ExecutorServiceSubmitToPartitionCodec.ts
@@ -42,14 +42,17 @@ export class ExecutorServiceSubmitToPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListAddAllCodec.ts
+++ b/src/codec/ListAddAllCodec.ts
@@ -47,11 +47,14 @@ export class ListAddAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListAddAllWithIndexCodec.ts
+++ b/src/codec/ListAddAllWithIndexCodec.ts
@@ -49,11 +49,14 @@ export class ListAddAllWithIndexCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListAddCodec.ts
+++ b/src/codec/ListAddCodec.ts
@@ -38,11 +38,14 @@ export class ListAddCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListAddListenerCodec.ts
+++ b/src/codec/ListAddListenerCodec.ts
@@ -40,11 +40,14 @@ export class ListAddListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventItem: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ListCompareAndRemoveAllCodec.ts
+++ b/src/codec/ListCompareAndRemoveAllCodec.ts
@@ -47,11 +47,14 @@ export class ListCompareAndRemoveAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListCompareAndRetainAllCodec.ts
+++ b/src/codec/ListCompareAndRetainAllCodec.ts
@@ -47,11 +47,14 @@ export class ListCompareAndRetainAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListContainsAllCodec.ts
+++ b/src/codec/ListContainsAllCodec.ts
@@ -47,11 +47,14 @@ export class ListContainsAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListContainsCodec.ts
+++ b/src/codec/ListContainsCodec.ts
@@ -38,11 +38,14 @@ export class ListContainsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListGetAllCodec.ts
+++ b/src/codec/ListGetAllCodec.ts
@@ -36,8 +36,11 @@ export class ListGetAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class ListGetAllCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListGetCodec.ts
+++ b/src/codec/ListGetCodec.ts
@@ -38,14 +38,17 @@ export class ListGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListIndexOfCodec.ts
+++ b/src/codec/ListIndexOfCodec.ts
@@ -38,11 +38,14 @@ export class ListIndexOfCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListIsEmptyCodec.ts
+++ b/src/codec/ListIsEmptyCodec.ts
@@ -36,11 +36,14 @@ export class ListIsEmptyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListIteratorCodec.ts
+++ b/src/codec/ListIteratorCodec.ts
@@ -36,8 +36,11 @@ export class ListIteratorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class ListIteratorCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListLastIndexOfCodec.ts
+++ b/src/codec/ListLastIndexOfCodec.ts
@@ -38,11 +38,14 @@ export class ListLastIndexOfCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListListIteratorCodec.ts
+++ b/src/codec/ListListIteratorCodec.ts
@@ -38,8 +38,11 @@ export class ListListIteratorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -49,8 +52,8 @@ export class ListListIteratorCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListRemoveCodec.ts
+++ b/src/codec/ListRemoveCodec.ts
@@ -38,11 +38,14 @@ export class ListRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListRemoveListenerCodec.ts
+++ b/src/codec/ListRemoveListenerCodec.ts
@@ -38,11 +38,14 @@ export class ListRemoveListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListRemoveWithIndexCodec.ts
+++ b/src/codec/ListRemoveWithIndexCodec.ts
@@ -38,14 +38,17 @@ export class ListRemoveWithIndexCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListSetCodec.ts
+++ b/src/codec/ListSetCodec.ts
@@ -40,14 +40,17 @@ export class ListSetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ListSizeCodec.ts
+++ b/src/codec/ListSizeCodec.ts
@@ -36,11 +36,14 @@ export class ListSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/ListSubCodec.ts
+++ b/src/codec/ListSubCodec.ts
@@ -40,8 +40,11 @@ export class ListSubCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class ListSubCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/LockGetLockCountCodec.ts
+++ b/src/codec/LockGetLockCountCodec.ts
@@ -36,11 +36,14 @@ export class LockGetLockCountCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/LockGetRemainingLeaseTimeCodec.ts
+++ b/src/codec/LockGetRemainingLeaseTimeCodec.ts
@@ -36,11 +36,14 @@ export class LockGetRemainingLeaseTimeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/LockIsLockedByCurrentThreadCodec.ts
+++ b/src/codec/LockIsLockedByCurrentThreadCodec.ts
@@ -38,11 +38,14 @@ export class LockIsLockedByCurrentThreadCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/LockIsLockedCodec.ts
+++ b/src/codec/LockIsLockedCodec.ts
@@ -36,11 +36,14 @@ export class LockIsLockedCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/LockTryLockCodec.ts
+++ b/src/codec/LockTryLockCodec.ts
@@ -44,11 +44,14 @@ export class LockTryLockCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapAddEntryListenerCodec.ts
+++ b/src/codec/MapAddEntryListenerCodec.ts
@@ -42,11 +42,14 @@ export class MapAddEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAddEntryListenerToKeyCodec.ts
+++ b/src/codec/MapAddEntryListenerToKeyCodec.ts
@@ -44,11 +44,14 @@ export class MapAddEntryListenerToKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAddEntryListenerToKeyWithPredicateCodec.ts
+++ b/src/codec/MapAddEntryListenerToKeyWithPredicateCodec.ts
@@ -46,11 +46,14 @@ export class MapAddEntryListenerToKeyWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAddEntryListenerWithPredicateCodec.ts
+++ b/src/codec/MapAddEntryListenerWithPredicateCodec.ts
@@ -44,11 +44,14 @@ export class MapAddEntryListenerWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAddInterceptorCodec.ts
+++ b/src/codec/MapAddInterceptorCodec.ts
@@ -38,11 +38,14 @@ export class MapAddInterceptorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapAddNearCacheEntryListenerCodec.ts
+++ b/src/codec/MapAddNearCacheEntryListenerCodec.ts
@@ -40,11 +40,14 @@ export class MapAddNearCacheEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventImapinvalidation: any, handleEventImapbatchinvalidation: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAddNearCacheInvalidationListenerCodec.ts
+++ b/src/codec/MapAddNearCacheInvalidationListenerCodec.ts
@@ -40,11 +40,17 @@ export class MapAddNearCacheInvalidationListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventImapinvalidation: any, handleEventImapbatchinvalidation: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAddPartitionLostListenerCodec.ts
+++ b/src/codec/MapAddPartitionLostListenerCodec.ts
@@ -38,11 +38,14 @@ export class MapAddPartitionLostListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventMappartitionlost: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MapAggregateCodec.ts
+++ b/src/codec/MapAggregateCodec.ts
@@ -38,14 +38,20 @@ export class MapAggregateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapAggregateWithPredicateCodec.ts
+++ b/src/codec/MapAggregateWithPredicateCodec.ts
@@ -40,14 +40,20 @@ export class MapAggregateWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapAssignAndGetUuidsCodec.ts
+++ b/src/codec/MapAssignAndGetUuidsCodec.ts
@@ -34,8 +34,14 @@ export class MapAssignAndGetUuidsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'partitionUuidList': null};
+        // Decode response from client message
+        var parameters: any = {
+            'partitionUuidList': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var partitionUuidListSize = clientMessage.readInt32();
         var partitionUuidList: any = [];
@@ -49,8 +55,8 @@ export class MapAssignAndGetUuidsCodec {
             partitionUuidList.push(partitionUuidListItem)
         }
         parameters['partitionUuidList'] = partitionUuidList;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapContainsKeyCodec.ts
+++ b/src/codec/MapContainsKeyCodec.ts
@@ -40,11 +40,14 @@ export class MapContainsKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapContainsValueCodec.ts
+++ b/src/codec/MapContainsValueCodec.ts
@@ -38,11 +38,14 @@ export class MapContainsValueCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapEntriesWithPagingPredicateCodec.ts
+++ b/src/codec/MapEntriesWithPagingPredicateCodec.ts
@@ -38,8 +38,11 @@ export class MapEntriesWithPagingPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class MapEntriesWithPagingPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapEntriesWithPredicateCodec.ts
+++ b/src/codec/MapEntriesWithPredicateCodec.ts
@@ -38,8 +38,11 @@ export class MapEntriesWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class MapEntriesWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapEntrySetCodec.ts
+++ b/src/codec/MapEntrySetCodec.ts
@@ -36,8 +36,11 @@ export class MapEntrySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class MapEntrySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapEventJournalReadCodec.ts
+++ b/src/codec/MapEventJournalReadCodec.ts
@@ -58,9 +58,18 @@ export class MapEventJournalReadCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'readCount': null, 'items': null, 'itemSeqs': null};
+        // Decode response from client message
+        var parameters: any = {
+            'readCount': null,
+            'items': null,
+            'itemSeqs': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['readCount'] = clientMessage.readInt32();
+
 
         var itemsSize = clientMessage.readInt32();
         var items: any = [];
@@ -70,6 +79,7 @@ export class MapEventJournalReadCodec {
             items.push(itemsItem)
         }
         parameters['items'] = items;
+
 
         if (clientMessage.readBoolean() !== true) {
 
@@ -82,8 +92,8 @@ export class MapEventJournalReadCodec {
             }
             parameters['itemSeqs'] = itemSeqs;
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapEventJournalSubscribeCodec.ts
+++ b/src/codec/MapEventJournalSubscribeCodec.ts
@@ -36,12 +36,20 @@ export class MapEventJournalSubscribeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'oldestSequence': null, 'newestSequence': null};
-        parameters['oldestSequence'] = clientMessage.readLong();
-        parameters['newestSequence'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'oldestSequence': null,
+            'newestSequence': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['oldestSequence'] = clientMessage.readLong();
+
+        parameters['newestSequence'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapEvictCodec.ts
+++ b/src/codec/MapEvictCodec.ts
@@ -40,11 +40,14 @@ export class MapEvictCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapExecuteOnAllKeysCodec.ts
+++ b/src/codec/MapExecuteOnAllKeysCodec.ts
@@ -38,8 +38,11 @@ export class MapExecuteOnAllKeysCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class MapExecuteOnAllKeysCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapExecuteOnKeyCodec.ts
+++ b/src/codec/MapExecuteOnKeyCodec.ts
@@ -42,14 +42,17 @@ export class MapExecuteOnKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapExecuteOnKeysCodec.ts
+++ b/src/codec/MapExecuteOnKeysCodec.ts
@@ -49,8 +49,11 @@ export class MapExecuteOnKeysCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -64,8 +67,8 @@ export class MapExecuteOnKeysCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapExecuteWithPredicateCodec.ts
+++ b/src/codec/MapExecuteWithPredicateCodec.ts
@@ -40,8 +40,11 @@ export class MapExecuteWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -55,8 +58,8 @@ export class MapExecuteWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapFetchEntriesCodec.ts
+++ b/src/codec/MapFetchEntriesCodec.ts
@@ -42,9 +42,17 @@ export class MapFetchEntriesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'tableIndex': null, 'entries': null};
+        // Decode response from client message
+        var parameters: any = {
+            'tableIndex': null,
+            'entries': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['tableIndex'] = clientMessage.readInt32();
+
 
         var entriesSize = clientMessage.readInt32();
         var entries: any = [];
@@ -58,8 +66,8 @@ export class MapFetchEntriesCodec {
             entries.push(entriesItem)
         }
         parameters['entries'] = entries;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapFetchKeysCodec.ts
+++ b/src/codec/MapFetchKeysCodec.ts
@@ -42,9 +42,17 @@ export class MapFetchKeysCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'tableIndex': null, 'keys': null};
+        // Decode response from client message
+        var parameters: any = {
+            'tableIndex': null,
+            'keys': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
         parameters['tableIndex'] = clientMessage.readInt32();
+
 
         var keysSize = clientMessage.readInt32();
         var keys: any = [];
@@ -54,8 +62,8 @@ export class MapFetchKeysCodec {
             keys.push(keysItem)
         }
         parameters['keys'] = keys;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapFetchNearCacheInvalidationMetadataCodec.ts
+++ b/src/codec/MapFetchNearCacheInvalidationMetadataCodec.ts
@@ -47,8 +47,15 @@ export class MapFetchNearCacheInvalidationMetadataCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'namePartitionSequenceList': null, 'partitionUuidList': null};
+        // Decode response from client message
+        var parameters: any = {
+            'namePartitionSequenceList': null,
+            'partitionUuidList': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var namePartitionSequenceListSize = clientMessage.readInt32();
         var namePartitionSequenceList: any = [];
@@ -74,6 +81,7 @@ export class MapFetchNearCacheInvalidationMetadataCodec {
         }
         parameters['namePartitionSequenceList'] = namePartitionSequenceList;
 
+
         var partitionUuidListSize = clientMessage.readInt32();
         var partitionUuidList: any = [];
         for (var partitionUuidListIndex = 0; partitionUuidListIndex < partitionUuidListSize; partitionUuidListIndex++) {
@@ -86,8 +94,8 @@ export class MapFetchNearCacheInvalidationMetadataCodec {
             partitionUuidList.push(partitionUuidListItem)
         }
         parameters['partitionUuidList'] = partitionUuidList;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapFetchWithQueryCodec.ts
+++ b/src/codec/MapFetchWithQueryCodec.ts
@@ -44,8 +44,15 @@ export class MapFetchWithQueryCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'results': null, 'nextTableIndexToReadFrom': null};
+        // Decode response from client message
+        var parameters: any = {
+            'results': null,
+            'nextTableIndexToReadFrom': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var resultsSize = clientMessage.readInt32();
         var results: any = [];
@@ -55,9 +62,10 @@ export class MapFetchWithQueryCodec {
             results.push(resultsItem)
         }
         parameters['results'] = results;
-        parameters['nextTableIndexToReadFrom'] = clientMessage.readInt32();
-        return parameters;
 
+        parameters['nextTableIndexToReadFrom'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapGetAllCodec.ts
+++ b/src/codec/MapGetAllCodec.ts
@@ -47,8 +47,11 @@ export class MapGetAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -62,8 +65,8 @@ export class MapGetAllCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapGetCodec.ts
+++ b/src/codec/MapGetCodec.ts
@@ -40,14 +40,17 @@ export class MapGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapGetEntryViewCodec.ts
+++ b/src/codec/MapGetEntryViewCodec.ts
@@ -40,14 +40,17 @@ export class MapGetEntryViewCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = EntryViewCodec.decode(clientMessage, toObjectFunction);
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapIsEmptyCodec.ts
+++ b/src/codec/MapIsEmptyCodec.ts
@@ -36,11 +36,14 @@ export class MapIsEmptyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapIsLockedCodec.ts
+++ b/src/codec/MapIsLockedCodec.ts
@@ -38,11 +38,14 @@ export class MapIsLockedCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapKeySetCodec.ts
+++ b/src/codec/MapKeySetCodec.ts
@@ -36,8 +36,11 @@ export class MapKeySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class MapKeySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapKeySetWithPagingPredicateCodec.ts
+++ b/src/codec/MapKeySetWithPagingPredicateCodec.ts
@@ -38,8 +38,11 @@ export class MapKeySetWithPagingPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -49,8 +52,8 @@ export class MapKeySetWithPagingPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapKeySetWithPredicateCodec.ts
+++ b/src/codec/MapKeySetWithPredicateCodec.ts
@@ -38,8 +38,11 @@ export class MapKeySetWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -49,8 +52,8 @@ export class MapKeySetWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapProjectCodec.ts
+++ b/src/codec/MapProjectCodec.ts
@@ -38,8 +38,14 @@ export class MapProjectCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -49,8 +55,8 @@ export class MapProjectCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapProjectWithPredicateCodec.ts
+++ b/src/codec/MapProjectWithPredicateCodec.ts
@@ -40,8 +40,14 @@ export class MapProjectWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +57,8 @@ export class MapProjectWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapPutCodec.ts
+++ b/src/codec/MapPutCodec.ts
@@ -44,14 +44,17 @@ export class MapPutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapPutIfAbsentCodec.ts
+++ b/src/codec/MapPutIfAbsentCodec.ts
@@ -44,14 +44,17 @@ export class MapPutIfAbsentCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceCancelCodec.ts
+++ b/src/codec/MapReduceCancelCodec.ts
@@ -38,11 +38,14 @@ export class MapReduceCancelCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceForCustomCodec.ts
+++ b/src/codec/MapReduceForCustomCodec.ts
@@ -93,8 +93,11 @@ export class MapReduceForCustomCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -108,8 +111,8 @@ export class MapReduceForCustomCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceForListCodec.ts
+++ b/src/codec/MapReduceForListCodec.ts
@@ -93,8 +93,11 @@ export class MapReduceForListCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -108,8 +111,8 @@ export class MapReduceForListCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceForMapCodec.ts
+++ b/src/codec/MapReduceForMapCodec.ts
@@ -93,8 +93,11 @@ export class MapReduceForMapCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -108,8 +111,8 @@ export class MapReduceForMapCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceForMultiMapCodec.ts
+++ b/src/codec/MapReduceForMultiMapCodec.ts
@@ -93,8 +93,11 @@ export class MapReduceForMultiMapCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -108,8 +111,8 @@ export class MapReduceForMultiMapCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceForSetCodec.ts
+++ b/src/codec/MapReduceForSetCodec.ts
@@ -93,8 +93,11 @@ export class MapReduceForSetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -108,8 +111,8 @@ export class MapReduceForSetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReduceJobProcessInformationCodec.ts
+++ b/src/codec/MapReduceJobProcessInformationCodec.ts
@@ -38,8 +38,12 @@ export class MapReduceJobProcessInformationCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'jobPartitionStates': null, 'processRecords': null};
+        // Decode response from client message
+        var parameters: any = {
+            'jobPartitionStates': null,
+            'processRecords': null
+        };
+
 
         var jobPartitionStatesSize = clientMessage.readInt32();
         var jobPartitionStates: any = [];
@@ -49,9 +53,10 @@ export class MapReduceJobProcessInformationCodec {
             jobPartitionStates.push(jobPartitionStatesItem)
         }
         parameters['jobPartitionStates'] = jobPartitionStates;
-        parameters['processRecords'] = clientMessage.readInt32();
-        return parameters;
 
+        parameters['processRecords'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapRemoveCodec.ts
+++ b/src/codec/MapRemoveCodec.ts
@@ -40,14 +40,17 @@ export class MapRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapRemoveEntryListenerCodec.ts
+++ b/src/codec/MapRemoveEntryListenerCodec.ts
@@ -38,11 +38,14 @@ export class MapRemoveEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapRemoveIfSameCodec.ts
+++ b/src/codec/MapRemoveIfSameCodec.ts
@@ -42,11 +42,14 @@ export class MapRemoveIfSameCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapRemoveInterceptorCodec.ts
+++ b/src/codec/MapRemoveInterceptorCodec.ts
@@ -38,11 +38,14 @@ export class MapRemoveInterceptorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapRemovePartitionLostListenerCodec.ts
+++ b/src/codec/MapRemovePartitionLostListenerCodec.ts
@@ -38,11 +38,14 @@ export class MapRemovePartitionLostListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapReplaceCodec.ts
+++ b/src/codec/MapReplaceCodec.ts
@@ -42,14 +42,17 @@ export class MapReplaceCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapReplaceIfSameCodec.ts
+++ b/src/codec/MapReplaceIfSameCodec.ts
@@ -44,11 +44,14 @@ export class MapReplaceIfSameCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapSizeCodec.ts
+++ b/src/codec/MapSizeCodec.ts
@@ -36,11 +36,14 @@ export class MapSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapSubmitToKeyCodec.ts
+++ b/src/codec/MapSubmitToKeyCodec.ts
@@ -42,14 +42,17 @@ export class MapSubmitToKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapTryLockCodec.ts
+++ b/src/codec/MapTryLockCodec.ts
@@ -46,11 +46,14 @@ export class MapTryLockCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapTryPutCodec.ts
+++ b/src/codec/MapTryPutCodec.ts
@@ -44,11 +44,14 @@ export class MapTryPutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapTryRemoveCodec.ts
+++ b/src/codec/MapTryRemoveCodec.ts
@@ -42,11 +42,14 @@ export class MapTryRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MapValuesCodec.ts
+++ b/src/codec/MapValuesCodec.ts
@@ -36,8 +36,11 @@ export class MapValuesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class MapValuesCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapValuesWithPagingPredicateCodec.ts
+++ b/src/codec/MapValuesWithPagingPredicateCodec.ts
@@ -38,8 +38,11 @@ export class MapValuesWithPagingPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class MapValuesWithPagingPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MapValuesWithPredicateCodec.ts
+++ b/src/codec/MapValuesWithPredicateCodec.ts
@@ -38,8 +38,11 @@ export class MapValuesWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -49,8 +52,8 @@ export class MapValuesWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapAddEntryListenerCodec.ts
+++ b/src/codec/MultiMapAddEntryListenerCodec.ts
@@ -40,11 +40,14 @@ export class MultiMapAddEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MultiMapAddEntryListenerToKeyCodec.ts
+++ b/src/codec/MultiMapAddEntryListenerToKeyCodec.ts
@@ -42,11 +42,14 @@ export class MultiMapAddEntryListenerToKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/MultiMapContainsEntryCodec.ts
+++ b/src/codec/MultiMapContainsEntryCodec.ts
@@ -42,11 +42,14 @@ export class MultiMapContainsEntryCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapContainsKeyCodec.ts
+++ b/src/codec/MultiMapContainsKeyCodec.ts
@@ -40,11 +40,14 @@ export class MultiMapContainsKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapContainsValueCodec.ts
+++ b/src/codec/MultiMapContainsValueCodec.ts
@@ -38,11 +38,14 @@ export class MultiMapContainsValueCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapEntrySetCodec.ts
+++ b/src/codec/MultiMapEntrySetCodec.ts
@@ -36,8 +36,11 @@ export class MultiMapEntrySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class MultiMapEntrySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapGetCodec.ts
+++ b/src/codec/MultiMapGetCodec.ts
@@ -40,8 +40,11 @@ export class MultiMapGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class MultiMapGetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapIsLockedCodec.ts
+++ b/src/codec/MultiMapIsLockedCodec.ts
@@ -38,11 +38,14 @@ export class MultiMapIsLockedCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapKeySetCodec.ts
+++ b/src/codec/MultiMapKeySetCodec.ts
@@ -36,8 +36,11 @@ export class MultiMapKeySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class MultiMapKeySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapPutCodec.ts
+++ b/src/codec/MultiMapPutCodec.ts
@@ -42,11 +42,14 @@ export class MultiMapPutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapRemoveCodec.ts
+++ b/src/codec/MultiMapRemoveCodec.ts
@@ -40,8 +40,11 @@ export class MultiMapRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class MultiMapRemoveCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapRemoveEntryCodec.ts
+++ b/src/codec/MultiMapRemoveEntryCodec.ts
@@ -42,11 +42,14 @@ export class MultiMapRemoveEntryCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapRemoveEntryListenerCodec.ts
+++ b/src/codec/MultiMapRemoveEntryListenerCodec.ts
@@ -38,11 +38,14 @@ export class MultiMapRemoveEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapSizeCodec.ts
+++ b/src/codec/MultiMapSizeCodec.ts
@@ -36,11 +36,14 @@ export class MultiMapSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapTryLockCodec.ts
+++ b/src/codec/MultiMapTryLockCodec.ts
@@ -46,11 +46,14 @@ export class MultiMapTryLockCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapValueCountCodec.ts
+++ b/src/codec/MultiMapValueCountCodec.ts
@@ -40,11 +40,14 @@ export class MultiMapValueCountCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/MultiMapValuesCodec.ts
+++ b/src/codec/MultiMapValuesCodec.ts
@@ -36,8 +36,11 @@ export class MultiMapValuesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class MultiMapValuesCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/QueueAddAllCodec.ts
+++ b/src/codec/QueueAddAllCodec.ts
@@ -47,11 +47,14 @@ export class QueueAddAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueAddListenerCodec.ts
+++ b/src/codec/QueueAddListenerCodec.ts
@@ -40,11 +40,14 @@ export class QueueAddListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventItem: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/QueueCompareAndRemoveAllCodec.ts
+++ b/src/codec/QueueCompareAndRemoveAllCodec.ts
@@ -47,11 +47,14 @@ export class QueueCompareAndRemoveAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueCompareAndRetainAllCodec.ts
+++ b/src/codec/QueueCompareAndRetainAllCodec.ts
@@ -47,11 +47,14 @@ export class QueueCompareAndRetainAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueContainsAllCodec.ts
+++ b/src/codec/QueueContainsAllCodec.ts
@@ -47,11 +47,14 @@ export class QueueContainsAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueContainsCodec.ts
+++ b/src/codec/QueueContainsCodec.ts
@@ -38,11 +38,14 @@ export class QueueContainsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueDrainToCodec.ts
+++ b/src/codec/QueueDrainToCodec.ts
@@ -36,8 +36,11 @@ export class QueueDrainToCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class QueueDrainToCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/QueueDrainToMaxSizeCodec.ts
+++ b/src/codec/QueueDrainToMaxSizeCodec.ts
@@ -38,8 +38,11 @@ export class QueueDrainToMaxSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -49,8 +52,8 @@ export class QueueDrainToMaxSizeCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/QueueIsEmptyCodec.ts
+++ b/src/codec/QueueIsEmptyCodec.ts
@@ -36,11 +36,14 @@ export class QueueIsEmptyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueIteratorCodec.ts
+++ b/src/codec/QueueIteratorCodec.ts
@@ -36,8 +36,11 @@ export class QueueIteratorCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class QueueIteratorCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/QueueOfferCodec.ts
+++ b/src/codec/QueueOfferCodec.ts
@@ -40,11 +40,14 @@ export class QueueOfferCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueuePeekCodec.ts
+++ b/src/codec/QueuePeekCodec.ts
@@ -36,14 +36,17 @@ export class QueuePeekCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/QueuePollCodec.ts
+++ b/src/codec/QueuePollCodec.ts
@@ -38,14 +38,17 @@ export class QueuePollCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/QueueRemainingCapacityCodec.ts
+++ b/src/codec/QueueRemainingCapacityCodec.ts
@@ -36,11 +36,14 @@ export class QueueRemainingCapacityCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueRemoveCodec.ts
+++ b/src/codec/QueueRemoveCodec.ts
@@ -38,11 +38,14 @@ export class QueueRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueRemoveListenerCodec.ts
+++ b/src/codec/QueueRemoveListenerCodec.ts
@@ -38,11 +38,14 @@ export class QueueRemoveListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueSizeCodec.ts
+++ b/src/codec/QueueSizeCodec.ts
@@ -36,11 +36,14 @@ export class QueueSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/QueueTakeCodec.ts
+++ b/src/codec/QueueTakeCodec.ts
@@ -36,14 +36,17 @@ export class QueueTakeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapAddEntryListenerCodec.ts
+++ b/src/codec/ReplicatedMapAddEntryListenerCodec.ts
@@ -38,11 +38,14 @@ export class ReplicatedMapAddEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ReplicatedMapAddEntryListenerToKeyCodec.ts
+++ b/src/codec/ReplicatedMapAddEntryListenerToKeyCodec.ts
@@ -40,11 +40,14 @@ export class ReplicatedMapAddEntryListenerToKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.ts
+++ b/src/codec/ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.ts
@@ -42,11 +42,14 @@ export class ReplicatedMapAddEntryListenerToKeyWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.ts
+++ b/src/codec/ReplicatedMapAddEntryListenerWithPredicateCodec.ts
@@ -40,11 +40,14 @@ export class ReplicatedMapAddEntryListenerWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ReplicatedMapAddNearCacheEntryListenerCodec.ts
+++ b/src/codec/ReplicatedMapAddNearCacheEntryListenerCodec.ts
@@ -40,11 +40,14 @@ export class ReplicatedMapAddNearCacheEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventEntry: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/ReplicatedMapContainsKeyCodec.ts
+++ b/src/codec/ReplicatedMapContainsKeyCodec.ts
@@ -38,11 +38,14 @@ export class ReplicatedMapContainsKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapContainsValueCodec.ts
+++ b/src/codec/ReplicatedMapContainsValueCodec.ts
@@ -38,11 +38,14 @@ export class ReplicatedMapContainsValueCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapEntrySetCodec.ts
+++ b/src/codec/ReplicatedMapEntrySetCodec.ts
@@ -36,8 +36,11 @@ export class ReplicatedMapEntrySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class ReplicatedMapEntrySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapGetCodec.ts
+++ b/src/codec/ReplicatedMapGetCodec.ts
@@ -38,14 +38,17 @@ export class ReplicatedMapGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapIsEmptyCodec.ts
+++ b/src/codec/ReplicatedMapIsEmptyCodec.ts
@@ -36,11 +36,14 @@ export class ReplicatedMapIsEmptyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapKeySetCodec.ts
+++ b/src/codec/ReplicatedMapKeySetCodec.ts
@@ -36,8 +36,11 @@ export class ReplicatedMapKeySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class ReplicatedMapKeySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapPutCodec.ts
+++ b/src/codec/ReplicatedMapPutCodec.ts
@@ -42,14 +42,17 @@ export class ReplicatedMapPutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapRemoveCodec.ts
+++ b/src/codec/ReplicatedMapRemoveCodec.ts
@@ -38,14 +38,17 @@ export class ReplicatedMapRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapRemoveEntryListenerCodec.ts
+++ b/src/codec/ReplicatedMapRemoveEntryListenerCodec.ts
@@ -38,11 +38,14 @@ export class ReplicatedMapRemoveEntryListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapSizeCodec.ts
+++ b/src/codec/ReplicatedMapSizeCodec.ts
@@ -36,11 +36,14 @@ export class ReplicatedMapSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/ReplicatedMapValuesCodec.ts
+++ b/src/codec/ReplicatedMapValuesCodec.ts
@@ -36,8 +36,11 @@ export class ReplicatedMapValuesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class ReplicatedMapValuesCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferAddAllCodec.ts
+++ b/src/codec/RingbufferAddAllCodec.ts
@@ -49,11 +49,14 @@ export class RingbufferAddAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferAddCodec.ts
+++ b/src/codec/RingbufferAddCodec.ts
@@ -40,11 +40,14 @@ export class RingbufferAddCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferCapacityCodec.ts
+++ b/src/codec/RingbufferCapacityCodec.ts
@@ -36,11 +36,14 @@ export class RingbufferCapacityCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferHeadSequenceCodec.ts
+++ b/src/codec/RingbufferHeadSequenceCodec.ts
@@ -36,11 +36,14 @@ export class RingbufferHeadSequenceCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferReadManyCodec.ts
+++ b/src/codec/RingbufferReadManyCodec.ts
@@ -50,9 +50,15 @@ export class RingbufferReadManyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'readCount': null, 'items': null, 'itemSeqs': null};
+        // Decode response from client message
+        var parameters: any = {
+            'readCount': null,
+            'items': null,
+            'itemSeqs': null
+        };
+
         parameters['readCount'] = clientMessage.readInt32();
+
 
         var itemsSize = clientMessage.readInt32();
         var items: any = [];
@@ -66,6 +72,7 @@ export class RingbufferReadManyCodec {
         if (clientMessage.isComplete()) {
             return parameters;
         }
+
         if (clientMessage.readBoolean() !== true) {
 
             var itemSeqsSize = clientMessage.readInt32();
@@ -77,8 +84,8 @@ export class RingbufferReadManyCodec {
             }
             parameters['itemSeqs'] = itemSeqs;
         }
+        parameters.itemSeqsExist = true;
         return parameters;
-
     }
 
 

--- a/src/codec/RingbufferReadOneCodec.ts
+++ b/src/codec/RingbufferReadOneCodec.ts
@@ -38,14 +38,17 @@ export class RingbufferReadOneCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferRemainingCapacityCodec.ts
+++ b/src/codec/RingbufferRemainingCapacityCodec.ts
@@ -36,11 +36,14 @@ export class RingbufferRemainingCapacityCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferSizeCodec.ts
+++ b/src/codec/RingbufferSizeCodec.ts
@@ -36,11 +36,14 @@ export class RingbufferSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/RingbufferTailSequenceCodec.ts
+++ b/src/codec/RingbufferTailSequenceCodec.ts
@@ -36,11 +36,14 @@ export class RingbufferTailSequenceCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorCancelFromAddressCodec.ts
+++ b/src/codec/ScheduledExecutorCancelFromAddressCodec.ts
@@ -42,11 +42,17 @@ export class ScheduledExecutorCancelFromAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorCancelFromPartitionCodec.ts
+++ b/src/codec/ScheduledExecutorCancelFromPartitionCodec.ts
@@ -40,11 +40,17 @@ export class ScheduledExecutorCancelFromPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetAllScheduledFuturesCodec.ts
+++ b/src/codec/ScheduledExecutorGetAllScheduledFuturesCodec.ts
@@ -36,8 +36,14 @@ export class ScheduledExecutorGetAllScheduledFuturesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'handlers': null};
+        // Decode response from client message
+        var parameters: any = {
+            'handlers': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         var handlersSize = clientMessage.readInt32();
         var handlers: any = [];
@@ -58,8 +64,8 @@ export class ScheduledExecutorGetAllScheduledFuturesCodec {
             handlers.push(handlersItem)
         }
         parameters['handlers'] = handlers;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetDelayFromAddressCodec.ts
+++ b/src/codec/ScheduledExecutorGetDelayFromAddressCodec.ts
@@ -40,11 +40,17 @@ export class ScheduledExecutorGetDelayFromAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetDelayFromPartitionCodec.ts
+++ b/src/codec/ScheduledExecutorGetDelayFromPartitionCodec.ts
@@ -38,11 +38,17 @@ export class ScheduledExecutorGetDelayFromPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readLong();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetResultFromAddressCodec.ts
+++ b/src/codec/ScheduledExecutorGetResultFromAddressCodec.ts
@@ -40,14 +40,20 @@ export class ScheduledExecutorGetResultFromAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetResultFromPartitionCodec.ts
+++ b/src/codec/ScheduledExecutorGetResultFromPartitionCodec.ts
@@ -38,14 +38,20 @@ export class ScheduledExecutorGetResultFromPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetStatsFromAddressCodec.ts
+++ b/src/codec/ScheduledExecutorGetStatsFromAddressCodec.ts
@@ -40,19 +40,26 @@ export class ScheduledExecutorGetStatsFromAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
+        // Decode response from client message
         var parameters: any = {
             'lastIdleTimeNanos': null,
             'totalIdleTimeNanos': null,
             'totalRuns': null,
             'totalRunTimeNanos': null
         };
-        parameters['lastIdleTimeNanos'] = clientMessage.readLong();
-        parameters['totalIdleTimeNanos'] = clientMessage.readLong();
-        parameters['totalRuns'] = clientMessage.readLong();
-        parameters['totalRunTimeNanos'] = clientMessage.readLong();
-        return parameters;
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['lastIdleTimeNanos'] = clientMessage.readLong();
+
+        parameters['totalIdleTimeNanos'] = clientMessage.readLong();
+
+        parameters['totalRuns'] = clientMessage.readLong();
+
+        parameters['totalRunTimeNanos'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorGetStatsFromPartitionCodec.ts
+++ b/src/codec/ScheduledExecutorGetStatsFromPartitionCodec.ts
@@ -38,19 +38,26 @@ export class ScheduledExecutorGetStatsFromPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
+        // Decode response from client message
         var parameters: any = {
             'lastIdleTimeNanos': null,
             'totalIdleTimeNanos': null,
             'totalRuns': null,
             'totalRunTimeNanos': null
         };
-        parameters['lastIdleTimeNanos'] = clientMessage.readLong();
-        parameters['totalIdleTimeNanos'] = clientMessage.readLong();
-        parameters['totalRuns'] = clientMessage.readLong();
-        parameters['totalRunTimeNanos'] = clientMessage.readLong();
-        return parameters;
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['lastIdleTimeNanos'] = clientMessage.readLong();
+
+        parameters['totalIdleTimeNanos'] = clientMessage.readLong();
+
+        parameters['totalRuns'] = clientMessage.readLong();
+
+        parameters['totalRunTimeNanos'] = clientMessage.readLong();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorIsCancelledFromAddressCodec.ts
+++ b/src/codec/ScheduledExecutorIsCancelledFromAddressCodec.ts
@@ -40,11 +40,17 @@ export class ScheduledExecutorIsCancelledFromAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorIsCancelledFromPartitionCodec.ts
+++ b/src/codec/ScheduledExecutorIsCancelledFromPartitionCodec.ts
@@ -38,11 +38,17 @@ export class ScheduledExecutorIsCancelledFromPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorIsDoneFromAddressCodec.ts
+++ b/src/codec/ScheduledExecutorIsDoneFromAddressCodec.ts
@@ -40,11 +40,17 @@ export class ScheduledExecutorIsDoneFromAddressCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/ScheduledExecutorIsDoneFromPartitionCodec.ts
+++ b/src/codec/ScheduledExecutorIsDoneFromPartitionCodec.ts
@@ -38,11 +38,17 @@ export class ScheduledExecutorIsDoneFromPartitionCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SemaphoreAvailablePermitsCodec.ts
+++ b/src/codec/SemaphoreAvailablePermitsCodec.ts
@@ -36,11 +36,14 @@ export class SemaphoreAvailablePermitsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/SemaphoreDrainPermitsCodec.ts
+++ b/src/codec/SemaphoreDrainPermitsCodec.ts
@@ -36,11 +36,14 @@ export class SemaphoreDrainPermitsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/SemaphoreInitCodec.ts
+++ b/src/codec/SemaphoreInitCodec.ts
@@ -38,11 +38,14 @@ export class SemaphoreInitCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SemaphoreTryAcquireCodec.ts
+++ b/src/codec/SemaphoreTryAcquireCodec.ts
@@ -40,11 +40,14 @@ export class SemaphoreTryAcquireCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetAddAllCodec.ts
+++ b/src/codec/SetAddAllCodec.ts
@@ -47,11 +47,14 @@ export class SetAddAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetAddCodec.ts
+++ b/src/codec/SetAddCodec.ts
@@ -38,11 +38,14 @@ export class SetAddCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetAddListenerCodec.ts
+++ b/src/codec/SetAddListenerCodec.ts
@@ -40,11 +40,14 @@ export class SetAddListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventItem: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/SetCompareAndRemoveAllCodec.ts
+++ b/src/codec/SetCompareAndRemoveAllCodec.ts
@@ -47,11 +47,14 @@ export class SetCompareAndRemoveAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetCompareAndRetainAllCodec.ts
+++ b/src/codec/SetCompareAndRetainAllCodec.ts
@@ -47,11 +47,14 @@ export class SetCompareAndRetainAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetContainsAllCodec.ts
+++ b/src/codec/SetContainsAllCodec.ts
@@ -47,11 +47,14 @@ export class SetContainsAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetContainsCodec.ts
+++ b/src/codec/SetContainsCodec.ts
@@ -38,11 +38,14 @@ export class SetContainsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetGetAllCodec.ts
+++ b/src/codec/SetGetAllCodec.ts
@@ -36,8 +36,11 @@ export class SetGetAllCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -47,8 +50,8 @@ export class SetGetAllCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/SetIsEmptyCodec.ts
+++ b/src/codec/SetIsEmptyCodec.ts
@@ -36,11 +36,14 @@ export class SetIsEmptyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetRemoveCodec.ts
+++ b/src/codec/SetRemoveCodec.ts
@@ -38,11 +38,14 @@ export class SetRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetRemoveListenerCodec.ts
+++ b/src/codec/SetRemoveListenerCodec.ts
@@ -38,11 +38,14 @@ export class SetRemoveListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/SetSizeCodec.ts
+++ b/src/codec/SetSizeCodec.ts
@@ -36,11 +36,14 @@ export class SetSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/TopicAddMessageListenerCodec.ts
+++ b/src/codec/TopicAddMessageListenerCodec.ts
@@ -38,11 +38,14 @@ export class TopicAddMessageListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
     static handle(clientMessage: ClientMessage, handleEventTopic: any, toObjectFunction: (data: Data) => any = null) {

--- a/src/codec/TopicRemoveMessageListenerCodec.ts
+++ b/src/codec/TopicRemoveMessageListenerCodec.ts
@@ -38,11 +38,14 @@ export class TopicRemoveMessageListenerCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionCreateCodec.ts
+++ b/src/codec/TransactionCreateCodec.ts
@@ -42,11 +42,14 @@ export class TransactionCreateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalListAddCodec.ts
+++ b/src/codec/TransactionalListAddCodec.ts
@@ -42,11 +42,14 @@ export class TransactionalListAddCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalListRemoveCodec.ts
+++ b/src/codec/TransactionalListRemoveCodec.ts
@@ -42,11 +42,14 @@ export class TransactionalListRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalListSizeCodec.ts
+++ b/src/codec/TransactionalListSizeCodec.ts
@@ -40,11 +40,14 @@ export class TransactionalListSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapContainsKeyCodec.ts
+++ b/src/codec/TransactionalMapContainsKeyCodec.ts
@@ -42,11 +42,14 @@ export class TransactionalMapContainsKeyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapGetCodec.ts
+++ b/src/codec/TransactionalMapGetCodec.ts
@@ -42,14 +42,17 @@ export class TransactionalMapGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapGetForUpdateCodec.ts
+++ b/src/codec/TransactionalMapGetForUpdateCodec.ts
@@ -42,14 +42,17 @@ export class TransactionalMapGetForUpdateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapIsEmptyCodec.ts
+++ b/src/codec/TransactionalMapIsEmptyCodec.ts
@@ -40,11 +40,14 @@ export class TransactionalMapIsEmptyCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapKeySetCodec.ts
+++ b/src/codec/TransactionalMapKeySetCodec.ts
@@ -40,8 +40,11 @@ export class TransactionalMapKeySetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class TransactionalMapKeySetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapKeySetWithPredicateCodec.ts
+++ b/src/codec/TransactionalMapKeySetWithPredicateCodec.ts
@@ -42,8 +42,11 @@ export class TransactionalMapKeySetWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class TransactionalMapKeySetWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapPutCodec.ts
+++ b/src/codec/TransactionalMapPutCodec.ts
@@ -46,14 +46,17 @@ export class TransactionalMapPutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapPutIfAbsentCodec.ts
+++ b/src/codec/TransactionalMapPutIfAbsentCodec.ts
@@ -44,14 +44,17 @@ export class TransactionalMapPutIfAbsentCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapRemoveCodec.ts
+++ b/src/codec/TransactionalMapRemoveCodec.ts
@@ -42,14 +42,17 @@ export class TransactionalMapRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapRemoveIfSameCodec.ts
+++ b/src/codec/TransactionalMapRemoveIfSameCodec.ts
@@ -44,11 +44,14 @@ export class TransactionalMapRemoveIfSameCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapReplaceCodec.ts
+++ b/src/codec/TransactionalMapReplaceCodec.ts
@@ -44,14 +44,17 @@ export class TransactionalMapReplaceCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapReplaceIfSameCodec.ts
+++ b/src/codec/TransactionalMapReplaceIfSameCodec.ts
@@ -46,11 +46,14 @@ export class TransactionalMapReplaceIfSameCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapSizeCodec.ts
+++ b/src/codec/TransactionalMapSizeCodec.ts
@@ -40,11 +40,14 @@ export class TransactionalMapSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapValuesCodec.ts
+++ b/src/codec/TransactionalMapValuesCodec.ts
@@ -40,8 +40,11 @@ export class TransactionalMapValuesCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -51,8 +54,8 @@ export class TransactionalMapValuesCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMapValuesWithPredicateCodec.ts
+++ b/src/codec/TransactionalMapValuesWithPredicateCodec.ts
@@ -42,8 +42,11 @@ export class TransactionalMapValuesWithPredicateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class TransactionalMapValuesWithPredicateCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMultiMapGetCodec.ts
+++ b/src/codec/TransactionalMultiMapGetCodec.ts
@@ -42,8 +42,11 @@ export class TransactionalMultiMapGetCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class TransactionalMultiMapGetCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMultiMapPutCodec.ts
+++ b/src/codec/TransactionalMultiMapPutCodec.ts
@@ -44,11 +44,14 @@ export class TransactionalMultiMapPutCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMultiMapRemoveCodec.ts
+++ b/src/codec/TransactionalMultiMapRemoveCodec.ts
@@ -42,8 +42,11 @@ export class TransactionalMultiMapRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -53,8 +56,8 @@ export class TransactionalMultiMapRemoveCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMultiMapRemoveEntryCodec.ts
+++ b/src/codec/TransactionalMultiMapRemoveEntryCodec.ts
@@ -44,11 +44,14 @@ export class TransactionalMultiMapRemoveEntryCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMultiMapSizeCodec.ts
+++ b/src/codec/TransactionalMultiMapSizeCodec.ts
@@ -40,11 +40,14 @@ export class TransactionalMultiMapSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalMultiMapValueCountCodec.ts
+++ b/src/codec/TransactionalMultiMapValueCountCodec.ts
@@ -42,11 +42,14 @@ export class TransactionalMultiMapValueCountCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalQueueOfferCodec.ts
+++ b/src/codec/TransactionalQueueOfferCodec.ts
@@ -44,11 +44,14 @@ export class TransactionalQueueOfferCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalQueuePeekCodec.ts
+++ b/src/codec/TransactionalQueuePeekCodec.ts
@@ -42,14 +42,17 @@ export class TransactionalQueuePeekCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalQueuePollCodec.ts
+++ b/src/codec/TransactionalQueuePollCodec.ts
@@ -42,14 +42,17 @@ export class TransactionalQueuePollCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalQueueSizeCodec.ts
+++ b/src/codec/TransactionalQueueSizeCodec.ts
@@ -40,11 +40,14 @@ export class TransactionalQueueSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalQueueTakeCodec.ts
+++ b/src/codec/TransactionalQueueTakeCodec.ts
@@ -40,14 +40,17 @@ export class TransactionalQueueTakeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         if (clientMessage.readBoolean() !== true) {
             parameters['response'] = toObjectFunction(clientMessage.readData());
         }
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalSetAddCodec.ts
+++ b/src/codec/TransactionalSetAddCodec.ts
@@ -42,11 +42,14 @@ export class TransactionalSetAddCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalSetRemoveCodec.ts
+++ b/src/codec/TransactionalSetRemoveCodec.ts
@@ -42,11 +42,14 @@ export class TransactionalSetRemoveCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readBoolean();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readBoolean();
+
+        return parameters;
     }
 
 

--- a/src/codec/TransactionalSetSizeCodec.ts
+++ b/src/codec/TransactionalSetSizeCodec.ts
@@ -40,11 +40,14 @@ export class TransactionalSetSizeCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readInt32();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readInt32();
+
+        return parameters;
     }
 
 

--- a/src/codec/XATransactionCollectTransactionsCodec.ts
+++ b/src/codec/XATransactionCollectTransactionsCodec.ts
@@ -34,8 +34,11 @@ export class XATransactionCollectTransactionsCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
+
 
         var responseSize = clientMessage.readInt32();
         var response: any = [];
@@ -45,8 +48,8 @@ export class XATransactionCollectTransactionsCodec {
             response.push(responseItem)
         }
         parameters['response'] = response;
-        return parameters;
 
+        return parameters;
     }
 
 

--- a/src/codec/XATransactionCreateCodec.ts
+++ b/src/codec/XATransactionCreateCodec.ts
@@ -38,11 +38,14 @@ export class XATransactionCreateCodec {
     }
 
     static decodeResponse(clientMessage: ClientMessage, toObjectFunction: (data: Data) => any = null) {
-// Decode response from client message
-        var parameters: any = {'response': null};
-        parameters['response'] = clientMessage.readString();
-        return parameters;
+        // Decode response from client message
+        var parameters: any = {
+            'response': null
+        };
 
+        parameters['response'] = clientMessage.readString();
+
+        return parameters;
     }
 
 


### PR DESCRIPTION
Due to https://github.com/hazelcast/hazelcast-client-protocol/pull/104, ClientAuthenticationCodec.decodeResponse throws with client 0.6.2 and server 3.6. You can scroll to ClientAuthenticationCodec and see what has changed with this PR.

Fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/207

I tried this with 3.6 and 3.7 server in my local but it is important to setup compatibility tests before assuming codecs work across versions.