### PR TITLE
Server version check in tests

### DIFF
--- a/scripts/dev-test-rc.sh
+++ b/scripts/dev-test-rc.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-HZ_VERSION="3.9"
+HZ_VERSION="3.9.1"
 HAZELCAST_TEST_VERSION="3.10-SNAPSHOT"
 HAZELCAST_VERSION=${HZ_VERSION}
 HAZELCAST_ENTERPRISE_VERSION=${HZ_VERSION}
@@ -51,7 +51,7 @@ if [ -n "${HAZELCAST_ENTERPRISE_KEY}" ]; then
             exit 1
         fi
     fi
-    CLASSPATH="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar:hazelcast-enterprise-${HAZELCAST_VERSION}.jar:hazelcast-${HAZELCAST_VERSION}.jar:hazelcast-tests-${HAZELCAST_VERSION}.jar:test/javaclasses"
+    CLASSPATH="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar:hazelcast-enterprise-${HAZELCAST_VERSION}.jar:hazelcast-${HAZELCAST_VERSION}.jar:hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar:test/javaclasses"
     echo "Starting Remote Controller ... enterprise ..."
 else
     if [ -f "hazelcast-${HAZELCAST_VERSION}.jar" ]; then
@@ -64,7 +64,7 @@ else
             exit 1
         fi
     fi
-    CLASSPATH="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar:hazelcast-${HAZELCAST_VERSION}.jar:test/javaclasses"
+    CLASSPATH="hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar:hazelcast-${HAZELCAST_VERSION}.jar:hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar"
     echo "Starting Remote Controller ... oss ..."
 fi
 

--- a/test/Util.js
+++ b/test/Util.js
@@ -15,6 +15,7 @@
  */
 
 var expect = require('chai').expect;
+var BuildMetadata = require('../lib/BuildMetadata').BuildMetadata;
 var promiseLater = function (time, func) {
     if (func === undefined) {
         func = function(){};
@@ -68,6 +69,14 @@ exports.fillMap = function (map, size, keyPrefix, valuePrefix) {
 
 exports.markEnterprise = function (_this) {
     if(!process.env.HAZELCAST_ENTERPRISE_KEY){
+        _this.skip();
+    }
+};
+
+exports.markServerVersionAtLeast = function (_this, client, expectedVersion) {
+    var actNumber = client.getClusterService().getOwnerConnection().getConnectedServerVersion();
+    var expNumber = BuildMetadata.calculateVersion(expectedVersion);
+    if (actNumber < expNumber) {
         _this.skip();
     }
 };

--- a/test/Util.js
+++ b/test/Util.js
@@ -68,6 +68,9 @@ exports.fillMap = function (map, size, keyPrefix, valuePrefix) {
 };
 
 exports.markEnterprise = function (_this) {
+    if (process.env.SERVER_TYPE === 'oss' || process.env.HZ_TYPE === 'oss') {
+        _this.skip();
+    }
     if(!process.env.HAZELCAST_ENTERPRISE_KEY){
         _this.skip();
     }
@@ -76,7 +79,7 @@ exports.markEnterprise = function (_this) {
 exports.markServerVersionAtLeast = function (_this, client, expectedVersion) {
     var actNumber = client.getClusterService().getOwnerConnection().getConnectedServerVersion();
     var expNumber = BuildMetadata.calculateVersion(expectedVersion);
-    if (actNumber < expNumber) {
+    if (actNumber === BuildMetadata.UNKNOWN_VERSION_ID || actNumber < expNumber) {
         _this.skip();
     }
 };

--- a/test/nearcache/InvalidationMetadataDistortionTest.js
+++ b/test/nearcache/InvalidationMetadataDistortionTest.js
@@ -22,6 +22,7 @@ var IdentifiedFactory = require('../javaclasses/IdentifiedFactory');
 var DistortInvalidationMetadataEntryProcessor = require('../javaclasses/DistortInvalidationMetadataEntryProcessor');
 var Promise = require('bluebird');
 var expect = require('chai').expect;
+var Util = require('../Util');
 
 describe('Invalidation metadata distortion', function () {
 
@@ -73,6 +74,8 @@ describe('Invalidation metadata distortion', function () {
 
 
     it('lost invalidation', function (done) {
+        Util.markServerVersionAtLeast(this, client, '3.8');
+
         this.timeout(13000);
         var stopTest = false;
 

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -73,6 +73,8 @@ describe('LostInvalidation', function() {
     });
 
     it('client eventually receives an update for which the invalidation event was dropped', function() {
+        Util.markServerVersionAtLeast(this, client, '3.8');
+
         var map = client.getMap(mapName);
         var key = 'key';
         var value = 'val';
@@ -98,6 +100,8 @@ describe('LostInvalidation', function() {
     });
 
     it('lost invalidation stress test', function() {
+        Util.markServerVersionAtLeast(this, client, '3.8');
+
         var map = client.getMap(mapName);
         var invalidationHandlerStub;
         return Util.promiseWaitMilliseconds(100).then(function(resp) {

--- a/test/nearcache/MigratedDataTest.js
+++ b/test/nearcache/MigratedDataTest.js
@@ -71,6 +71,8 @@ describe('MigratedData', function() {
     });
 
     it('killing a server migrates data to the other node, migrated data has new uuid, near cache discards data with old uuid', function() {
+        Util.markServerVersionAtLeast(this, client, '3.8');
+
         var map = client.getMap(mapName);
         var survivingMember;
         var key = 1;


### PR DESCRIPTION
adds a utility method to skip tests if expected server version is not satisfied

Without the check newly added eventually consistent near cache tests fail in client compatibility test suite against older server versions.