### PR TITLE
Add missing EVENT_PARTITIONS constant

### DIFF
--- a/src/BitsUtil.ts
+++ b/src/BitsUtil.ts
@@ -32,10 +32,11 @@ export class BitsUtil {
     static EVENT_CACHEBATCHINVALIDATION = 211;
     static EVENT_QUERYCACHESINGLE = 212;
     static EVENT_QUERYCACHEBATCH = 213;
-
     static EVENT_CACHEPARTITIONLOST = 214;
     static EVENT_IMAPINVALIDATION = 215;
     static EVENT_IMAPBATCHINVALIDATION = 216;
+    static EVENT_PARTITIONS = 217;
+
     static BYTE_SIZE_IN_BYTES: number = 1;
     static BOOLEAN_SIZE_IN_BYTES: number = 1;
     static SHORT_SIZE_IN_BYTES: number = 2;

--- a/src/codec/ClientDeployClassesCodec.ts
+++ b/src/codec/ClientDeployClassesCodec.ts
@@ -43,7 +43,7 @@ export class ClientDeployClassesCodec {
             var key: string = classDefinitionsItem[0];
             var val: any = classDefinitionsItem[1];
             dataSize += BitsUtil.calculateSizeString(key);
-            data_size += BitsUtil.INT_SIZE_IN_BYTES
+            dataSize += BitsUtil.INT_SIZE_IN_BYTES
             val.forEach((valItem: any) => {
                 dataSize += BitsUtil.BYTE_SIZE_IN_BYTES;
             });


### PR DESCRIPTION
- `EVENT_PARTITIONS` constant is used in `ClientAddPartitionListenerCodec` but not defined. (https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/src/codec/ClientAddPartitionListenerCodec.ts#L57)

- Also fixed a typo `data_size` -> `dataSize`.