### PR TITLE
simplify code samples

### DIFF
--- a/code_samples/aggregation.js
+++ b/code_samples/aggregation.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Client = require('hazelcast-client').Client;
+var Aggregators = require('hazelcast-client').Aggregators;
+var Predicates = require('hazelcast-client').Predicates;
+
+Client.newHazelcastClient().then(function (hazelcastClient) {
+    var client = hazelcastClient;
+    var map = hazelcastClient.getMap('person-age-map');
+
+    map.putAll([
+        ['Philip', 46],
+        ['Elizabeth', 44],
+        ['Henry', 13],
+        ['Paige', 15]
+    ]).then(function () {
+        return map.aggregate(Aggregators.count());
+    }).then(function (count) {
+        console.log('There are ' + count + ' people.');
+        return map.aggregateWithPredicate(Aggregators.count(), Predicates.lessEqual('this', 18));
+    }).then(function (count) {
+        console.log('There are ' + count + ' children.');
+        return map.aggregate(Aggregators.numberAvg());
+    }).then(function (avgAge) {
+        console.log('Average age is '+ avgAge);
+        return client.shutdown();
+    });
+});

--- a/code_samples/custom_serializer.js
+++ b/code_samples/custom_serializer.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
-var Config = require('../.').Config;
+var Client = require('hazelcast-client').Client;
+var Config = require('hazelcast-client').Config;
 var cfg = new Config.ClientConfig();
 
 function TimeOfDay(hour, minute, second) {

--- a/code_samples/distributedobject_listener.js
+++ b/code_samples/distributedobject_listener.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
+var Client = require('hazelcast-client').Client;
 Client.newHazelcastClient().then(function(hazelcastClient) {
     hazelcastClient.addDistributedObjectListener(function(serviceName, name, event) {
         console.log('Distributed object event >>> ' + JSON.stringify({serviceName: serviceName, name: name, event: event}));

--- a/code_samples/global_serializer.js
+++ b/code_samples/global_serializer.js
@@ -19,8 +19,8 @@
  * We will use Mousse serializer to serialize our self referring objects.
  */
 var mousse = require('mousse');
-var Client = require('../.').Client;
-var Config = require('../.').Config;
+var Client = require('hazelcast-client').Client;
+var Config = require('hazelcast-client').Config;
 var cfg = new Config.ClientConfig();
 cfg.serializationConfig.globalSerializer = {
     mousseSerialize: mousse.serialize,

--- a/code_samples/list.js
+++ b/code_samples/list.js
@@ -14,62 +14,28 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
-
-var addPerson = function(list, val){
-  return   list.add(val).then(function(){
-        console.log('Added value: ' + val);
-  });
-};
-
-var addPersonTo = function(list, val, index){
-    return   list.add(val, index).then(function(){
-        console.log('Added value to the ' + index + 'th index: ' + val);
-    });
-};
-
-var removePerson = function(list, val){
-    return list.remove(val).then(function(){
-         console.log('Removed value: ' + val);
-    });
-};
-
-var removePersonAt = function(list, index){
-    return list.removeAt(index).then(function(previousVal){
-        console.log('Removed value: ' + previousVal);
-    });
-};
-
-var shutDownHz = function(client){
-      return client.shutdown();
-};
+var Client = require('hazelcast-client').Client;
 
 Client.newHazelcastClient().then(function(hazelcastClient){
+    var client = hazelcastClient;
     var list = hazelcastClient.getList('people');
-    var john = 'John';
-    var jane = 'Jane';
-    var thomas = 'Thomas';
 
-    //adds the value to the end of the list
-    addPerson(list, john)
-        .then(function(){
-            //adds the value to the specific index
-            return addPersonTo(list, jane, 2);
-        })
-        .then(function(){
-            return addPerson(list, thomas);
-        })
-        .then(function(){
-            //removes the given value in the list
-            return removePerson(list, jane);
-        })
-        .then(function(){
-            //removes the value in the list, specified by the index
-            return removePersonAt(list, 2);
-        })
-        .then(function(){
-            shutDownHz(hazelcastClient);
-        })
+    list.add('John').then(function (value) {
+        console.log('Added John.');
+        return list.add('Jane', 1);
+    }).then(function () {
+        console.log('Added Jane to index 1.');
+        return list.add('Thomas');
+    }).then(function () {
+        console.log('Added Thomas.');
+        return list.remove('Jane');
+    }).then(function (value) {
+        console.log('Removed Jane.');
+        return list.removeAt(1);
+    }).then(function (value) {
+        console.log('Removed ' + value);
+        return client.shutdown();
+    });
 });
 
 

--- a/code_samples/logging.js
+++ b/code_samples/logging.js
@@ -15,8 +15,8 @@
  */
 
 var winston = require('winston');
-var Config = require('../.').Config;
-var HazelcastClient = require('../.').Client;
+var Config = require('hazelcast-client').Config;
+var HazelcastClient = require('hazelcast-client').Client;
 
 if(process.argv.length != 3){
     console.log('Run as node logging.js [logger]');

--- a/code_samples/map_entry_listener.js
+++ b/code_samples/map_entry_listener.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
+var Client = require('hazelcast-client').Client;
 var listener = {
     added: function(key, oldVal, newVal) {
         console.log('added key: ' + key + ', old value: ' + oldVal + ', new value: ' + newVal);

--- a/code_samples/near_cache.js
+++ b/code_samples/near_cache.js
@@ -1,5 +1,5 @@
-var Client = require('../.').Client;
-var Config = require('../.').Config;
+var Client = require('hazelcast-client').Client;
+var Config = require('hazelcast-client').Config;
 
 var nearCachedMapName = 'nearCachedMap';
 var regularMapName = 'reqularMap';

--- a/code_samples/node_modules/hazelcast-client/index.js
+++ b/code_samples/node_modules/hazelcast-client/index.js
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-var HazelcastClient = require('hazelcast-client').Client;
-var Config = require('hazelcast-client').Config;
-var cfg = new Config.ClientConfig();
-cfg.listeners.addLifecycleListener(function(state) {
-    console.log('Lifecycle Event >>> ' + state);
-});
-HazelcastClient.newHazelcastClient(cfg).then(function(hazelcastClient) {
-    hazelcastClient.shutdown();
-});
+//This dummy module serves as a link to actual hazelcast-client implementation from code_samples directory.
+//This module should NOT be used anywhere outside of this code_samples directory.
+module.exports = require('../../../');

--- a/code_samples/paging_predicate.js
+++ b/code_samples/paging_predicate.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
-var Config = require('../.').Config;
-var Predicates = require('../.').Predicates;
+var Client = require('hazelcast-client').Client;
+var Config = require('hazelcast-client').Config;
+var Predicates = require('hazelcast-client').Predicates;
 var cfg = new Config.ClientConfig();
 
 //This comparator is both a comparator and an IdentifiedDataSerializable.

--- a/code_samples/queue.js
+++ b/code_samples/queue.js
@@ -14,63 +14,26 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
-
-var insertPerson = function (queue, val) {
-    return queue.add(val).then(function(previousVal) {
-        console.log('Added value: ' + val + ',  previous value: ' + JSON.stringify(previousVal));
-    });
-};
-
-var pollPerson = function(queue){
-    return queue.poll().then(function(previousVal) {
-        console.log('Polled value: ' + JSON.stringify(previousVal));
-    });
-};
-
-var peekPerson = function(queue){
-  return queue.peek().then(function(previousVal){
-        console.log('Peeked value: ' + JSON.stringify(previousVal));
-  });
-};
-
-var shutdownHz = function(client) {
-    return client.shutdown();
-};
+var Client = require('hazelcast-client').Client;
 
 Client.newHazelcastClient().then(function(hazelcastClient){
+    var client = hazelcastClient;
     var queue = hazelcastClient.getQueue('people');
-    var john = 'John';
-    var jane = 'Jane';
-    var judy = 'Judy';
 
-    //inserts to the back of the queue
-    insertPerson(queue,john)
-        .then(function (){
-            //inserts to the back of the queue
-            return insertPerson(queue,jane);
-        })
-        .then(function (){
-            //inserts to the back of the queue
-            return insertPerson(queue,judy);
-        })
-        .then(function (){
-            //retrieves and also removes the head of the queue
-            return pollPerson(queue);
-        })
-        .then(function(){
-            //retrieves but not remove the head of the queue
-            return peekPerson(queue);
-        })
-        .then(function (){
-            return pollPerson(queue);
-        })
-        .then(function(){
-            return peekPerson(queue);
-        })
-        .then(function(){
-            shutdownHz(hazelcastClient)
-        })
+    queue.put('Item1').then(function () {
+        return queue.put('Item2');
+    }).then(function () {
+        return queue.peek();
+    }).then(function (item) {
+        console.log('Peeked item: ' + item + '. Item is not removed from queue.');
+        return queue.poll();
+    }).then(function (item) {
+        console.log('Retrieved item: ' + item + '. Item is removed from queue.');
+        return queue.poll();
+    }).then(function (item) {
+        console.log('Retrieved item: ' + item);
+        return client.shutdown();
+    });
 });
 
 

--- a/code_samples/set.js
+++ b/code_samples/set.js
@@ -14,78 +14,20 @@
  * limitations under the License.
  */
 
-var Client = require('../.').Client;
-
-var insertPerson = function(myset, val){
-    return myset.add(val).then(function(previousVal){
-       console.log('Added value: ' + val + ' Insert operation: ' + previousVal);
-    });
-};
-
-var removePerson = function(myset,val){
-    return myset.remove(val).then(function() {
-        console.log('Removed value: ' + val);
-    });
-};
-
-
-var containPerson = function(myset, val){
-    return myset.contains(val).then(function(previousVal){
-        if(previousVal === true)
-            console.log("Set contains the value " + val) ;
-        else
-            console.log("Set does not contain the value " + val);
-    });
-};
-
-var totalPeople = function(myset){
-    return myset.size().then(function(previousVal){
-       console.log("Set consists of " + previousVal + " elements");
-    });
-}
-
-var shutdownHz = function(client) {
-    return client.shutdown();
-};
-
+var Client = require('hazelcast-client').Client;
 
 Client.newHazelcastClient().then(function (hazelcastClient) {
-    var set = hazelcastClient.getSet('people');
-    var john = 'John';
-    var jane = 'Jane';
-    var anotherjohn = 'John';
+    var client = hazelcastClient;
+    var set = hazelcastClient.getSet('my-distributed-set');
 
-    //insert an element
-    insertPerson(set, john)
-        .then(function () {
-            //inserts a different element
-            return insertPerson(set, jane);
-        })
-        .then(function () {
-            //trying to insert an element which has been already added to the set and so failing to add
-            return insertPerson(set, anotherjohn);
-        })
-        .then(function () {
-            //check if an element is in the set or not
-            return containPerson(set, 'John');
-        })
-        .then(function () {
-            //check if an element is in the set or not
-            return containPerson(set, 'Jack');
-        })
-        .then(function () {
-            //total number of elements in the set
-            return totalPeople(set);
-        })
-        .then(function () {
-            //removes the given value in the set
-            return removePerson(set,'John');
-        })
-        .then(function () {
-            //Because the element was removed, now we can add this element to the set back
-            return insertPerson(set,'John');
-        })
-        .then(function () {
-            shutdownHz(hazelcastClient);
-        })
+    set.add('key').then(function () {
+        console.log('"key" is added to the set.');
+        return set.contains('key');
+    }).then(function (contains) {
+        console.log(contains);
+        return set.size();
+    }).then(function (val) {
+        console.log('Number of elements in the set: ' + val);
+        return client.shutdown();
+    });
 });

--- a/code_samples/ssl_authentication.js
+++ b/code_samples/ssl_authentication.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-var Config = require('../.').Config;
-var HazelcastClient = require('../.').Client;
+var Config = require('hazelcast-client').Config;
+var HazelcastClient = require('hazelcast-client').Client;
 
 if (process.argv.length < 5 ) {
     console.log('Usage: \n' +
@@ -27,7 +27,7 @@ var cfg = new Config.ClientConfig();
 cfg.networkConfig.sslOptions = {
     servername: process.argv[2],
     cert: process.argv[3],
-    ca: process.argv[4],
+    ca: process.argv[4]
 };
 
 HazelcastClient.newHazelcastClient(cfg).then(function (client) {


### PR DESCRIPTION
Before code samples loaded client module using `require('../.')` because they actually refer to the same module that they are present in. I think this causes confusion for our users. I created a dummy `hazelcast-client` module inside code_sample folder. This dummy client actually loads the actual module in this repo. So when we do `require('hazelcast-client')` inside `code_samples` the samples refer to the actual implementation. I think this looks much tidier and easy to use for our users.

Also, I simplified samples for map, set, queue and list. They had too much unnecessary indirection for simple code samples.

Update: Adds code sample for newly implemented Aggregators. https://github.com/hazelcast/hazelcast-nodejs-client/pull/250