### PR TITLE
fix Near Cache bugs

### DIFF
--- a/src/nearcache/MetadataFetcher.ts
+++ b/src/nearcache/MetadataFetcher.ts
@@ -37,11 +37,13 @@ export class MetadataFetcher {
     }
 
     initHandler(handler: RepairingHandler): Promise<void> {
-        const scanPromise = this.scanMembers([handler.getName()])[0];
-        return scanPromise.then((response: ClientMessage) => {
-            const metadata = MapFetchNearCacheInvalidationMetadataCodec.decodeResponse(response);
-            handler.initUuid(metadata.partitionUuidList);
-            handler.initSequence(metadata.namePartitionSequenceList[0]);
+        const scanPromises = this.scanMembers([handler.getName()]);
+        return Promise.all(scanPromises).then((responses: ClientMessage[]) => {
+            responses.forEach((response) => {
+                const metadata = MapFetchNearCacheInvalidationMetadataCodec.decodeResponse(response);
+                handler.initUuid(metadata.partitionUuidList);
+                handler.initSequence(metadata.namePartitionSequenceList[0]);
+            });
         });
     }
 

--- a/src/nearcache/RepairingHandler.ts
+++ b/src/nearcache/RepairingHandler.ts
@@ -101,6 +101,7 @@ export class RepairingHandler {
         if (currentUuid != null && currentUuid.equals(newuuid)) {
             return;
         }
+
         metadata.setUuid(newuuid);
         metadata.reset();
     }

--- a/test/nearcache/NearCacheTest.js
+++ b/test/nearcache/NearCacheTest.js
@@ -145,18 +145,22 @@ describe('NearCacheImpl', function () {
 
             beforeEach(function () {
                 nearCache = new NearCacheImpl(testConfig, createSerializationService());
+                nearCache.setReady();
             });
 
 
             it('simple put/get', function () {
                 nearCache.put(ds('key'), 'val');
-                return expect(nearCache.get(ds('key'))).to.equal('val');
+                return nearCache.get(ds('key')).then((res) => {
+                    return expect(res).to.equal('val');
+                });
             });
 
 
             it('returns undefined for non existing value', function () {
-                nearCache.get(ds('random'));
-                return expect(nearCache.getStatistics().missCount).to.equal(1);
+                return nearCache.get(ds('random')).then(() => {
+                    return expect(nearCache.getStatistics().missCount).to.equal(1);
+                });
             });
 
             it('record does not expire if ttl is 0', function () {


### PR DESCRIPTION
This pr fixes the following bugs in NearCache:

1. NearCache `get` operation is called before NearCahe is  active. I added a promise to hold the `get` operation until NearCache is active.

2. At the start, `NearCache Invalidation Metadata` is just obtained for one member. If there are more than one member, all metadata cannot be obtained and this results in unexpected misses in NearCache. I took metadata for all members and this bug is fixed.

fixes #295
fixes #298  