### PR TITLE
refactor ClientConnection.send to return a promise

### DIFF
--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -83,8 +83,20 @@ export class ClientConnection {
         return ready.promise;
     }
 
-    write(buffer: Buffer, cb: (err: any) => void ): void {
-        this.socket.write(buffer, 'utf8', cb);
+    write(buffer: Buffer): Promise<void> {
+        let deferred = Promise.defer<void>();
+        try {
+            this.socket.write(buffer, (err: any) => {
+                if (err) {
+                    deferred.reject(err);
+                } else {
+                    deferred.resolve();
+                }
+            });
+        } catch (err) {
+            deferred.reject(err);
+        }
+        return deferred.promise;
     }
 
     /**


### PR DESCRIPTION
InvocationService's invoke utility methods did not return a promise. Instead they dealt with possible failures themselves. This lead to duplicate error handling codes in each of these utility methods. `try..catch` block in `invokeNonSmart` and `invokeSmart` were not really useful because they only catch synchronous errors(calling a method on null for example). Each method called from `invokeSmart` dealt with errors themselves. Now, they return a promise so error handling can be done once for all in `invokeSmart`