### PR TITLE
Fix/configpattern

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -215,7 +215,7 @@ export default class HazelcastClient {
      * @returns {ITopic<E>}
      */
     getReliableTopic<E>(name: string): ITopic<E> {
-        return new ReliableTopicProxy(name, this);
+        return <ITopic<E>>this.proxyManager.getOrCreateProxy(name, ProxyManager.RELIABLETOPIC_SERVICE);
     }
 
     getReplicatedMap<K, V>(name: string): IReplicatedMap<K, V> {

--- a/src/config/ConfigPatternMatcher.ts
+++ b/src/config/ConfigPatternMatcher.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ConfigurationError} from '../HazelcastError';
+
+export class ConfigPatternMatcher {
+
+    /**
+     *
+     * @param configPatterns
+     * @param itemName
+     * @throws
+     * @returns `null` if there is no matching pattern
+     *          the best matching pattern otherwis
+     */
+    matches(configPatterns: string[], itemName: string): string {
+        let bestMatchingPoint = -1;
+        let matchingPattern: string = null;
+        let duplicatePattern: string = null;
+        configPatterns.forEach((pattern: string) => {
+            let currentPoint = this.getMatchingPoint(pattern, itemName);
+            if (currentPoint > bestMatchingPoint) {
+                bestMatchingPoint = currentPoint;
+                matchingPattern = pattern;
+                duplicatePattern = null;
+            } else if (currentPoint === bestMatchingPoint && matchingPattern != null) {
+                duplicatePattern = matchingPattern;
+                matchingPattern = pattern;
+            }
+        });
+        if (duplicatePattern != null) {
+            throw new ConfigurationError('Found ambiguous configurations for item ' + itemName + ': "' + matchingPattern +
+                '" vs "' + duplicatePattern + '". Please specify your configuration.');
+        }
+        return matchingPattern;
+    }
+
+    getMatchingPoint(pattern: string, itemName: string): number {
+        let index = pattern.indexOf('*');
+        if (index === -1) {
+            return -1;
+        }
+        let firstPart = pattern.substring(0, index);
+        if (!itemName.startsWith(firstPart)) {
+            return -1;
+        }
+        let secondPart = pattern.substring(index + 1);
+        if (!itemName.endsWith(secondPart)) {
+            return -1;
+        }
+        return firstPart.length + secondPart.length;
+    }
+}

--- a/src/config/FlakeIdGeneratorConfig.ts
+++ b/src/config/FlakeIdGeneratorConfig.ts
@@ -48,4 +48,10 @@ export class FlakeIdGeneratorConfig {
             'prefetchCount: ' + this.prefetchCount + ', ' +
             'prefetchValidityMillis: ' + this.prefetchValidityMillis + ']';
     }
+
+    clone(): FlakeIdGeneratorConfig {
+        let other = new FlakeIdGeneratorConfig();
+        Object.assign(other, this);
+        return other;
+    }
 }

--- a/src/config/NearCacheConfig.ts
+++ b/src/config/NearCacheConfig.ts
@@ -48,4 +48,10 @@ export class NearCacheConfig {
             'evictionMaxSize: ' + this.evictionMaxSize + ', ' +
             'maxIdleSeconds: ' + this.maxIdleSeconds + ']';
     }
+
+    clone(): NearCacheConfig {
+        let other = new NearCacheConfig();
+        Object.assign(other, this);
+        return other;
+    }
 }

--- a/src/config/ReliableTopicConfig.ts
+++ b/src/config/ReliableTopicConfig.ts
@@ -20,4 +20,17 @@ export class ReliableTopicConfig {
     name: string = 'default';
     readBatchSize: number = 25;
     overloadPolicy: TopicOverloadPolicy = TopicOverloadPolicy.BLOCK;
+
+    toString(): string {
+        return 'ReliableTopicConfig[' +
+            'name: ' + this.name + ', ' +
+            'readBatchSize: ' + this.readBatchSize + ', ' +
+            'overloadPolicy: ' + this.overloadPolicy + ']';
+    }
+
+    clone(): ReliableTopicConfig {
+        let other = new ReliableTopicConfig();
+        Object.assign(other, this);
+        return other;
+    }
 }

