### PR TITLE
unskip reliable topic tests

### DIFF
--- a/src/Address.ts
+++ b/src/Address.ts
@@ -16,8 +16,8 @@
 
 import {IdentifiedDataSerializable} from './serialization/Serializable';
 import {DataInput, DataOutput} from './serialization/Data';
-import {ADDRESS_CLASS_ID, CLUSTER_DATA_FACTORY_ID} from './ClusterDataFactory';
 import * as net from 'net';
+import {ClusterDataFactoryHelper} from './ClusterDataFactoryHelper';
 
 class Address implements IdentifiedDataSerializable {
 
@@ -48,11 +48,11 @@ class Address implements IdentifiedDataSerializable {
     }
 
     getFactoryId(): number {
-        return CLUSTER_DATA_FACTORY_ID;
+        return ClusterDataFactoryHelper.FACTORY_ID;
     }
 
     getClassId(): number {
-        return ADDRESS_CLASS_ID;
+        return ClusterDataFactoryHelper.ADDRESS_ID;
     }
 
     equals(other: Address): boolean {

--- a/src/ClusterDataFactoryHelper.ts
+++ b/src/ClusterDataFactoryHelper.ts
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-import {IdentifiedDataSerializableFactory, IdentifiedDataSerializable} from './serialization/Serializable';
-import Address = require('./Address');
-import {ClusterDataFactoryHelper} from './ClusterDataFactoryHelper';
-
-export class ClusterDataFactory implements IdentifiedDataSerializableFactory {
-
-    create(type: number): IdentifiedDataSerializable {
-        if (type === ClusterDataFactoryHelper.ADDRESS_ID) {
-            return new Address();
-        }
-
-        return null;
-    }
+export class ClusterDataFactoryHelper {
+    static readonly FACTORY_ID = 0;
+    static readonly ADDRESS_ID = 1;
 }

--- a/src/proxy/RingbufferProxy.ts
+++ b/src/proxy/RingbufferProxy.ts
@@ -91,7 +91,7 @@ export class RingbufferProxy<E> extends PartitionSpecificProxy implements IRingb
             .then<Array<E>>((raw: any) => {
                 return raw['items'].map((r: Data) => {
                     return this.toObject(r);
-                });
+                }, this);
             });
     }
 }

--- a/src/proxy/topic/RawTopicMessage.ts
+++ b/src/proxy/topic/RawTopicMessage.ts
@@ -23,8 +23,6 @@ export const RELIABLE_TOPIC_MESSAGE_FACTORY_ID = -18;
 export const RELIABLE_TOPIC_CLASS_ID = 2;
 
 export class RawTopicMessage implements IdentifiedDataSerializable {
-
-
     publishTime: Long;
     publisherAddress: Address;
     payload: Data;
@@ -52,11 +50,9 @@ export class RawTopicMessage implements IdentifiedDataSerializable {
 
 export class ReliableTopicMessageFactory implements IdentifiedDataSerializableFactory {
     create(type: number): IdentifiedDataSerializable {
-
         if (type === RELIABLE_TOPIC_CLASS_ID) {
             return new RawTopicMessage();
         }
-
         return null;
     }
 }

--- a/src/proxy/topic/ReliableTopicListenerRunner.ts
+++ b/src/proxy/topic/ReliableTopicListenerRunner.ts
@@ -54,7 +54,7 @@ export class ReliableTopicListenerRunner<E> {
         this.ringbuffer.readMany(this.sequenceNumber, 1, this.batchSize).then((result: Array<RawTopicMessage>) => {
             if (!this.cancelled) {
                 result.forEach((raw: RawTopicMessage) => {
-                    var msg = new TopicMessage<E>();
+                    let msg = new TopicMessage<E>();
                     msg.messageObject = this.serializationService.toObject(raw.payload);
                     msg.publisher = raw.publisherAddress;
                     msg.publishingTime = raw.publishTime;
@@ -80,7 +80,7 @@ export class ReliableTopicListenerRunner<E> {
                 return;
             }
 
-            var message = 'Listener of topic "' + this.proxy.getName() + '" caught an exception, terminating listener';
+            var message = 'Listener of topic "' + this.proxy.getName() + '" caught an exception, terminating listener. ' + e;
             this.loggingService.warn('ReliableTopicListenerRunner', message);
 
             this.proxy.removeMessageListener(this.listenerId);

--- a/src/proxy/topic/TopicMessageListener.ts
+++ b/src/proxy/topic/TopicMessageListener.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {TopicMessage} from './TopicMessage';
 
 export interface TopicMessageListener<E> {
-    (item: E): void;
+    (message: TopicMessage<E>): void;
 }

--- a/src/serialization/SerializationService.ts
+++ b/src/serialization/SerializationService.ts
@@ -30,9 +30,9 @@ import {PortableSerializer} from './portable/PortableSerializer';
 import {IdentifiedDataSerializableFactory} from './Serializable';
 import * as DefaultPredicates from './DefaultPredicates';
 import {PredicateFactory, PREDICATE_FACTORY_ID} from './PredicateFactory';
-import {PartitionAware} from '../core/PartitionAware';
 import {RELIABLE_TOPIC_MESSAGE_FACTORY_ID, ReliableTopicMessageFactory} from '../proxy/topic/RawTopicMessage';
-import {CLUSTER_DATA_FACTORY_ID, ClusterDataFactory} from '../ClusterDataFactory';
+import {ClusterDataFactoryHelper} from '../ClusterDataFactoryHelper';
+import {ClusterDataFactory} from '../ClusterDataFactory';
 
 export interface SerializationService {
     toData(object: any, paritioningStrategy?: any) : Data;
@@ -257,7 +257,7 @@ export class SerializationServiceV1 implements SerializationService {
         }
         factories[PREDICATE_FACTORY_ID] = new PredicateFactory(DefaultPredicates);
         factories[RELIABLE_TOPIC_MESSAGE_FACTORY_ID] = new ReliableTopicMessageFactory();
-        factories[CLUSTER_DATA_FACTORY_ID] = new ClusterDataFactory();
+        factories[ClusterDataFactoryHelper.FACTORY_ID] = new ClusterDataFactory();
         this.registerSerializer('identified', new IdentifiedDataSerializableSerializer(factories));
     }
 


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/219

The problem was that two topics in consecutive tests used the same topic. This PR changes test topics' names.