### PR TITLE
fixes issue when cluster service member list contains dead members

### DIFF
--- a/src/Address.ts
+++ b/src/Address.ts
@@ -39,6 +39,21 @@ class Address implements IdentifiedDataSerializable {
         return ADDRESS_CLASS_ID;
     }
 
+    equals(other: Address): boolean {
+        if (other === this) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        if (other.host === this.host &&
+            other.port === this.port &&
+            other.type === this.type) {
+            return true;
+        }
+        return false;
+    }
+
     toString(): string {
         return this.host + ':' + this.port;
     }

--- a/src/core/Member.ts
+++ b/src/core/Member.ts
@@ -22,6 +22,19 @@ export class Member {
         this.attributes = attributes;
     }
 
+    equals(other: Member): boolean {
+        if (other === this) {
+            return true;
+        }
+        if (other == null) {
+            return false;
+        }
+        if (other.address.equals(this.address) && other.uuid === this.uuid && other.isLiteMember === this.isLiteMember) {
+            return true;
+        }
+        return false;
+    }
+
     toString() {
         return 'Member[ uuid: ' + this.uuid.toString() + ', address: ' + this.address.toString() + ']';
     }

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -9,7 +9,7 @@ import HazelcastClient from '../HazelcastClient';
 import Address = require('../Address');
 import ClientMessage = require('../ClientMessage');
 import {IllegalStateError} from '../HazelcastError';
-import {UUID} from '../core/UUID';
+import * as assert from 'assert';
 
 const MEMBER_ADDED = 1;
 const MEMBER_REMOVED = 2;
@@ -223,8 +223,11 @@ export class ClusterService extends EventEmitter {
     }
 
     private memberRemoved(member: Member) {
-        this.members.splice(this.members.indexOf(member), 1);
-        this.client.getConnectionManager().destroyConnection(member.address);
-        this.emit(EMIT_MEMBER_REMOVED, member);
+        let memberIndex = this.members.findIndex(member.equals, member);
+        let removedMemberList = this.members.splice(memberIndex, 1);
+        assert(removedMemberList.length === 1);
+        let removedMember = removedMemberList[0];
+        this.client.getConnectionManager().destroyConnection(removedMember.address);
+        this.emit(EMIT_MEMBER_REMOVED, removedMember);
     }
 }

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -61,6 +61,30 @@ describe('ClusterService', function() {
         });
     });
 
+    it('getMembers returns correct list after a member is removed', function (done) {
+        this.timeout(20000);
+        var member2;
+        var member3;
+        client.getClusterService().once('memberRemoved', function () {
+            var remainingMemberList = client.getClusterService().getMembers();
+            try {
+                expect(remainingMemberList).to.have.length(2);
+                expect(remainingMemberList[0].address.port).to.equal(ownerMember.port);
+                expect(remainingMemberList[1].address.port).to.equal(member3.port);
+                done();
+            } catch (e) {
+                done(e);
+            }
+        });
+        Controller.startMember(cluster.id).then(function (res) {
+            member2 = res;
+            return Controller.startMember(cluster.id);
+        }).then(function (res) {
+            member3 = res;
+            Controller.shutdownMember(cluster.id, member2.uuid);
+        });
+    });
+
     it('should throw with message containing wrong host addresses in config', function() {
         var configuredAddresses = [
             {host: '0.0.0.0', port: '5709'},


### PR DESCRIPTION
`ClusterService.memberRemoved` method found removed member in the list by `===` comparing. This was not able to find the member when member lost information came from the cluster, therefore caused a random member to be removed instead of dead one.