### PR TITLE
adds ReadOnlyLazyList

### DIFF
--- a/src/core/ReadOnlyLazyList.ts
+++ b/src/core/ReadOnlyLazyList.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {SerializationService, SerializationServiceV1} from '../serialization/SerializationService';
+
+class ReadOnlyLazyListIterator<T> implements Iterator<T> {
+
+    private index = 0;
+    private list: ReadOnlyLazyList<T>;
+
+    constructor(list: ReadOnlyLazyList<T>) {
+        this.list = list;
+    }
+
+    next(): IteratorResult<T> {
+        if (this.index < this.list.size()) {
+            return { done: false, value: this.list.get(this.index++) };
+        } else {
+            return { done: true, value: undefined};
+        }
+    }
+
+}
+
+export class ReadOnlyLazyList<T> implements Iterable<T> {
+    private internalArray: Array<any>;
+    private serializationService: SerializationService;
+
+    constructor(array: Array<any>, serializationService: SerializationService) {
+        this.internalArray = array;
+        this.serializationService = serializationService;
+    }
+
+    get(index: number): T {
+        let dataOrObject = this.internalArray[index];
+        if (dataOrObject == null) {
+            return undefined;
+        }
+        if ((<SerializationServiceV1>this.serializationService).isData(dataOrObject)) {
+            let obj = this.serializationService.toObject(dataOrObject);
+            this.internalArray[index] = obj;
+            return obj;
+        } else {
+            return dataOrObject;
+        }
+    }
+
+    size(): number {
+        return this.internalArray.length;
+    }
+
+    values(): Iterator<T> {
+        return new ReadOnlyLazyListIterator(this);
+    }
+
+    slice(start: number, end?: number): ReadOnlyLazyList<T> {
+        return new ReadOnlyLazyList<T>(this.internalArray.slice(start, end), this.serializationService);
+    }
+
+    toArray(): Array<T> {
+        let arr: Array<T> = [];
+        let iterator = this.values();
+        for (let item = iterator.next(); !item.done; item = iterator.next()) {
+            arr.push(item.value);
+        }
+        return arr;
+    }
+
+    [Symbol.iterator](): Iterator<T> {
+        return this.values();
+    }
+}
+

--- a/src/proxy/IList.ts
+++ b/src/proxy/IList.ts
@@ -17,6 +17,7 @@
 import * as Promise from 'bluebird';
 import {DistributedObject} from '../DistributedObject';
 import {ItemListener} from '../core/ItemListener';
