### PR TITLE
adds declarative configuration doc

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,418 @@
+You can configure Hazelcast Node.js Client declaratively (JSON) or programmatically (API).
+* Programmatic configuration
+* Declarative configuration (JSON file)
+
+# Programmatic Configuration
+For programmatic configuration of the Hazelcast Java Client, just instantiate a ClientConfig object and configure the
+desired aspects. An example is shown below.
+
+```javascript
+var Config = require('hazelcast-client').Config;
+var Address = require('hazelcast-client').Address;
+var cfg = new Config.ClientConfig();
+cfg.networkConfig.addresses.push(new Address('127.0.0.11', 5701));
+return HazelcastClient.newHazelcastClient(cfg);
+```
+
+Refer to [Hazelcast Node.js Client API Docs](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs) for details.
+
+# Declarative Configuration (JSON)
+For declarative configuration, the Hazelcast client looks at the following places for the client configuration file.
+
+1. Environment variable: The client first looks for the environment variable `HAZELCAST_CLIENT_CONFIG`. If it exists, 
+the client looks for the configuration file in the specified location.
+2. Current working directory: If there is no environment variable set, the client tries to load `hazelcast-client.json`
+from current working directory.
+3. Default configuration: If above methods fail, the client starts with default configuration.
+
+Following is a sample JSON configuration file:
+```json
+{
+    "group": {
+        "name": "hazel",
+        "password": "cast"
+    },
+    "properties": {
+        "hazelcast.client.heartbeat.timeout": 10000,
+        "hazelcast.client.invocation.retry.pause.millis": 4000,
+        "hazelcast.client.invocation.timeout.millis": 180000,
+        "hazelcast.invalidation.reconciliation.interval.seconds": 50,
+        "hazelcast.invalidation.max.tolerated.miss.count": 15,
+        "hazelcast.invalidation.min.reconciliation.interval.seconds": 60
+    },
+    "network": {
+        "clusterMembers": [
+            "127.0.0.1:5701"
+        ],
+        "smartRouting": true,
+        "connectionTimeout": 6000,
+        "connectionAttemptPeriod": 4000,
+        "connectionAttemptLimit": 3
+    }
+}
+```
+
+## Group Configuration
+Clients should provide a group name and password in order to connect to the cluster.
+You can configure them as shown below.
+```json
+{
+    "group": {
+        "name": "hazel",
+        "password": "cast"
+    }
+}
+```
+
+## Client Network
+All network related configuration of Hazelcast Node.js Client is performed via the `network` element in the declarative
+configuration file. Let's first give an example for `network` configuration. Then we will look at its properties.
+```json
+{
+    "network": {
+        "clusterMembers": [
+            "127.0.0.9",
+            "127.0.0.2:5702"
+        ],
+        "smartRouting": false,
+        "connectionTimeout": 6000,
+        "connectionAttemptPeriod": 4000,
+        "connectionAttemptLimit": 3,
+        "ssl": {
+            "enabled": true,
+            "factory": {
+                "path": "path/to/file",
+                "exportedName": "exportedName",
+                "properties": {
+                    "userDefinedProperty1": "userDefinedValue"
+                }
+            }
+        }
+    }
+}
+```
+
+### Configuring Address List
+Address list is the initial list of cluster addresses to which the client will connect. The client uses this
+list to find an alive member. Although it may be enough to give only one address of a member in the cluster
+(since all members communicate with each other), it is recommended that you give the addresses for all the members.
+```json
+{
+    "network": {
+        "clusterMembers": [
+            "127.0.0.9",
+            "127.0.0.2:5702"
+        ]
+    }
+}
+```
+If the port part is omitted, then 5701, 5702, and 5703 will be tried in random order.
+
+Default address is 127.0.0.1.
+
+### Setting Smart Routing
+Smart routing defines whether the client mode is smart or unisocket. The following is an example configuration.
+```json
+{
+    "network": {
+        "smartRouting": true
+    }
+}
+```
+Default is smart routing mode.
+
+### Setting Connection Timeout
+Connection timeout is the timeout value in milliseconds for members to accept client connection requests.
+```json
+{
+    "network": {
+        "connectionTimeout": 6000
+    }
+}
+```
+Default value is 5000 milliseconds.
+
+### Setting Connection Attempt Limit
+While the client is trying to connect initially to one of the members in the  address list, that member
+might not be available at that moment. Instead of giving up, throwing an error and stopping the client, 
+the client will retry as many as connection attempt limit times. This is also the case when the previously
+established connection between the client and that member goes down.
+```json
+{
+    "network": {
+        "connectionAttemptLimit": 3
+    }
+}
+```
+Default value is 2.
+### Setting Connection Attempt Period
+Connection timeout period is the duration in milliseconds between the connection attempts defined by
+connection attempt limit.
+```json
+{
+    "network": {
+        "connectionAttemptPeriod": 4000
+    }
+}
+```
+Default value is 3000.
+### Enabling Client TLS/SSL
+You can use TLS/SSL to secure the connection between the client and members. If you want TLS/SSL enabled
+for the client-cluster connection, you should set an SSL configuration. Once set, the connection (socket) is 
+established out of an options object supplied by the user.
+
+Hazelcast Node.js Client uses a user supplied SSL options object to pass to 
+[`tls.connect` of Node.js](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback). There are two ways
+to provide this object to the client;
+1. Using builtin `BasicSSLOptionsFactory` bundled with the client.
+2. Writing an SSLOptionsFactory.
+
+#### 1. Using Built-in BasicSSLOptionsFactory
+Hazelcast Node.js Client includes a utility factory class that creates the necessary options object out of supplied
+properties. All you need to do is specify your factory as `BasicSSLOptionsFactory` and provide the following options.
+
+    certPath
+    caPath
+    servername
+    rejectUnauthorized
+    ciphers
+
+Refer to [`tls.connect` of Node.js](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for meaning
+of each option.
+> `certPath` and `caPath` define file path to respective file that stores such information.
+
+```json
+{
+    "network": {
+        "ssl": {
+            "enabled": true,
+            "factory": {
+                "exportedName": "BasicSSLOptionsFactory",
+                "properties": {
+                    "caPath": "ca.pem",
+                    "certPath": "cert.pem",
+                    "rejectUnauthorized": false
+                }
+            }
+        }
+    }
+}
+```
+If these options are not enough for your application, you may write your own options factory and instruct the client
+to get the options from it.
+
+#### Writing an SSL Options Factory
+In order to use the full range of options provided to [`tls.connect` of Node.js](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback),
+you may write your own factory object.
+```json
+{
+    "network": {
+        "ssl": {
+            "enabled": true,
+            "factory": {
+                "path": "my_factory.js",
+                "exportedName": "SSLFactory",
+                "properties": {
+                    "caPath": "ca.pem",
+                    "certPath": "cert.pem",
+                    "keepOrder": true
+                }
+            }
+        }
+    }
+}
+```
+
+
+my_factory.js
+```javascript
+function SSLFactory() {
+}
+ 
+SSLFactory.prototype.init = function(props) {
+    this.keyPath = props.keyPath;
+    this.caPath = props.caPath;
+    this.keepOrder = props.userDefinedProperty1;
+};
+ 
+SSLFactory.prototype.getSSLOptions = function() {
+    var sslOpts = {
+        servername: 'foo.bar.com',
+        rejectUnauthorized: true,
+        cert: fs.readFileSync(this.keyPath),
+        ca: fs.readFileSync(this.caPath)
+    };
+    if (this.keepOrder) {
+        sslOpts.honorCipherOrder = true;
+    }
+    return sslOpts;
+};
+exports.SSLFactory = SSLFactory;
+```
+
+The client loads MyFactory.js at runtime and creates an instance of SSLFactory. It then, calls `init` method with
+the properties section in JSON config. Lastly, the client calls `getSSLOptions` method of SSLFactory to create the
+options object.
+
+For information about path resolution, refer to [Path Resolution](#path-resolution-and-object-loading)
+
+## Serialization Configuration
+This section shows how to configure Hazelcast serialization declaratively. Please refer to [Hazelcast IMDG Reference Manual](http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#serialization)
+and [Node.js client readme](https://github.com/hazelcast/hazelcast-nodejs-client/#serialization-considerations) for
+learning about serialization.
+
+Serialization configuration is as follows:
+
+```json
+{
+"serialization": {
+        "defaultNumberType": "integer",
+        "isBigEndian": false,
+        "dataSerializableFactories": [
+            {
+                "path": "path/to/file",
+                "exportedName": "exportedName",
+                "factoryId": 0
+            }
+        ],
+        "portableFactories": [
+            {
+                "path": "path/to/file",
+                "exportedName": "exportedName",
+                "factoryId": 1
+            }
+        ],
+        "portableVersion": 1,
+        "globalSerializer": {
+            "path": "path/to/file",
+            "exportedName": "exportedName"
+        },
+        "serializers": [
+            {
+                "path": "path/to/custom",
+                "exportedName": "CustomSerializer1",
+                "typeId": 2
+            },
+            {
+                "path": "path/to/custom",
+                "exportedName": "CustomSerializer2",
+                "typeId": 3
+            }
+        ]
+    }
+}
+```
+
+One important aspect of Node.js Client's serialization is `defaultNumberType`. Hazelcast servers use 4 different
+primitive numeric types; `int`, `long`, `float` and `double`. However, Javascript has only one numeric type which
+is `number`. Number is a floating point type. If you do not work with heterogenous clients (multiple languages),
+you do not need to worry about this setting. However, if your numeric data is accessed by clients in different 
+languages, you need to map `number` type to one of the numeric types recognized by Java servers. Hazelcast handles
+type conversions automatically. Accepted values for `defaultNumberType` are `integer`, `float` and `double`. You
+may use `long` module for working with longs. [long module](https://www.npmjs.com/package/long) is included
+in Hazelcast Node.js client.
+
+Related section: [Path Resolution](#path-resolution-and-object-loading)
+
+## Configuring Near Cache
+You may configure near caches for your maps as the following:
+
+```json
+{
+    "nearCaches": [
+        {
+            "name": "nc-map",
+            "invalidateOnChange": false,
+            "maxIdleSeconds": 2,
+            "inMemoryFormat": "object",
+            "timeToLiveSeconds": 3,
+            "evictionPolicy": "lru",
+            "evictionMaxSize": 3000,
+            "evictionSamplingCount": 4,
+            "evictionSamplingPoolSize": 8
+        }
+    ]
+}
+```
+`nearCaches` is an array that includes one configuration object for each near cache in the client. For meanings
+of configuration options refer to [NearCacheConfig API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/0.7/docs/classes/_config_.nearcacheconfig.html)
+
+## Composing Declarative Configuration
+You can compose the declarative configuration of your Hazelcast client from multiple declarative
+configuration snippets. In order to compose a declarative configuration, you can use the `import` element to load
+different declarative configuration files.
+
+group-config.json:
+```json
+{
+    "group": {
+        "name": "hazel",
+        "password": "cast"
+    }
+}
+```
+
+network-config.json:
+```json
+{
+    "network": {
+        "clusterMembers": [
+            "127.0.0.10:4001",
+            "127.0.0.11:4001"
+        ]
+    }
+}
+```
+
+To get your example Hazelcast declarative configuration out of the above two, use the `import` element as
+shown below.
+
+```json
+{
+    "import": [
+        "group-config.json",
+        "network-config.json"
+    ]
+}
+```
+
+> Note: Use `import` element on top level of json hierarchy. 
+
+
+## Path Resolution and Object Loading
+For configuration elements that require you to specify a code piece, you will need to specify the path to
+code and the name of exported element that you want the client to use. This configuration is set by the following:
+```json
+{
+    "path": "path/to/file",
+    "exportedName": "MyObject"
+}
+```
+
+In the above configuration, `path` shows the address to the file that you want the client to load. Unless this is an
+absolute path, it is relative to the location of `hazelcast-config.json` file.
+
+In Javascript you can define and export as many objects as you want in a single file. Above configuration element
+is designed to load only one specified object from a file. Therefore `exportedName` specifies the name of desired
+object.
+
+Let's say your project directory structure is like the following:
+
+    my_app/
+    my_app/index.js
+    my_app/factory_utils.js
+    my_app/hazelcast-client.json
+    my_app/node_modules/
+    my_app/node_modules/hazelcast-client
+    
+In `factory_utils.js`, you have multiple exported functions.
+```javascript
+exports.utilityFunction = function() {...}
+exports.MySSLFactory = function() {...}
+```
+
+In order to load `MySSLFactory` in your SSL configuration, you should set `path` and `exportedName` as `factory_utils.js`
+and `MySSLFactory` respectively.
+
+If you have only one export as the default export from `factory_utils.js`, just skip `exportedName` property and
+the client will load the default export from the file.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Please see Hazelcast Node.js [code samples](https://github.com/hazelcast/hazelca
 
 You can also refer to Hazelcast Node.js [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/).
 
+# Configuration
+
+You can configure Hazelcast Node.js Client declaratively (JSON) or programmatically (API).
+
+See [CONFIG.md](CONFIG.md) for details.
+
+
 # Serialization Considerations
 
 Hazelcast needs to serialize objects in order to be able to keep them in the server memory. For primitive types, it uses Hazelcast native serialization. For other complex types (e.g. JS objects), it uses JSON serialization.


### PR DESCRIPTION
Since JSON declarative configuration is available only in Node.js, I created this detailed explanation in CONFIG.md file. It describes how to configure all settings but users still need to depend on docs.hazelcast.org to understand what these settings mean.