### PR TITLE
fixes removing wrong member from memberlist issue

### DIFF
--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -251,10 +251,11 @@ export class ClusterService extends EventEmitter {
 
     private memberRemoved(member: Member) {
         let memberIndex = this.members.findIndex(member.equals, member);
-        let removedMemberList = this.members.splice(memberIndex, 1);
-        assert(removedMemberList.length === 1);
-        let removedMember = removedMemberList[0];
-        this.client.getConnectionManager().destroyConnection(removedMember.address);
-        this.emit(EMIT_MEMBER_REMOVED, removedMember);
+        if (memberIndex !== -1) {
+            let removedMemberList = this.members.splice(memberIndex, 1);
+            assert(removedMemberList.length === 1);
+        }
+        this.client.getConnectionManager().destroyConnection(member.address);
+        this.emit(EMIT_MEMBER_REMOVED, member);
     }
 }


### PR DESCRIPTION
If member had already been removed from the member list, do not try to remove it again. When the member is not in the list `findIndex` returns -1. Then `splice`  breaks the array at the wrong index(-1 represents the last element in the array). So it causes an alive member to be removed from the list.