### PR TITLE
fix Map Partition Aware Test

### DIFF
--- a/test/map/MapPartitionAwareTest.js
+++ b/test/map/MapPartitionAwareTest.js
@@ -46,10 +46,10 @@ describe('Map Partition Aware', function () {
             'result=""+getLocalMapStats();';
     }
 
-    function _fillMap(map, ssize) {
+    function _fillMap(map, size) {
         var entryList = [];
-        for (var i = 0; i < ssize; i++) {
-            entryList.push([new PartitionAwareKey('' + Math.random(), 'specificKey'), '' + Math.random()]);
+        for (var i = 0; i < size; i++) {
+            entryList.push([new PartitionAwareKey('' + i, 'specificKey'), '' + Math.random()]);
         }
         return map.putAll(entryList);
     }


### PR DESCRIPTION
This pr fixes Map Partition Aware test. Test sometimes fails because `Math.random()` returns same value. In Map, keys must be unique so it cannot add 10000 entries. For this reason, I used index values   for keys. fixes #297 