### PR TITLE
fixes #260

### DIFF
--- a/src/serialization/portable/ClassDefinitionWriter.ts
+++ b/src/serialization/portable/ClassDefinitionWriter.ts
@@ -86,7 +86,7 @@ export class ClassDefinitionWriter implements PortableWriter {
     writeNullPortable(fieldName: string, factoryId: number, classId: number): void {
         var version: number = 0;
         var nestedCD = this.portableContext.lookupClassDefinition(factoryId, classId, version);
-        if (nestedCD === null) {
+        if (nestedCD == null) {
             throw new RangeError('Cannot write null portable without explicitly registering class definition!');
         }
         this.addFieldByType(fieldName, FieldType.PORTABLE, nestedCD.getFactoryId(), nestedCD.getClassId());

--- a/src/serialization/portable/PortableSerializer.ts
+++ b/src/serialization/portable/PortableSerializer.ts
@@ -65,7 +65,7 @@ export class PortableSerializer implements Serializer {
 
         var portable: Portable = factory.create(classId);
         var classDefinition = this.portableContext.lookupClassDefinition(factoryId, classId, version);
-        if (classDefinition === null) {
+        if (classDefinition == null) {
             var backupPos = input.position();
             try {
                 classDefinition = this.portableContext.readClassDefinitionFromInput(input, factoryId, classId, version);

--- a/test/serialization/PortableSerializersLiveTest.js
+++ b/test/serialization/PortableSerializersLiveTest.js
@@ -12,6 +12,22 @@ describe('Default serializers with live instance', function() {
     var client;
     var map;
 
+    function getClientConfig() {
+        var cfg = new Config.ClientConfig();
+        cfg.serializationConfig.portableFactories[10] = {
+            create: function(classId) {
+                if (classId === 222) {
+                    return new InnerPortable();
+                } else if (classId === 21) {
+                    return new SimplePortable();
+                } else {
+                    return null;
+                }
+            }
+        };
+        return cfg;
+    }
+
     before(function() {
         return RC.createCluster(null, null).then(function (res) {
             cluster = res;
@@ -19,19 +35,7 @@ describe('Default serializers with live instance', function() {
             return RC.startMember(cluster.id);
         }).then(function (m) {
             member = m;
-            var cfg = new Config.ClientConfig();
-            cfg.serializationConfig.portableFactories[10] = {
-                create: function(classId) {
-                    if (classId === 222) {
-                        return new InnerPortable();
-                    } else if (classId === 21) {
-                        return new SimplePortable();
-                    } else {
-                        return null;
-                    }
-                }
-            };
-            return Client.newHazelcastClient(cfg);
+            return Client.newHazelcastClient(getClientConfig());
         }).then(function (cl) {
             client = cl;
             map = client.getMap('test');
@@ -43,12 +47,32 @@ describe('Default serializers with live instance', function() {
         return RC.shutdownCluster(cluster.id);
     });
 
-    it('two portables write and read', function () {
+    it('client can write and read two different serializable objects of the same factory', function () {
         var simplePortable = new SimplePortable('atext');
         var innerPortable = new InnerPortable('str1', 'str2');
         return map.put('simpleportable', simplePortable).then(function () {
             return map.put('innerportable', innerPortable);
         }).then(function() {
+            return map.get('simpleportable');
+        }).then(function (sp) {
+            return map.get('innerportable').then(function (ip) {
+                expect(sp).to.deep.equal(simplePortable);
+                expect(ip).to.deep.equal(innerPortable);
+                return Promise.resolve();
+            });
+        });
+    });
+
+    it('client can read two different serializable objects of the same factory (written by another client)', function () {
+        var simplePortable = new SimplePortable('atext');
+        var innerPortable = new InnerPortable('str1', 'str2');
+        return map.putAll([['simpleportable', simplePortable], ['innerportable', innerPortable]]).then(function () {
+            client.shutdown();
+        }).then(function() {
+            return Client.newHazelcastClient(getClientConfig());
+        }).then(function (cl) {
+            client = cl;
+            map = client.getMap('test');
             return map.get('simpleportable');
         }).then(function (sp) {
             return map.get('innerportable').then(function (ip) {


### PR DESCRIPTION
`PortableContext.lookupClassDefinition` may return `null` or `undefined`. For `ClassDefinitionWriter` the two return values mean the same thing. So, changed `=== null` to `==null`. The latter covers both `null` and `undefined`.