### PR TITLE
add AddressHelper object and refactor the connection behavior

### DIFF
--- a/src/discovery/HazelcastCloudDiscovery.ts
+++ b/src/discovery/HazelcastCloudDiscovery.ts
@@ -1,5 +1,5 @@
 import Address = require('../Address');
-import {createAddressFromString} from '../Util';
+import {AddressHelper} from '../Util';
 import {get} from 'https';
 import {IncomingMessage} from 'http';
 import * as Promise from 'bluebird';
@@ -73,7 +73,7 @@ export class HazelcastCloudDiscovery {
             const privateAddress = value[HazelcastCloudDiscovery.PRIVATE_ADDRESS_PROPERTY];
             const publicAddress = value[HazelcastCloudDiscovery.PUBLIC_ADDRESS_PROPERTY];
 
-            const publicAddr = createAddressFromString(publicAddress.toString());
+            const publicAddr = AddressHelper.createAddressFromString(publicAddress.toString());
             privateToPublicAddresses.set(new Address(privateAddress, publicAddr.port).toString(), publicAddr);
         }
 

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -25,7 +25,7 @@ import HazelcastClient from '../HazelcastClient';
 import {IllegalStateError} from '../HazelcastError';
 import * as assert from 'assert';
 import {MemberSelector} from '../core/MemberSelector';
-import {createAddressFromString} from '../Util';
+import {AddressHelper} from '../Util';
 import Address = require('../Address');
 import ClientMessage = require('../ClientMessage');
 
@@ -86,7 +86,7 @@ export class ClusterService extends EventEmitter {
         return this.getPossibleMemberAddresses().then((res) => {
             this.knownAddresses = [];
             res.forEach((value) => {
-                this.knownAddresses.push(createAddressFromString(value));
+                this.knownAddresses = this.knownAddresses.concat(AddressHelper.getSocketAddresses(value));
             });
 
             const attemptLimit = this.client.getConfig().networkConfig.connectionAttemptLimit;

--- a/test/AddressHelperTest.js
+++ b/test/AddressHelperTest.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Controller = require('./RC');
+var expect = require('chai').expect;
+
+var HazelcastClient = require('../.').Client;
+var Config = require('../.').Config;
+
+describe('AddressHelper', function () {
+    this.timeout(30000);
+
+    var cluster;
+    var client;
+
+    before(function () {
+        return Controller.createCluster(null, null).then(function (res) {
+            cluster = res;
+            return Controller.startMember(cluster.id);
+        }).then(function () {
+            var cfg = new Config.ClientConfig();
+            cfg.networkConfig.addresses = ['127.0.0.2', '127.0.0.1:5701'];
+            return HazelcastClient.newHazelcastClient(cfg);
+        }).then(function (res) {
+            client = res;
+        });
+    });
+
+    after(function () {
+        client.shutdown();
+        return Controller.shutdownCluster(cluster.id);
+    });
+
+
+    it('should try all addresses', function () {
+        var knownAddresses = client.getClusterService().knownAddresses.map(function (address) {
+            return address.toString();
+        });
+
+        expect(knownAddresses).to.have.members(['127.0.0.2:5701', '127.0.0.2:5702', '127.0.0.2:5703', '127.0.0.1:5701']);
+    });
+});

--- a/test/config/ConfigBuilderTest.js
+++ b/test/config/ConfigBuilderTest.js
@@ -19,7 +19,7 @@ var path = require('path');
 var ConfigBuilder = require('../../lib/config/ConfigBuilder').ConfigBuilder;
 var Config = require('../../lib/index').Config;
 var Long = require('long');
-var createAddressFromString = require("../../lib/Util").createAddressFromString;
+var AddressHelper = require("../../lib/Util").AddressHelper;
 
 describe('ConfigBuilder Test', function () {
     var configFull;
@@ -38,8 +38,24 @@ describe('ConfigBuilder Test', function () {
 
     it('networkConfig', function () {
         var networkCfg = configFull.networkConfig;
-        var address0 = createAddressFromString(networkCfg.addresses[0]);
-        var address1 = createAddressFromString(networkCfg.addresses[1]);
+
+        var addresses0 = AddressHelper.getSocketAddresses(networkCfg.addresses[0]);
+        expect(addresses0[0].host).to.equal('127.0.0.9');
+        expect(addresses0[0].port).to.equal(5701);
+        expect(addresses0[1].host).to.equal('127.0.0.9');
+        expect(addresses0[1].port).to.equal(5702);
+        expect(addresses0[2].host).to.equal('127.0.0.9');
+        expect(addresses0[2].port).to.equal(5703);
+        expect(addresses0.length).to.equal(3);
+
+        var addresses1 = AddressHelper.getSocketAddresses(networkCfg.addresses[1]);
+        expect(addresses1[0].host).to.equal('127.0.0.2');
+        expect(addresses1[0].port).to.equal(5702);
+        expect(addresses1.length).to.equal(1);
+
+
+        var address0 = AddressHelper.createAddressFromString(networkCfg.addresses[0]);
+        var address1 = AddressHelper.createAddressFromString(networkCfg.addresses[1]);
         expect(address0.host).to.equal('127.0.0.9');
         expect(address0.port).to.be.undefined;
         expect(address1.host).to.equal('127.0.0.2');


### PR DESCRIPTION
This PR changes the connection behaviour. Currently, the client tries just `localhost:5701` address while connecting to cluster. It should try `5071`, `5072`, `5073` when port number is not defined.