### PR TITLE
prevent client hanging due to incompatible server

### DIFF
--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -108,7 +108,10 @@ export class ClientConnectionManager extends EventEmitter {
 
         const connectionTimeout = this.client.getConfig().networkConfig.connectionTimeout;
         if (connectionTimeout !== 0) {
-            return connectionResolver.promise.timeout(connectionTimeout, new HazelcastError('Connection timed-out'));
+            return connectionResolver.promise.timeout(connectionTimeout, new HazelcastError(
+                'Connection timed-out')).finally(() => {
+                delete this.pendingConnections[addressIndex];
+            });
         }
         return connectionResolver.promise;
     }


### PR DESCRIPTION
This PR fixes client hanging defect that occurs when there is a server that does not support open binary protocol. It returns an `IllegalStateError` with message `Connection timed-out`.

fixes #132 