### PR TITLE
adds default export support to import configs

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -176,7 +176,12 @@ export function resolvePath(path: string): string {
 }
 
 export function loadNameFromPath(path: string, exportedName: string): any {
-    return require(resolvePath(path))[exportedName];
+    let requirePath = require(resolvePath(path));
+    if (exportedName === undefined) {
+        return requirePath;
+    } else {
+        return require(resolvePath(path))[exportedName];
+    }
 }
 
 export function createAddressFromString(address: string, defaultPort?: number): Address {

--- a/test/javaclasses/IdentifiedFactory.js
+++ b/test/javaclasses/IdentifiedFactory.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var IdentifiedEntryProcessor = require('./IdentifiedFactory');
+var IdentifiedEntryProcessor = require('./IdentifiedEntryProcessor');
 var DistortInvalidationMetadataEntryProcessor = require('./DistortInvalidationMetadataEntryProcessor');
 var CustomComparator = require('./CustomComparator');
 

--- a/test/serialization/SerializationServiceTest.js
+++ b/test/serialization/SerializationServiceTest.js
@@ -16,7 +16,9 @@
 
 var expect = require('chai').expect;
 var SerializationService = require('../../lib/serialization/SerializationService').SerializationServiceV1;
+var IdentifiedEntryProcessor = require('../javaclasses/IdentifiedEntryProcessor');
 var Config = require('../../').Config;
+var Path = require('path');
 
 describe('SerializationServiceTest', function () {
 
@@ -39,6 +41,10 @@ describe('SerializationServiceTest', function () {
         path: __filename,
         exportedName: 'CustomSerializer'
     };
+
+    var identifiedDataSerializableFactoryDefaultExportConfig = {
+        path: Path.resolve(__filename, '../../javaclasses/IdentifiedFactory.js')
+    }
 
     it('adds data serializable factory by its name', function () {
         var serializationConfig = new Config.SerializationConfig();
@@ -89,6 +95,18 @@ describe('SerializationServiceTest', function () {
         expect(object.val).to.equal(3);
         expect(object.self).to.equal(object);
     });
+
+    it('adds identified factory without named export', function () {
+        var serializationConfig = new Config.SerializationConfig();
+        serializationConfig.dataSerializableFactoryConfigs[66] = identifiedDataSerializableFactoryDefaultExportConfig;
+
+        var serializationService = new SerializationService(serializationConfig);
+
+        var data = serializationService.toData(new IdentifiedEntryProcessor('x'));
+        var object = serializationService.toObject(data);
+
+        expect(object.value).to.equal('x');
+    })
 });
 
 function IDataSerializable(val) {


### PR DESCRIPTION
When `exportedName` is not specified in Json config, dynamic module loader loads default export.