### PR TITLE
fix ProxyManager proxies map

### DIFF
--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -88,8 +88,8 @@ export class ProxyManager {
     }
 
     public getOrCreateProxy(name: string, serviceName: string, createAtServer = true): DistributedObject {
-        if (this.proxies[name]) {
-            return this.proxies[name];
+        if (this.proxies[serviceName + name]) {
+            return this.proxies[serviceName + name];
         } else {
             let newProxy: DistributedObject;
             if (serviceName === ProxyManager.MAP_SERVICE && this.client.getConfig().getNearCacheConfig(name)) {
@@ -100,13 +100,13 @@ export class ProxyManager {
             if (createAtServer) {
                 this.createProxy(newProxy);
             }
-            this.proxies[name] = newProxy;
+            this.proxies[serviceName + name] = newProxy;
             return newProxy;
         }
     }
 
     destroyProxy(name: string, serviceName: string): Promise<void> {
-        delete this.proxies[name];
+        delete this.proxies[serviceName + name];
         const clientMessage = ClientDestroyProxyCodec.encodeRequest(name, serviceName);
         clientMessage.setPartitionId(-1);
         return this.client.getInvocationService().invokeOnRandomTarget(clientMessage).return();

--- a/test/ClientProxyTest.js
+++ b/test/ClientProxyTest.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+var Controller = require('./RC');
+var expect = require('chai').expect;
+
 var MapProxy = require('../lib/proxy/MapProxy').MapProxy;
 var ConnectionManager = require('../lib/invocation/ClientConnectionManager').ClientConnectionManager;
 var ClientConnection = require('../lib/invocation/ClientConnection').ClientConnection;
@@ -23,10 +26,21 @@ var assert = require('chai').assert;
 var sandbox = sinon.createSandbox();
 
 describe('Generic proxy test', function () {
+    var cluster;
+    var client;
+    var map;
+    var list;
 
     afterEach(function () {
-        sandbox.restore();
-    });
+            sandbox.restore();
+            if (map && list) {
+                map.destroy();
+                list.destroy();
+                client.shutdown();
+                return Controller.shutdownCluster(cluster.id);
+            }
+        }
+    );
 
     it('Client without active connection should return unknown version', function () {
         var connectionManagerStub = sandbox.stub(ConnectionManager.prototype);
@@ -50,5 +64,19 @@ describe('Generic proxy test', function () {
 
         var mapProxy = new MapProxy(clientStub, 'mockMapService', 'mockMap');
         assert.equal(mapProxy.getConnectedServerVersion(), 30700);
+    });
+
+    it('Proxies with the same name should be different for different services', function () {
+        return Controller.createCluster().then(function (response) {
+            cluster = response;
+            return Controller.startMember(cluster.id);
+        }).then(function () {
+            return HazelcastClient.newHazelcastClient();
+        }).then(function (res) {
+            client = res;
+            map = client.getMap('Furkan');
+            list = client.getList('Furkan');
+            expect(list.getServiceName()).to.be.equal('hz:impl:listService');
+        });
     });
 })


### PR DESCRIPTION
ProxyManager proxies map should keep namespaces as key rather than names of proxies. Otherwise, The list is same with map in the following example.

```
var map = client.getMap('Furkan');
var list = client.getList('Furkan');
````

fixes #361 