### PR TITLE
increases timeout for ClusterServiceTests.js. This test failed with 3…

### DIFF
--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -21,7 +21,7 @@ var Config = require('../.').Config;
 var Promise = require('bluebird');
 
 describe('ClusterService', function() {
-    this.timeout(15000);
+    this.timeout(25000);
     var cluster;
     var ownerMember;
 


### PR DESCRIPTION
….6 server because that server was slower to shutdown compared to newer servers