### PR TITLE
Remove typedoc from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "rimraf": "2.6.2",
     "sinon": "4.0.0",
     "tslint": "5.7.0",
-    "typedoc": "0.9.0",
     "typescript": "2.5.2",
     "winston": "2.3.1"
   },


### PR DESCRIPTION
New typedoc breaks the builds because of its incompatible dependencies on build path. This PR removes typedoc from dev-dependencies but leaves `generate-docs` script in `package.json`. If somebody runs `npm run generate-docs` without installing `typedoc` in their system, they will get error. If they install `typedoc` globally in their systems, docs are generated(if no dependency conflicts with the installation).