### PR TITLE
add more logging while connection to cluster

### DIFF
--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -116,7 +116,7 @@ export class ClientConnection {
         return this.authenticatedAsOwner;
     }
 
-    setAuthneticatedAsOwner(asOwner: boolean): void {
+    setAuthenticatedAsOwner(asOwner: boolean): void {
         this.authenticatedAsOwner = asOwner;
     }
 

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -18,7 +18,7 @@ import * as Promise from 'bluebird';
 import {LoggingService} from '../logging/LoggingService';
 import {EventEmitter} from 'events';
 import HazelcastClient from '../HazelcastClient';
-import {ClientNotActiveError, HazelcastError} from '../HazelcastError';
+import {ClientNotActiveError, HazelcastError, IllegalStateError} from '../HazelcastError';
 import {ClientConnection} from './ClientConnection';
 import {ConnectionAuthenticator} from './ConnectionAuthenticator';
 import Address = require('../Address');
@@ -52,10 +52,10 @@ export class ClientConnectionManager extends EventEmitter {
      * Returns the {@link ClientConnection} with given {@link Address}. If there is no such connection established,
      * it first connects to the address and then return the {@link ClientConnection}.
      * @param address
-     * @param ownerConnection Sets the connected node as owner of this client if true.
+     * @param asOwner Sets the connected node as owner of this client if true.
      * @returns {Promise<ClientConnection>|Promise<T>}
      */
-    getOrConnect(address: Address, ownerConnection: boolean = false): Promise<ClientConnection> {
+    getOrConnect(address: Address, asOwner: boolean = false): Promise<ClientConnection> {
         let addressIndex = address.toString();
         let connectionResolver: Promise.Resolver<ClientConnection> = Promise.defer<ClientConnection>();
 
@@ -76,13 +76,13 @@ export class ClientConnectionManager extends EventEmitter {
             this.client.getInvocationService().processResponse(data);
         };
 
-        this.triggerConnect(address).then((socket: net.Socket) => {
+        this.triggerConnect(address, asOwner).then((socket: net.Socket) => {
             let clientConnection = new ClientConnection(this.client, address, socket);
 
             return this.initiateCommunication(clientConnection).then(() => {
                 return clientConnection.registerResponseCallback(processResponseCallback);
             }).then(() => {
-                return this.authenticate(clientConnection, ownerConnection);
+                return this.authenticate(clientConnection, asOwner);
             }).then(() => {
                 this.establishedConnections[clientConnection.getAddress().toString()] = clientConnection;
                 this.onConnectionOpened(clientConnection);
@@ -94,6 +94,7 @@ export class ClientConnectionManager extends EventEmitter {
             delete this.pendingConnections[addressIndex];
         });
 
+
         let connectionTimeout = this.client.getConfig().networkConfig.connectionTimeout;
         if (connectionTimeout !== 0) {
             return connectionResolver.promise.timeout(connectionTimeout, new HazelcastError('Connection timed-out'));
@@ -101,7 +102,13 @@ export class ClientConnectionManager extends EventEmitter {
         return connectionResolver.promise;
     }
 
-    private triggerConnect(address: Address): Promise<net.Socket> {
+    private triggerConnect(address: Address, asOwner: boolean): Promise<net.Socket> {
+        if (!asOwner) {
+            if (this.client.getClusterService().getOwnerConnection() == null) {
+                let error = new IllegalStateError('Owner connection is not available!');
+                return Promise.reject(error);
+            }
+        }
         if (this.client.getConfig().networkConfig.sslOptions) {
             let opts = this.client.getConfig().networkConfig.sslOptions;
             return this.connectTLSSocket(address, opts);

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -89,7 +89,7 @@ export class ClientConnectionManager extends EventEmitter {
                 connectionResolver.resolve(clientConnection);
             });
         }).catch((e: any) => {
-            connectionResolver.resolve(null);
+            connectionResolver.reject(e);
         }).finally(() => {
             delete this.pendingConnections[addressIndex];
         });

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -241,8 +241,8 @@ export class InvocationService {
         return this.client.getConnectionManager().getOrConnect(address).then((connection: ClientConnection) => {
             return this.send(invocation, connection);
         }).catch((e) => {
-            this.logger.error('InvocationService', e);
-            throw new Error(address.toString() + ' is not available.');
+            this.logger.debug('InvocationService', e);
+            throw new IOError(address.toString() + ' is not available.', e);
         });
     }
 
@@ -251,8 +251,8 @@ export class InvocationService {
         return this.client.getConnectionManager().getOrConnect(ownerAddress).then((connection: ClientConnection) => {
             return this.send(invocation, connection);
         }).catch((e) => {
-            this.logger.error('InvocationService', e);
-            throw new IOError(ownerAddress.toString() + '(partition owner) is not available.');
+            this.logger.debug('InvocationService', e);
+            throw new IOError(ownerAddress.toString() + '(partition owner) is not available.', e);
         });
     }
 

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -239,20 +239,20 @@ export class InvocationService {
 
     private invokeOnAddress(invocation: Invocation, address: Address): Promise<void> {
         return this.client.getConnectionManager().getOrConnect(address).then((connection: ClientConnection) => {
-            if (connection == null) {
-                throw new Error(address.toString() + ' is not available.');
-            }
             return this.send(invocation, connection);
+        }).catch((e) => {
+            this.logger.error('InvocationService', e);
+            throw new Error(address.toString() + ' is not available.');
         });
     }
 
     private invokeOnPartitionOwner(invocation: Invocation, partitionId: number): Promise<void> {
         let ownerAddress = this.client.getPartitionService().getAddressForPartition(partitionId);
         return this.client.getConnectionManager().getOrConnect(ownerAddress).then((connection: ClientConnection) => {
-            if (connection == null) {
-                throw new IOError(ownerAddress.toString() + '(partition owner) is not available.');
-            }
             return this.send(invocation, connection);
+        }).catch((e) => {
+            this.logger.error('InvocationService', e);
+            throw new IOError(ownerAddress.toString() + '(partition owner) is not available.');
         });
     }
 


### PR DESCRIPTION
Fixes #232, #294.

This pr adds some debug logs when connection to cluster. It also changes a few variable names.

When looking at the outputs I realized that there were some false negatives when trying to authenticate. After debugging I realized that when owner connection was down the client was still trying to open non owner connections. See #294.

**The output with wrong group name or password**

```
[DefaultLogger] INFO at ClusterService: Members received.
[ Member {
    address: Address { host: 'localhost', port: 5701, type: 0 },
    uuid: 'ca15b1a9-6d0d-4ff8-921d-378ccbee7452',
    isLiteMember: false,
    attributes: {} } ]
[DefaultLogger] INFO at HazelcastClient: Client started
[DefaultLogger] ERROR at ConnectionAuthenticator: Invalid Credentials
[DefaultLogger] WARN at ClusterService: Error: Invalid Credentials, could not authenticate connection to 127.0.0.1:5701
[DefaultLogger] ERROR at ConnectionAuthenticator: Invalid Credentials
[DefaultLogger] WARN at ClusterService: Error: Invalid Credentials, could not authenticate connection to 127.0.0.1:5701
[DefaultLogger] ERROR at HazelcastClient: Client failed to start
{ Error: Unable to connect to any of the following addresses: 127.0.0.1:5701
    at new IllegalStateError (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/HazelcastError.js:63:28)
    at ClusterService.tryConnectingToAddresses (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/invocation/ClusterService.js:166:29)
    at /Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/invocation/ClusterService.js:189:30
    at tryCatcher (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:689:18)
    at Async._drainQueue (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5)
  cause: Error: Invalid Credentials, could not authenticate connection to 127.0.0.1:5701
    at /Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/invocation/ConnectionAuthenticator.js:55:27
    at tryCatcher (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5) }
```

**The output with wrong serialization version**

```
[DefaultLogger] ERROR at ConnectionAuthenticator: Serialization version mismatch
[DefaultLogger] WARN at ClusterService: Error: Serialization version mismatch, could not authenticate connection to 127.0.0.1:5701
[DefaultLogger] ERROR at ConnectionAuthenticator: Serialization version mismatch
[DefaultLogger] WARN at ClusterService: Error: Serialization version mismatch, could not authenticate connection to 127.0.0.1:5701
[DefaultLogger] ERROR at HazelcastClient: Client failed to start
{ Error: Unable to connect to any of the following addresses: 127.0.0.1:5701
    at new IllegalStateError (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/HazelcastError.js:63:28)
    at ClusterService.tryConnectingToAddresses (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/invocation/ClusterService.js:166:29)
    at /Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/invocation/ClusterService.js:189:30
    at tryCatcher (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:689:18)
    at Async._drainQueue (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5)
  cause: Error: Serialization version mismatch, could not authenticate connection to 127.0.0.1:5701
    at /Users/hazelcast/nodeJS/hazelcast-nodejs-client/lib/invocation/ConnectionAuthenticator.js:59:27
    at tryCatcher (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/hazelcast/nodeJS/hazelcast-nodejs-client/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5) }
```