### PR TITLE
Fix typing of `hazelcast.logging` property in HazelcastClient

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -27,7 +27,7 @@ import {InvocationService} from './invocation/InvocationService';
 import {LifecycleEvent, LifecycleService} from './LifecycleService';
 import {ListenerService} from './ListenerService';
 import {LockReferenceIdGenerator} from './LockReferenceIdGenerator';
-import {LoggingService} from './logging/LoggingService';
+import {LoggingService, ILogger} from './logging/LoggingService';
 import {RepairingTask} from './nearcache/RepairingTask';
 import {PartitionService} from './PartitionService';
 import {ClientErrorFactory} from './protocol/ErrorFactory';
@@ -76,7 +76,7 @@ export default class HazelcastClient {
             this.config = config;
         }
 
-        LoggingService.initialize(this.config.properties['hazelcast.logging'] as string);
+        LoggingService.initialize(this.config.properties['hazelcast.logging'] as string | ILogger);
         this.loggingService = LoggingService.getLoggingService();
         this.invocationService = new InvocationService(this);
         this.listenerService = new ListenerService(this);

--- a/src/config/Properties.ts
+++ b/src/config/Properties.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {ILogger} from '../logging/LoggingService';
+
 export interface Properties {
-    [prop: string]: string | number | boolean;
+    [prop: string]: string | number | boolean | ILogger;
 }


### PR DESCRIPTION
The TypeScript definition of the property `hazelcast.logging` used in [the constructor of the `HazelcastClient`](https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/src/HazelcastClient.ts#L79) does not match the one from [the `initialize` method of `LoggingService`](https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/src/logging/LoggingService.ts#L53).

This PR allows the use of a custom `LoggingService` in a TypeScript project.