### PR TITLE
Invocation service fails retrying invocations when client is not active

### DIFF
--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -245,7 +245,9 @@ export class InvocationService {
 
     private notifyError(invocation: Invocation, error: Error): void {
         var correlationId = invocation.request.getCorrelationId().toNumber();
-        if (this.isRetryable(invocation)) {
+        if (!this.client.getLifecycleService().isRunning()) {
+            invocation.deferred.reject(new ClientNotActiveError('Client is not active.', error));
+        } else if (this.isRetryable(invocation)) {
             this.logger.debug('InvocationService',
                 'Retrying(' + invocation.invokeCount + ') on correlation-id=' + correlationId, error);
             if (invocation.invokeCount < MAX_FAST_INVOCATION_COUNT) {


### PR DESCRIPTION
* InvocationService retries the invocations until they are expired even when client is not active anymore.

Realized this issue when HeartbeatTest failed due to previous test's invocations affecting the next test.