--- a/src/proxy/FlakeIdGeneratorProxy.ts
+++ b/src/proxy/FlakeIdGeneratorProxy.ts
@@ -31,10 +31,7 @@ export class FlakeIdGeneratorProxy extends BaseProxy implements FlakeIdGenerator
 
     constructor(client: HazelcastClient, serviceName: string, name: string) {
         super(client, serviceName, name);
-        this.config = client.getConfig().flakeIdGeneratorConfigs[name];
-        if (this.config == null) {
-            this.config = new FlakeIdGeneratorConfig();
-        }
+        this.config = client.getConfig().getFlakeIdGeneratorConfig(name);
         this.autoBatcher = new AutoBatcher(() => {
             return this.encodeInvokeOnRandomTarget(FlakeIdGeneratorNewIdBatchCodec, this.config.prefetchCount).then((re: any) => {
                 return new Batch(this.config.prefetchValidityMillis, re.base, re.increment, re.batchSize);

--- a/src/proxy/NearCachedMapProxy.ts
+++ b/src/proxy/NearCachedMapProxy.ts
@@ -39,7 +39,8 @@ export class NearCachedMapProxy<K, V> extends MapProxy<K, V> {
 
     constructor(client: HazelcastClient, servicename: string, name: string) {
         super(client, servicename, name);
-        this.nearCache = new NearCacheImpl(this.client.getConfig().nearCacheConfigs[name], this.client.getSerializationService());
+        this.nearCache = new NearCacheImpl(this.client.getConfig().getNearCacheConfig(name),
+            this.client.getSerializationService());
         if (this.nearCache.isInvalidatedOnChange()) {
             this.addNearCacheInvalidationListener().then((id: string) => {
                 this.invalidationListenerId = id;

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -41,6 +41,7 @@ import {ListenerMessageCodec} from '../ListenerMessageCodec';
 import {ClientNotActiveError, HazelcastError} from '../HazelcastError';
 import {FlakeIdGeneratorProxy} from './FlakeIdGeneratorProxy';
 import {PNCounterProxy} from './PNCounterProxy';
+import {ReliableTopicProxy} from './topic/ReliableTopicProxy';
 
 export class ProxyManager {
     public static readonly MAP_SERVICE: string = 'hz:impl:mapService';
@@ -55,6 +56,7 @@ export class ProxyManager {
     public static readonly ATOMICLONG_SERVICE: string = 'hz:impl:atomicLongService';
     public static readonly FLAKEID_SERVICE: string = 'hz:impl:flakeIdGeneratorService';
     public static readonly PNCOUNTER_SERVICE: string = 'hz:impl:PNCounterService';
+    public static readonly RELIABLETOPIC_SERVICE: string = 'hz:impl:reliableTopicService';
 
     public readonly service: {[serviceName: string]: any} = {};
     private readonly proxies: { [proxyName: string]: DistributedObject; } = {};
@@ -82,6 +84,7 @@ export class ProxyManager {
         this.service[ProxyManager.ATOMICLONG_SERVICE] = AtomicLongProxy;
         this.service[ProxyManager.FLAKEID_SERVICE] = FlakeIdGeneratorProxy;
         this.service[ProxyManager.PNCOUNTER_SERVICE] = PNCounterProxy;
+        this.service[ProxyManager.RELIABLETOPIC_SERVICE] = ReliableTopicProxy;
     }
 
     public getOrCreateProxy(name: string, serviceName: string, createAtServer = true): DistributedObject {
@@ -89,7 +92,7 @@ export class ProxyManager {
             return this.proxies[name];
         } else {
             let newProxy: DistributedObject;
-            if (serviceName === ProxyManager.MAP_SERVICE && this.client.getConfig().nearCacheConfigs[name]) {
+            if (serviceName === ProxyManager.MAP_SERVICE && this.client.getConfig().getNearCacheConfig(name)) {
                 newProxy = new NearCachedMapProxy(this.client, serviceName, name);
             } else {
                 newProxy = new this.service[serviceName](this.client, serviceName, name);

--- a/src/proxy/topic/ITopic.ts
+++ b/src/proxy/topic/ITopic.ts
@@ -16,8 +16,9 @@
 
 import {TopicMessageListener} from './TopicMessageListener';
 import * as Promise from 'bluebird';
+import {DistributedObject} from '../../DistributedObject';
 
-export interface ITopic<E> {
+export interface ITopic<E> extends DistributedObject {
     addMessageListener(listener: TopicMessageListener<E>): string;
     removeMessageListener(id: string): boolean;
     publish(message: E): Promise<void>;

--- a/test/config/ConfigPatternMatcherTest.js
+++ b/test/config/ConfigPatternMatcherTest.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var expect = require('chai').expect;
+var Config = require('../..').Config;
+var HzError = require('../..').HazelcastErrors;
+
+describe('ConfigPatternMatcherTest', function () {
+
+    var cfg = new Config.ClientConfig();
+    var f1 = new Config.FlakeIdGeneratorConfig();
+    f1.prefetchValidityMillis = 111;
+    f1.prefetchCount = 44;
+
+    var f2 = new Config.FlakeIdGeneratorConfig();
+    f2.prefetchValidityMillis = 1176451;
+    f2.prefetchCount = 534;
+
+    var f3 = new Config.FlakeIdGeneratorConfig();
+    f2.prefetchValidityMillis = 114;
+    f2.prefetchCount = 14;
+
+    var f4 = new Config.FlakeIdGeneratorConfig();
+    f4.prefetchValidityMillis = 114;
+    f4.prefetchCount = 14;
+
+    beforeEach(function () {
+        cfg.flakeIdGeneratorConfigs['pref*'] = f2;
+        cfg.flakeIdGeneratorConfigs['*postf'] = f3;
+        cfg.flakeIdGeneratorConfigs['pref*postf'] = f4;
+    });
+
+    function assertConfig(actual, expected, name) {
+        for (var prop in actual) {
+            if (typeof actual[prop] !== 'function') {
+                if (prop === 'name') {
+                    expect(actual[prop]).to.be.equal(name);
+                } else {
+                    expect(actual[prop]).to.be.equal(expected[prop]);
+                }
+            }
+        }
+
+    }
+
+    it('lookupByPattern', function () {
+        assertConfig(cfg.getFlakeIdGeneratorConfig('pref123postf'), f4, 'pref123postf');
+        assertConfig(cfg.getFlakeIdGeneratorConfig('123postf'), f3, '123postf');
+        assertConfig(cfg.getFlakeIdGeneratorConfig('pref123'), f2, 'pref123');
+        assertConfig(cfg.getFlakeIdGeneratorConfig('unconfigured'), new Config.FlakeIdGeneratorConfig(), 'unconfigured');
+    });
+
+    it('lookupByPattern with explicit default', function () {
+        cfg.flakeIdGeneratorConfigs['default'] = f1;
+        assertConfig(cfg.getFlakeIdGeneratorConfig('pref123postf'), f4, 'pref123postf');
+        assertConfig(cfg.getFlakeIdGeneratorConfig('123postf'), f3, '123postf');
+        assertConfig(cfg.getFlakeIdGeneratorConfig('pref123'), f2, 'pref123');
+        assertConfig(cfg.getFlakeIdGeneratorConfig('unconfigured'), f1, 'unconfigured');
+    });
+
+    it('duplicate pattern throws', function () {
+        cfg.flakeIdGeneratorConfigs['abcde*'] = f2;
+        expect(cfg.getFlakeIdGeneratorConfig.bind(cfg, 'abcde.somemore.postf')).to.throw(HzError.ConfigurationError);
+    });
+});

--- a/test/ssl/ClientSSLAuthenticationTest.js
+++ b/test/ssl/ClientSSLAuthenticationTest.js
@@ -88,7 +88,6 @@ describe('SSL Client Authentication Test', function () {
         describe(title, function () {
 
             afterEach(function () {
-                this.timeout(4000);
                 return Controller.shutdownCluster(cluster.id);
             });
 


### PR DESCRIPTION
Adds config pattern matching.

Also, it fixes a reliable topic proxy that I found while implementing this. I realized that reliable topic proxy was not created by proxy manager. This may cause creating a new proxy for the same reliable topic every time `client.getReliableTopic` is called.