### PR TITLE
PagingPredicate fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import * as Predicates from './core/Predicate';
 import Address = require('./Address');
 import TopicOverloadPolicy = require('./proxy/topic/TopicOverloadPolicy');
 import * as HazelcastErrors from './HazelcastError';
+import {IterationType} from './core/Predicate';
 
 export {
     HazelcastClient as Client,
@@ -31,5 +32,6 @@ export {
     Address,
     Predicates,
     TopicOverloadPolicy,
-    HazelcastErrors
+    HazelcastErrors,
+    IterationType
 };

--- a/test/javaclasses/CustomComparator.js
+++ b/test/javaclasses/CustomComparator.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+var IterationType = require('../../lib/').IterationType;
+
 /**
  *
  * @param type
@@ -45,12 +47,35 @@ CustomComparator.prototype.readData = function (inp) {
     this.iterationType = inp.readInt();
 };
 
-CustomComparator.prototype.sort = function (o1, o2) {
-    if (this.type === 0) {
-        return o1[1] - o2[1];
-    } else {
-        return o2[1] - o1[1];
+CustomComparator.prototype.sort = function (e1, e2) {
+    var str1;
+    var str2;
+    switch (this.iterationType) {
+        case IterationType.KEY:
+            str1 = e1[0].toString();
+            str2 = e2[0].toString();
+            break;
+        case IterationType.VALUE:
+            str1 = e1[1].toString();
+            str2 = e2[1].toString();
+            break;
+        case IterationType.ENTRY:
+            str1 = e1[0].toString() + e1[1].toString();
+            str2 = e2[0].toString() + e2[1].toString();
+            break;
+        default:
+            str1 = e1[0].toString();
+            str2 = e2[0].toString();
     }
+    switch (this.type) {
+        case 0:
+            return str1.localeCompare(str2);
+        case 1:
+            return str2.localeCompare(str1);
+        case 2:
+            return str1.length - str2.length;
+    }
+    return 0;
 };
 
 module.exports = CustomComparator;

--- a/test/map/MapPredicateTest.js
+++ b/test/map/MapPredicateTest.js
@@ -187,8 +187,8 @@ describe("Predicates", function() {
     });
 
     it('Paging with reverse comparator should have elements in reverse order', function() {
-        var paging = Predicates.paging(Predicates.lessThan('this', 40), 3, createReverseValueComparator());
-        return testPredicate(paging, [39, 38, 37], true);
+        var paging = Predicates.paging(Predicates.lessThan('this', 10), 3, createReverseValueComparator());
+        return testPredicate(paging, [9, 8, 7], true);
     });
 
     it('Paging first page should have first two items', function() {


### PR DESCRIPTION
`CustomComparator` is javascript counterpart of server side `CustomComparator` test class. JS version's sort method is very short and **wrong**. CustomComparator on Java side compares entries after converting key and value to strings. JS version should do the same. Line
```
o1[0] - o2[0]
```
works for strings as Java's `String.compareTo` to some extent. Except when the object is a string that represents a number such as `"39"`. Javascript type coercion converts this string to a number when it sees the subtract operation. Therefore the operation in `sort` was actually a subtract operation between two numbers instead of string comparison in this test. So the assumption of this test was wrong. Therefore this PR fixes the test.
Thankfully, there is nothing wrong with the implementation. Only the test was broken.

This PR also puts `IterationType` object in `index` so that the users can import it and use it when they implement custom comparators. That was not possible before.