+import {ReadOnlyLazyList} from '../core/ReadOnlyLazyList';
 
 export interface IList<E> extends DistributedObject {
 
@@ -157,8 +158,9 @@ export interface IList<E> extends DistributedObject {
      * Return a view of this list that contains elements between index numbers from `start` (inclusive) to `end` (exclusive)
      * @param start start of the view
      * @param end end of the view
+     * @return a view of this list that contains elements between index numbers from `start` (inclusive) to `end` (exclusive)
      */
-    subList(start: number, end: number): Promise<E[]>;
+    subList(start: number, end: number): Promise<ReadOnlyLazyList<E>>;
 
     /**
      * Returns an array that contains all elements of this list in proper sequence.

--- a/src/proxy/IMap.ts
+++ b/src/proxy/IMap.ts
@@ -21,6 +21,7 @@ import {IMapListener} from '../core/MapListener';
 import {Predicate} from '../core/Predicate';
 import {IdentifiedDataSerializable, Portable} from '../serialization/Serializable';
 import {Aggregator} from '../aggregation/Aggregator';
+import {ReadOnlyLazyList} from '../core/ReadOnlyLazyList';
 export interface IMap<K, V> extends DistributedObject {
 
     /**
@@ -279,16 +280,17 @@ export interface IMap<K, V> extends DistributedObject {
     unlock(key: K): Promise<void>;
 
     /**
-     * Returns an array of values contained in this map.
+     * Returns a list of values contained in this map.
      */
-    values(): Promise<V[]>;
+    values(): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * Queries the map based on the specified predicate and returns the values of matching entries.
      * Specified predicate runs on all members in parallel.
      * @param predicate
+     * @return a list of values that satisfies the given predicate.
      */
-    valuesWithPredicate(predicate: Predicate): Promise<V[]>;
+    valuesWithPredicate(predicate: Predicate): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * Returns a key-value pair representing the association of given key

--- a/src/proxy/IReplicatedMap.ts
+++ b/src/proxy/IReplicatedMap.ts
@@ -20,6 +20,7 @@ import {Predicate} from '../core/Predicate';
 import {IMapListener} from '../core/MapListener';
 import Long = require('long');
 import {ArrayComparator} from '../util/ArrayComparator';
+import {ReadOnlyLazyList} from '../core/ReadOnlyLazyList';
 
 export interface IReplicatedMap<K, V> extends DistributedObject {
     /**
@@ -119,9 +120,9 @@ export interface IReplicatedMap<K, V> extends DistributedObject {
     keySet(): Promise<K[]>;
 
     /**
-     * @return Returns an array of values contained in this map.
+     * @return a list of values contained in this map.
      */
-    values(comparator?: ArrayComparator<V>): Promise<V[]>;
+    values(comparator?: ArrayComparator<V>): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * @return Returns entries as an array of key-value pairs.

--- a/src/proxy/ISet.ts
+++ b/src/proxy/ISet.ts
@@ -37,10 +37,10 @@ export interface ISet<E> extends DistributedObject {
     addAll(items : E[]) : Promise<boolean>;
 
     /**
-     * Returns all item in this set.
+     * Returns an array containing all of the elements in the set.
      * @return An array of items.
      */
-    getAll(): Promise<E[]>;
+    toArray(): Promise<E[]>;
 
     /**
      * Removes all of the elements from this set.

--- a/src/proxy/MultiMap.ts
+++ b/src/proxy/MultiMap.ts
@@ -17,6 +17,7 @@
 import * as Promise from 'bluebird';
 import {DistributedObject} from '../DistributedObject';
 import {IMapListener} from '../core/MapListener';
+import {ReadOnlyLazyList} from '../core/ReadOnlyLazyList';
 
 export interface MultiMap<K, V> extends DistributedObject {
 
@@ -34,9 +35,9 @@ export interface MultiMap<K, V> extends DistributedObject {
     /**
      * Retrieves a list of values associated with the specified key.
      * @param key key to search for.
-     * @return array of values associated with the specified key.
+     * @return a list of values associated with the specified key.
      */
-    get(key: K): Promise<Array<V>>;
+    get(key: K): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * Removes an association of the specified value with the specified key. Calling this method does not affect
@@ -50,9 +51,9 @@ export interface MultiMap<K, V> extends DistributedObject {
     /**
      * Detaches all values from the specified key.
      * @param key key from which all entries should be removed.
-     * @return an array of old values that were associated with this key prior to this method call.
+     * @return a list of old values that were associated with this key prior to this method call.
      */
-    removeAll(key: K): Promise<Array<V>>;
+    removeAll(key: K): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * @return an array of all keys in this multi-map.
@@ -60,9 +61,9 @@ export interface MultiMap<K, V> extends DistributedObject {
     keySet(): Promise<Array<K>>;
 
     /**
-     * @return a flat array of all values stored in this multi-map.
+     * @return a flat list of all values stored in this multi-map.
      */
-    values(): Promise<Array<V>>;
+    values(): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * Returns all entries in this multi-map. If a certain key has multiple values associated with it,

--- a/src/proxy/SetProxy.ts
+++ b/src/proxy/SetProxy.ts
@@ -46,13 +46,12 @@ export class SetProxy<E> extends PartitionSpecificProxy implements ISet<E> {
         return this.encodeInvoke<boolean>(SetAddAllCodec, this.serializeList(items));
     }
 
-    getAll(): Promise<E[]> {
-        return this.encodeInvoke(SetGetAllCodec)
-            .then((items: Array<Data>) => {
-                return items.map((item) => {
-                    return this.toObject(item);
-                });
+    toArray(): Promise<E[]> {
+        return this.encodeInvoke(SetGetAllCodec).then((items: Array<Data>) => {
+            return items.map((item) => {
+                return this.toObject(item);
             });
+        });
     }
 
     clear(): Promise<void> {

--- a/src/serialization/SerializationService.ts
+++ b/src/serialization/SerializationService.ts
@@ -67,7 +67,7 @@ export class SerializationServiceV1 implements SerializationService {
         this.registerGlobalSerializer();
     }
 
-    private isData(object: any): boolean {
+    public isData(object: any): boolean {
         if (object instanceof HeapData ) {
             return true;
         } else {

--- a/test/list/ListProxyTest.js
+++ b/test/list/ListProxyTest.js
@@ -235,7 +235,7 @@ describe("List Proxy", function () {
         return listInstance.addAll([1, 2, 3, 4, 5, 6]).then(function () {
             return listInstance.subList(1, 5);
         }).then(function (subList) {
-            expect(subList).to.deep.equal([2, 3, 4, 5]);
+            expect(subList.toArray()).to.deep.equal([2, 3, 4, 5]);
         });
     });
 

--- a/test/map/MapPredicateTest.js
+++ b/test/map/MapPredicateTest.js
@@ -83,9 +83,9 @@ describe("Predicates", function() {
     function testPredicate(predicate, expecteds, orderMatters) {
         return map.valuesWithPredicate(predicate).then(function(values) {
             if (orderMatters) {
-                return expect(values).to.deep.equal(expecteds);
+                return expect(values.toArray()).to.deep.equal(expecteds);
             } else {
-                return expect(values).to.have.members(expecteds);
+                return expect(values.toArray()).to.have.members(expecteds);
             }
         });
     }
@@ -119,7 +119,7 @@ describe("Predicates", function() {
         return localMap.put('temp', 'tempval').then(function() {
             return localMap.valuesWithPredicate(Predicates.like('this', 'tempv%'));
         }).then(function (values) {
-            return expect(values).to.have.members(['tempval']);
+            return expect(values.toArray()).to.have.members(['tempval']);
         }).then(function() {
             return localMap.destroy();
         });
@@ -130,7 +130,7 @@ describe("Predicates", function() {
         return localMap.putAll([['temp', 'tempval'], ['TEMP', 'TEMPVAL']]).then(function() {
             return localMap.valuesWithPredicate(Predicates.ilike('this', 'tempv%'));
         }).then(function (values) {
-            return expect(values).to.have.members(['tempval', 'TEMPVAL']);
+            return expect(values.toArray()).to.have.members(['tempval', 'TEMPVAL']);
         }).then(function() {
             return localMap.destroy();
         });
@@ -171,7 +171,7 @@ describe("Predicates", function() {
         return localMap.putAll([['06', 'ankara'], ['07', 'antalya']]).then(function() {
             return localMap.valuesWithPredicate(Predicates.regex('this', '^.*ya$'));
         }).then(function (values) {
-            return expect(values).to.have.members(['antalya']);
+            return expect(values.toArray()).to.have.members(['antalya']);
         }).then(function() {
             return localMap.destroy();
         });

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -436,7 +436,7 @@ describe('MapProxy', function() {
 
             it('values', function() {
                 return map.values().then(function(vals) {
-                    return expect(vals).to.deep.have.members([
+                    return expect(vals.toArray()).to.deep.have.members([
                         'val0', 'val1', 'val2', 'val3', 'val4',
                         'val5', 'val6', 'val7', 'val8', 'val9'
                     ]);
@@ -447,7 +447,7 @@ describe('MapProxy', function() {
                 return map.clear().then(function() {
                     return map.values();
                 }).then(function(vals) {
-                    return expect(vals).to.have.lengthOf(0);
+                    return expect(vals.toArray()).to.have.lengthOf(0);
                 })
             });
 
@@ -794,9 +794,9 @@ describe('MapProxy', function() {
             });
 
             it('valuesWithPredicate', function() {
-                return map.valuesWithPredicate(Predicates.sql('this == val3')).then(function(valueSet) {
-                    expect(valueSet.length).to.equal(1);
-                    expect(valueSet[0]).to.equal('val3');
+                return map.valuesWithPredicate(Predicates.sql('this == val3')).then(function(valueList) {
+                    expect(valueList.toArray().length).to.equal(1);
+                    expect(valueList.toArray()[0]).to.equal('val3');
                 });
             });
 
@@ -816,8 +816,8 @@ describe('MapProxy', function() {
 
             it('valuesWithPredicate paging', function() {
                 return map.valuesWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1)).then(function(values) {
-                    expect(values.length).to.equal(1);
-                    expect(values[0]).to.equal('val3');
+                    expect(values.toArray().length).to.equal(1);
+                    expect(values.toArray()[0]).to.equal('val3');
                 });
             });
 

--- a/test/multimap/MultiMapProxyTest.js
+++ b/test/multimap/MultiMapProxyTest.js
@@ -56,7 +56,7 @@ describe("MultiMap Proxy", function () {
         return map.put(1, 1).then(function () {
             return map.get(1);
         }).then(function (values) {
-            expect(values).to.deep.equal([1]);
+            expect(values.toArray()).to.deep.equal([1]);
         });
     });
 
@@ -66,7 +66,7 @@ describe("MultiMap Proxy", function () {
         }).then(function () {
             return map.get(1);
         }).then(function (values) {
-            expect(values.sort()).to.deep.equal([1, 2]);
+            expect(values.toArray().sort()).to.deep.equal([1, 2]);
         });
     });
 
@@ -93,7 +93,7 @@ describe("MultiMap Proxy", function () {
         }).then(function () {
             return map.get(1)
         }).then(function (values) {
-            expect(values.sort()).to.deep.equal([1, 5])
+            expect(values.toArray().sort()).to.deep.equal([1, 5])
         });
     });
 
@@ -118,10 +118,10 @@ describe("MultiMap Proxy", function () {
         return Promise.all(puts).then(function () {
             return map.removeAll(1);
         }).then(function (oldValues) {
-            expect(oldValues.sort()).to.deep.equal([1, 3, 5]);
+            expect(oldValues.toArray().sort()).to.deep.equal([1, 3, 5]);
             return map.get(1)
         }).then(function (values) {
-            expect(values).to.be.empty;
+            expect(values.toArray()).to.be.empty;
         });
     });
 
@@ -139,7 +139,7 @@ describe("MultiMap Proxy", function () {
         return Promise.all(puts).then(function () {
             return map.values();
         }).then(function (values) {
-            expect(values.sort()).to.deep.equal([1, 3, 5]);
+            expect(values.toArray().sort()).to.deep.equal([1, 3, 5]);
         });
     });
 

--- a/test/replicatedmap/ReplicatedMapProxyTest.js
+++ b/test/replicatedmap/ReplicatedMapProxyTest.js
@@ -237,7 +237,7 @@ describe('ReplicatedMap Proxy', function () {
                 return rm.values();
             })
             .then(function (values) {
-                expect(values).to.eql(['value1', 'value2', 'value3']);
+                expect(values.toArray()).to.eql(['value1', 'value2', 'value3']);
             });
     });
 
@@ -247,17 +247,15 @@ describe('ReplicatedMap Proxy', function () {
             ['key2', 'value2'],
             ['key3', 'value3'],
             ['key1', 'value1']
-        ])
-            .then(function () {
-                return rm.values(function (a, b) {
-                    return b[b.length - 1] - a[a.length - 1];
-                });
-            })
-            .then(function (values) {
-                values.forEach(function (value, index) {
-                    expect(value).to.equal(expectedArray[index]);
-                });
+        ]).then(function () {
+            return rm.values(function (a, b) {
+                return b[b.length - 1] - a[a.length - 1];
             });
+        }).then(function (values) {
+            values.toArray().forEach(function (value, index) {
+                expect(value).to.equal(expectedArray[index]);
+            });
+        });
     });
 
     it('returns keySet', function () {

--- a/test/set/SetProxyTest.js
+++ b/test/set/SetProxyTest.js
@@ -67,10 +67,10 @@ describe("Set Proxy", function () {
         });
     });
 
-    it("gets all", function () {
+    it("toArray", function () {
         var input = [1, 2, 3];
         return setInstance.addAll(input).then(function () {
-            return setInstance.getAll().then(function (all) {
+            return setInstance.toArray().then(function (all) {
                 expect(all.sort()).to.deep.equal(input);
             });
         });
@@ -117,7 +117,7 @@ describe("Set Proxy", function () {
         return setInstance.addAll([1, 2, 3]).then(function () {
             return setInstance.remove(1)
         }).then(function () {
-            return setInstance.getAll().then(function (all) {
+            return setInstance.toArray().then(function (all) {
                 expect(all.sort()).to.deep.equal([2, 3]);
             });
         });
@@ -127,7 +127,7 @@ describe("Set Proxy", function () {
         return setInstance.addAll([1, 2, 3, 4]).then(function () {
             return setInstance.removeAll([1, 2]);
         }).then(function () {
-            return setInstance.getAll().then(function (all) {
+            return setInstance.toArray().then(function (all) {
                 expect(all.sort()).to.deep.equal([3, 4]);
             });
         });
@@ -137,7 +137,7 @@ describe("Set Proxy", function () {
         return setInstance.addAll([1, 2, 3, 4]).then(function () {
             return setInstance.retainAll([1, 2]);
         }).then(function () {
-            return setInstance.getAll().then(function (all) {
+            return setInstance.toArray().then(function (all) {
                 expect(all.sort()).to.deep.equal([1, 2]);
             });
         });


### PR DESCRIPTION
- Adds `ReadOnlyLazyList`. All proxy methods that return `UnmodifiableLazyList` in Java client return `ReadOnlyLazyList`.
- `ISet` interface includes `getAll` which maps to `toArray` in Java client. There is no `getAll` method in Java Client's ISet. This PR changes `ISet#getAll` to `toArray`.
- This changes interfaces `IList`, `IMap`, `IReplicatedMap`, `MultiMap` and `ISet`.