### PR TITLE
adds json schema

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -1,0 +1,299 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "id": "https://github.com/hazelcast/hazelcast-nodejs-client/blob/schema/config-schema.json",
+    "title": "Hazelcast Node.js Client Configuration",
+    "type": "object",
+    "definitions": {
+        "importPath": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "format": "uri-reference"
+                },
+                "exportedName": {
+                    "type": "string"
+                }
+            }
+        },
+        "propertiesObject": {
+            "type": "object",
+            "propertyNames": {
+                "pattern": "^[^ ]*$"
+            },
+            "additionalProperties": {
+                "type": [
+                    "number",
+                    "string"
+                ]
+            }
+        },
+        "positiveInteger": {
+            "type": "number",
+            "minimum": 0,
+            "multipleOf": 1
+        },
+        "listenerConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/importPath"
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "lifecycle",
+                                "map"
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+        "factoryConfig": {
+            "allOf": [
+                {
+                    "$ref": "#/definitions/importPath"
+                },
+                {
+                    "properties": {
+                        "factoryId": {
+                            "$ref": "#/definitions/positiveInteger"
+                        }
+                    }
+                }
+            ]
+        },
+        "factoryConfigArray": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/factoryConfig"
+            }
+        }
+    },
+    "properties": {
+        "group": {
+            "type": "object",
+            "required": [
+                "name",
+                "password"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        },
+        "properties": {
+            "$ref": "#/definitions/propertiesObject"
+        },
+        "network": {
+            "type": "object",
+            "properties": {
+                "clusterMembers": {
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "smartRouting": {
+                    "type": "boolean",
+                    "default": true
+                },
+                "connectionTimeout": {
+                    "type": "number",
+                    "minimum": 1000,
+                    "default": 5000
+                },
+                "connectionAttemptPeriod": {
+                    "type": "number",
+                    "minimum": 1,
+                    "default": 3000
+                },
+                "connectionAttemptLimit": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 2
+                },
+                "ssl": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "factory": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/definitions/importPath"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "properties": {
+                                            "$ref": "#/definitions/propertiesObject"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "listeners": {
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/listenerConfig"
+            }
+        },
+        "serialization": {
+            "type": "object",
+            "properties": {
+                "defaultNumberType": {
+                    "enum": [
+                        "integer",
+                        "float",
+                        "double"
+                    ],
+                    "default": "double"
+                },
+                "isBigEndian": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "portableVersion": {
+                    "$ref": "#/definitions/positiveInteger"
+                },
+                "dataSerializableFactories": {
+                    "$ref": "#/definitions/factoryConfigArray"
+                },
+                "portableFactories": {
+                    "$ref": "#/definitions/factoryConfigArray"
+                },
+                "globalSerializer": {
+                    "$ref": "#/definitions/importPath"
+                },
+                "serializers": {
+                    "type": "array",
+                    "items": {
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/importPath"
+                            },
+                            {
+                                "required": [
+                                    "typeId"
+                                ],
+                                "properties": {
+                                    "typeId": {
+                                        "$ref": "#/definitions/positiveInteger"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "nearCaches": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "invalidateOnChange": {
+                        "type": "boolean",
+                        "default": true
+                    },
+                    "maxIdleSeconds": {
+                        "type": "number",
+                        "default": 0,
+                        "minimum": 0
+                    },
+                    "inMemoryFormat": {
+                        "enum": [
+                            "object",
+                            "binary"
+                        ],
+                        "default": "binary"
+                    },
+                    "timeToLiveSeconds": {
+                        "type": "number",
+                        "minimum": 0,
+                        "default": 0
+                    },
+                    "evictionPolicy": {
+                        "enum": [
+                            "none",
+                            "lru",
+                            "lfu",
+                            "random"
+                        ],
+                        "default": "none"
+                    },
+                    "evictionMaxSize": {
+                        "$ref": "#/definitions/positiveInteger",
+                        "default": "maximum safe integer"
+                    },
+                    "evictionSamplingCount": {
+                        "$ref": "#/definitions/positiveInteger",
+                        "default": 8
+                    },
+                    "evictionSamplingPoolSize": {
+                        "$ref": "#/definitions/positiveInteger",
+                        "default": 16
+                    }
+                }
+            }
+        },
+        "reliableTopics": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "readBatchSize": {
+                        "$ref": "#/definitions/positiveInteger",
+                        "default": 25
+                    },
+                    "overloadPolicy": {
+                        "enum": [
+                            "discard_oldest",
+                            "discard_newest",
+                            "block",
+                            "error"
+                        ],
+                        "default": "block"
+                    }
+                }
+            }
+        },
+        "import": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chai-as-promised": "7.1.1",
     "hazelcast-remote-controller": "^1.0.0",
     "istanbul": "0.4.5",
+    "jsonschema": "^1.2.2",
     "mocha": "3.5.3",
     "mousse": "0.3.1",
     "remap-istanbul": "0.9.6",

--- a/test/config/SchemaValidationTest.js
+++ b/test/config/SchemaValidationTest.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var expect = require('chai').expect;
+var validate = require('jsonschema').validate;
+var fs = require('fs');
+var path = require('path');
+
+describe('SchemaValidationTest', function () {
+
+    var schema;
+
+    before(function () {
+        schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../config-schema.json'), 'utf8'));
+    });
+
+    function validateCandidate(candidate) {
+        var candidateJson = JSON.parse(candidate);
+        return validate(candidateJson, schema, { nestedErrors: true });
+    }
+
+    it('hazelcast-client-full.json passes validation', function () {
+        var fulljson = fs.readFileSync(path.resolve(__dirname, 'hazelcast-client-full.json'), 'utf8');
+        expect(validateCandidate(fulljson).valid).to.be.true;
+    });
+
+    it('invalid configuration is caught by the validator', function () {
+        var invalidJson = fs.readFileSync(path.resolve(__dirname, 'hazelcast-client-invalid.json'), 'utf8');
+        expect(validateCandidate(invalidJson).errors[0]).to.exist.with.property('message', 'must have a minimum value of 1000');
+    });
+});
+

--- a/test/config/hazelcast-client-invalid.json
+++ b/test/config/hazelcast-client-invalid.json
@@ -1,0 +1,5 @@
+{
+    "network": {
+        "connectionTimeout": 65.6
+    }
+}


### PR DESCRIPTION
This is a schema file for hazelcast-client.json config files.

There is no built-in support for this validation in Javascript or Node.js. I think implementing this validation in client code has a limited value. User can use this schema to validate their hazelcast-client.json using a third party json schema validator.