### PR TITLE
Migrate Promise.defer to new Promise

### DIFF
--- a/src/ListenerService.ts
+++ b/src/ListenerService.ts
@@ -27,7 +27,7 @@ import {Invocation} from './invocation/InvocationService';
 import {RegistrationKey} from './invocation/RegistrationKey';
 import {ListenerMessageCodec} from './ListenerMessageCodec';
 import {LoggingService} from './logging/LoggingService';
-import {copyObjectShallow} from './Util';
+import {copyObjectShallow, DeferredPromise} from './Util';
 import {UuidUtil} from './util/UuidUtil';
 
 export class ListenerService implements ConnectionHeartbeatListener {
@@ -110,7 +110,7 @@ export class ListenerService implements ConnectionHeartbeatListener {
     }
 
     invokeRegistrationFromRecord(userRegistrationKey: string, connection: ClientConnection): Promise<ClientEventRegistration> {
-        const deferred = Promise.defer<ClientEventRegistration>();
+        const deferred = DeferredPromise<ClientEventRegistration>();
         const activeRegsOnUserKey = this.activeRegistrations.get(userRegistrationKey);
         if (activeRegsOnUserKey !== undefined && activeRegsOnUserKey.has(connection)) {
             deferred.resolve(activeRegsOnUserKey.get(connection));
@@ -159,7 +159,7 @@ export class ListenerService implements ConnectionHeartbeatListener {
     }
 
     deregisterListener(userRegistrationKey: string): Promise<boolean> {
-        const deferred = Promise.defer<boolean>();
+        const deferred = DeferredPromise<boolean>();
         const registrationsOnUserKey = this.activeRegistrations.get(userRegistrationKey);
         if (registrationsOnUserKey === undefined) {
             deferred.resolve(false);
@@ -207,7 +207,7 @@ export class ListenerService implements ConnectionHeartbeatListener {
         const activeConnections = copyObjectShallow(this.client.getConnectionManager().getActiveConnections());
         const userRegistrationKey: string = UuidUtil.generate().toString();
         let connectionsOnUserKey: Map<ClientConnection, ClientEventRegistration>;
-        const deferred = Promise.defer<string>();
+        const deferred = DeferredPromise<string>();
         const registerRequest = codec.encodeAddRequest(this.isSmart());
         connectionsOnUserKey = this.activeRegistrations.get(userRegistrationKey);
         if (connectionsOnUserKey === undefined) {

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -16,6 +16,7 @@
 
 import * as assert from 'assert';
 import * as Long from 'long';
+import * as Promise from 'bluebird';
 import * as Path from 'path';
 import {JsonConfigLocator} from './config/JsonConfigLocator';
 import {Comparator} from './core/Comparator';
@@ -314,4 +315,18 @@ export function cancelRepetitionTask(task: Task): void {
     } else if (task.timeoutId != null) {
         clearTimeout(task.timeoutId);
     }
+}
+
+export function DeferredPromise<T>(): Promise.Resolver<T> {
+    let resolve: any;
+    let reject: any;
+    const promise = new Promise(function (): void {
+        resolve = arguments[0];
+        reject = arguments[1];
+    });
+    return {
+        resolve,
+        reject,
+        promise,
+    } as Promise.Resolver<T>;
 }

--- a/src/config/JsonConfigLocator.ts
+++ b/src/config/JsonConfigLocator.ts
@@ -19,6 +19,7 @@ import * as fs from 'fs';
 import * as Path from 'path';
 import {LoggingService} from '../logging/LoggingService';
 import {ConfigBuilder} from './ConfigBuilder';
+import {DeferredPromise} from '../Util';
 
 export class JsonConfigLocator {
     static readonly ENV_VARIABLE_NAME = 'HAZELCAST_CLIENT_CONFIG';
@@ -60,7 +61,7 @@ export class JsonConfigLocator {
     loadFromWorkingDirectory(): Promise<boolean> {
         const cwd = process.cwd();
         const jsonPath = Path.resolve(cwd, JsonConfigLocator.DEFAULT_FILE_NAME);
-        const deferred = Promise.defer<boolean>();
+        const deferred = DeferredPromise<boolean>();
         fs.access(jsonPath, (err) => {
             if (err) {
                 deferred.resolve(false);
@@ -82,7 +83,7 @@ export class JsonConfigLocator {
     }
 
     loadPath(path: string): Promise<Buffer> {
-        const deferred = Promise.defer<Buffer>();
+        const deferred = DeferredPromise<Buffer>();
         fs.readFile(path, (err, data: Buffer) => {
             if (err) {
                 this.logger.trace('JsonConfigLocator', 'Cannot read from ' + path.toString());

--- a/src/discovery/HazelcastCloudDiscovery.ts
+++ b/src/discovery/HazelcastCloudDiscovery.ts
@@ -1,5 +1,5 @@
 import Address = require('../Address');
-import {AddressHelper} from '../Util';
+import {AddressHelper, DeferredPromise} from '../Util';
 import {get} from 'https';
 import {IncomingMessage} from 'http';
 import * as Promise from 'bluebird';
@@ -40,7 +40,7 @@ export class HazelcastCloudDiscovery {
     }
 
     callService(): Promise<Map<string, Address>> {
-        const deferred = Promise.defer<Map<string, Address>>();
+        const deferred = DeferredPromise<Map<string, Address>>();
 
         const url = URL.parse(this.endpointUrl);
         const endpointUrlOptions = {

--- a/src/invocation/ClientConnection.ts
+++ b/src/invocation/ClientConnection.ts
@@ -21,6 +21,7 @@ import {BuildMetadata} from '../BuildMetadata';
 import HazelcastClient from '../HazelcastClient';
 import {IOError} from '../HazelcastError';
 import Address = require('../Address');
+import {DeferredPromise} from '../Util';
 
 export class ClientConnection {
     private address: Address;
@@ -69,7 +70,7 @@ export class ClientConnection {
     }
 
     write(buffer: Buffer): Promise<void> {
-        const deferred = Promise.defer<void>();
+        const deferred = DeferredPromise<void>();
         try {
             this.socket.write(buffer, (err: any) => {
                 if (err) {

--- a/src/invocation/ClientConnectionManager.ts
+++ b/src/invocation/ClientConnectionManager.ts
@@ -23,7 +23,7 @@ import {ClientConnection} from './ClientConnection';
 import {ConnectionAuthenticator} from './ConnectionAuthenticator';
 import * as net from 'net';
 import * as tls from 'tls';
-import {loadNameFromPath} from '../Util';
+import {DeferredPromise, loadNameFromPath} from '../Util';
 import {BasicSSLOptionsFactory} from '../connection/BasicSSLOptionsFactory';
 import {AddressTranslator} from '../connection/AddressTranslator';
 import {AddressProvider} from '../connection/AddressProvider';
@@ -63,7 +63,7 @@ export class ClientConnectionManager extends EventEmitter {
      */
     getOrConnect(address: Address, asOwner: boolean = false): Promise<ClientConnection> {
         const addressIndex = address.toString();
-        const connectionResolver: Promise.Resolver<ClientConnection> = Promise.defer<ClientConnection>();
+        const connectionResolver: Promise.Resolver<ClientConnection> = DeferredPromise<ClientConnection>();
 
         const establishedConnection = this.establishedConnections[addressIndex];
         if (establishedConnection) {
@@ -170,7 +170,7 @@ export class ClientConnectionManager extends EventEmitter {
     }
 
     private connectTLSSocket(address: Address, configOpts: any): Promise<tls.TLSSocket> {
-        const connectionResolver = Promise.defer<tls.TLSSocket>();
+        const connectionResolver = DeferredPromise<tls.TLSSocket>();
         const socket = tls.connect(address.port, address.host, configOpts);
         socket.once('secureConnect', () => {
             connectionResolver.resolve(socket);
@@ -186,7 +186,7 @@ export class ClientConnectionManager extends EventEmitter {
     }
 
     private connectNetSocket(address: Address): Promise<net.Socket> {
-        const connectionResolver = Promise.defer<net.Socket>();
+        const connectionResolver = DeferredPromise<net.Socket>();
         const socket = net.connect(address.port, address.host);
         socket.once('connect', () => {
             connectionResolver.resolve(socket);

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -25,7 +25,7 @@ import HazelcastClient from '../HazelcastClient';
 import {IllegalStateError} from '../HazelcastError';
 import * as assert from 'assert';
 import {MemberSelector} from '../core/MemberSelector';
-import {AddressHelper} from '../Util';
+import {AddressHelper, DeferredPromise} from '../Util';
 import {MemberAttributeEvent, MemberAttributeOperationType} from '../core/MemberAttributeEvent';
 import Address = require('../Address');
 import ClientMessage = require('../ClientMessage');
@@ -223,7 +223,7 @@ export class ClusterService extends EventEmitter {
                 const error = new IllegalStateError(errorMessage, cause);
                 return Promise.reject(error);
             } else {
-                const deferred = Promise.defer<void>();
+                const deferred = DeferredPromise<void>();
                 setTimeout(
                     () => {
                         this.tryConnectingToAddresses(0, remainingAttemptLimit, attemptPeriod).then(() => {

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -30,6 +30,7 @@ import {LoggingService} from '../logging/LoggingService';
 import {ClientConnection} from './ClientConnection';
 import Address = require('../Address');
 import ClientMessage = require('../ClientMessage');
+import {DeferredPromise} from '../Util';
 
 const EXCEPTION_MESSAGE_TYPE = 109;
 const MAX_FAST_INVOCATION_COUNT = 5;
@@ -131,7 +132,7 @@ export class InvocationService {
 
     invoke(invocation: Invocation): Promise<ClientMessage> {
         const newCorrelationId = Long.fromNumber(this.correlationCounter++);
-        invocation.deferred = Promise.defer<ClientMessage>();
+        invocation.deferred = DeferredPromise<ClientMessage>();
         invocation.request.setCorrelationId(newCorrelationId);
         this.doInvoke(invocation);
         return invocation.deferred.promise;

--- a/src/nearcache/NearCache.ts
+++ b/src/nearcache/NearCache.ts
@@ -21,7 +21,7 @@ import {NearCacheConfig} from '../config/NearCacheConfig';
 import {DataKeyedHashMap} from '../DataStoreHashMap';
 import {Data} from '../serialization/Data';
 import {SerializationService} from '../serialization/SerializationService';
-import {shuffleArray} from '../Util';
+import {DeferredPromise, shuffleArray} from '../Util';
 import * as AlwaysFreshStaleReadDetectorImpl from './AlwaysFreshStaleReadDetectorImpl';
 import {DataRecord} from './DataRecord';
 import {StaleReadDetector} from './StaleReadDetector';
@@ -108,7 +108,7 @@ export class NearCacheImpl implements NearCache {
 
         this.evictionCandidatePool = [];
         this.internalStore = new DataKeyedHashMap<DataRecord>();
-        this.ready = Promise.defer();
+        this.ready = DeferredPromise();
     }
 
     setReady(): void {

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -43,6 +43,7 @@ import {ReliableTopicProxy} from './topic/ReliableTopicProxy';
 import {DistributedObjectEvent, DistributedObjectListener} from '../core/DistributedObjectListener';
 import Address = require('../Address');
 import ClientMessage = require('../ClientMessage');
+import {DeferredPromise} from '../Util';
 
 export class ProxyManager {
     public static readonly MAP_SERVICE: string = 'hz:impl:mapService';
@@ -92,7 +93,7 @@ export class ProxyManager {
         if (this.proxies[serviceName + name]) {
             return Promise.resolve(this.proxies[serviceName + name]);
         } else {
-            const deferred = Promise.defer <DistributedObject>();
+            const deferred = DeferredPromise<DistributedObject>();
             let newProxy: DistributedObject;
             if (serviceName === ProxyManager.MAP_SERVICE && this.client.getConfig().getNearCacheConfig(name)) {
                 newProxy = new NearCachedMapProxy(this.client, serviceName, name);
@@ -154,7 +155,7 @@ export class ProxyManager {
     }
 
     private createProxy(proxyObject: DistributedObject): Promise<ClientMessage> {
-        const promise = Promise.defer<ClientMessage>();
+        const promise = DeferredPromise<ClientMessage>();
         this.initializeProxy(proxyObject, promise, Date.now() + this.invocationTimeoutMillis);
         return promise.promise;
     }

--- a/src/proxy/flakeid/AutoBatcher.ts
+++ b/src/proxy/flakeid/AutoBatcher.ts
@@ -17,6 +17,7 @@
 import * as Promise from 'bluebird';
 import {EventEmitter} from 'events';
 import * as Long from 'long';
+import {DeferredPromise} from '../../Util';
 
 export class Batch {
     private nextIdLong: Long;
@@ -85,7 +86,7 @@ export class AutoBatcher {
     }
 
     nextId(): Promise<Long> {
-        const deferred = Promise.defer<Long>();
+        const deferred = DeferredPromise<Long>();
         this.queue.push(deferred);
         this.processIdRequests();
         return deferred.promise;

--- a/test/HazelcastClientTest.js
+++ b/test/HazelcastClientTest.js
@@ -18,7 +18,7 @@ var expect = require('chai').expect;
 var Config = require('../.').Config;
 var Controller = require('./RC');
 var HazelcastClient = require('../.').Client;
-var Promise = require('bluebird');
+var DeferredPromise = require('./Util').DeferredPromise;
 
 var dummyConfig = new Config.ClientConfig();
 dummyConfig.networkConfig.smartRouting = false;
@@ -52,7 +52,7 @@ ManagedObjects.prototype.destroyAll = function () {
 };
 
 ManagedObjects.prototype.destroy = function (name) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     this.managedObjects.filter((el) => {
         if (el.getName() === name) {
             el.destroy().then(function () {

--- a/test/HazelcastClientTest.js
+++ b/test/HazelcastClientTest.js
@@ -18,7 +18,7 @@ var expect = require('chai').expect;
 var Config = require('../.').Config;
 var Controller = require('./RC');
 var HazelcastClient = require('../.').Client;
-var DeferredPromise = require('./Util').DeferredPromise;
+var DeferredPromise = require('../lib/Util').DeferredPromise;
 
 var dummyConfig = new Config.ClientConfig();
 dummyConfig.networkConfig.smartRouting = false;

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -17,7 +17,7 @@
 var HazelcastClient = require('../.').Client;
 var Controller = require('./RC');
 var expect = require('chai').expect;
-var DeferredPromise = require('./Util').DeferredPromise;
+var DeferredPromise = require('../lib/Util').DeferredPromise;
 var MemberAttributeOperationType = require('../.').MemberAttributeOperationType;
 
 describe('MembershipListener', function () {

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -17,8 +17,9 @@
 var HazelcastClient = require('../.').Client;
 var Controller = require('./RC');
 var expect = require('chai').expect;
-var Promise = require('bluebird');
-var MemberAttributeOperationType = require('../.').MemberAttributeOperationType
+var DeferredPromise = require('./Util').DeferredPromise;
+var MemberAttributeOperationType = require('../.').MemberAttributeOperationType;
+
 describe('MembershipListener', function () {
     this.timeout(10000);
     var cluster;
@@ -49,7 +50,7 @@ describe('MembershipListener', function () {
     it('sees member added event', function (done) {
         var newMember;
         var err = undefined;
-        var listenerCalledResolver = Promise.defer();
+        var listenerCalledResolver = DeferredPromise();
 
         client.clusterService.on('memberAdded', function (member) {
             listenerCalledResolver.resolve(member);
@@ -73,7 +74,7 @@ describe('MembershipListener', function () {
 
     it('sees member removed event', function (done) {
         var newMember;
-        var listenerCalledResolver = Promise.defer();
+        var listenerCalledResolver = DeferredPromise();
 
         client.clusterService.on('memberRemoved', function (member) {
             listenerCalledResolver.resolve(member);

--- a/test/RC.js
+++ b/test/RC.js
@@ -15,7 +15,7 @@
  */
 
 var RemoteController = require('hazelcast-remote-controller');
-var DeferredPromise = require('./Util').DeferredPromise;
+var DeferredPromise = require('../lib/Util').DeferredPromise;
 
 var controller = new RemoteController('localhost', 9701);
 

--- a/test/RC.js
+++ b/test/RC.js
@@ -15,12 +15,12 @@
  */
 
 var RemoteController = require('hazelcast-remote-controller');
-var Promise = require('bluebird');
+var DeferredPromise = require('./Util').DeferredPromise;
 
 var controller = new RemoteController('localhost', 9701);
 
 function createCluster(hzVersion, config) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.createCluster(hzVersion, config, function (err, cluster) {
         if (err) return deferred.reject(err);
         return deferred.resolve(cluster);
@@ -29,7 +29,7 @@ function createCluster(hzVersion, config) {
 }
 
 function startMember(clusterId) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.startMember(clusterId, function (err, member) {
         if (err) return deferred.reject(err);
         return deferred.resolve(member);
@@ -38,7 +38,7 @@ function startMember(clusterId) {
 }
 
 function exit() {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.exit(function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -47,7 +47,7 @@ function exit() {
 }
 
 function shutdownMember(clusterId, memberUuid) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.shutdownMember(clusterId, memberUuid, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -56,7 +56,7 @@ function shutdownMember(clusterId, memberUuid) {
 }
 
 function shutdownCluster(clusterId) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.shutdownCluster(clusterId, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -65,7 +65,7 @@ function shutdownCluster(clusterId) {
 }
 
 function terminateMember(clusterId, memberUuid) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.terminateMember(clusterId, memberUuid, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -74,7 +74,7 @@ function terminateMember(clusterId, memberUuid) {
 }
 
 function terminateCluster(clusterId) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.terminateCluster(clusterId, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -83,7 +83,7 @@ function terminateCluster(clusterId) {
 }
 
 function executeOnController(clusterId, script, lang) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     controller.executeOnController(clusterId, script, lang, function (err, res) {
         if (err) return deferred.reject(err);
         if (res.success === false) return deferred.reject(res.message);

--- a/test/Util.js
+++ b/test/Util.js
@@ -16,6 +16,8 @@
 
 var expect = require('chai').expect;
 var BuildMetadata = require('../lib/BuildMetadata').BuildMetadata;
+var Promise = require('bluebird');
+
 var promiseLater = function (time, func) {
     if (func === undefined) {
         func = function () {
@@ -108,6 +110,19 @@ exports.findMemberByAddress = function (client, address) {
         return m.address.equals(address);
     });
 };
+
+exports.DeferredPromise = function () {
+    var resolve, reject;
+    var promise = new Promise(function () {
+        resolve = arguments[0];
+        reject = arguments[1];
+    });
+    return {
+        resolve: resolve,
+        reject: reject,
+        promise: promise
+    };
+}
 
 exports.promiseLater = promiseLater;
 exports.expectAlmostEqual = expectAlmostEqual;

--- a/test/Util.js
+++ b/test/Util.js
@@ -16,8 +16,6 @@
 
 var expect = require('chai').expect;
 var BuildMetadata = require('../lib/BuildMetadata').BuildMetadata;
-var Promise = require('bluebird');
-
 var promiseLater = function (time, func) {
     if (func === undefined) {
         func = function () {
@@ -110,19 +108,6 @@ exports.findMemberByAddress = function (client, address) {
         return m.address.equals(address);
     });
 };
-
-exports.DeferredPromise = function () {
-    var resolve, reject;
-    var promise = new Promise(function () {
-        resolve = arguments[0];
-        reject = arguments[1];
-    });
-    return {
-        resolve: resolve,
-        reject: reject,
-        promise: promise
-    };
-}
 
 exports.promiseLater = promiseLater;
 exports.expectAlmostEqual = expectAlmostEqual;

--- a/test/flakeid/FlakeIdGeneratorProxyTest.js
+++ b/test/flakeid/FlakeIdGeneratorProxyTest.js
@@ -111,7 +111,7 @@ describe("FlakeIdGeneratorProxyTest", function () {
             flakeIdGenerator = idGenerator;
             return flakeIdGenerator.newId()
         }).then(function (id) {
-            firstId=id;
+            firstId = id;
             return flakeIdGenerator.newId();
         }).then(function (secondId) {
             return expect(secondId.equals(firstId.add(FLAKE_ID_STEP))).to.be.true;
@@ -124,7 +124,7 @@ describe("FlakeIdGeneratorProxyTest", function () {
             flakeIdGenerator = idGenerator;
             return flakeIdGenerator.newId()
         }).then(function (id) {
-            firstId=id;
+            firstId = id;
             return Util.promiseWaitMilliseconds(SHORT_TERM_VALIDITY_MILLIS + 1000);
         }).then(function () {
             return flakeIdGenerator.newId();
@@ -140,7 +140,7 @@ describe("FlakeIdGeneratorProxyTest", function () {
             flakeIdGenerator = idGenerator;
             return flakeIdGenerator.newId()
         }).then(function (id) {
-            firstId=id;
+            firstId = id;
             return flakeIdGenerator.newId();
         }).then(function () {
             //after this we exhausted the batch at hand
@@ -152,6 +152,7 @@ describe("FlakeIdGeneratorProxyTest", function () {
         }).then(function (secondId) {
             var borderId = firstId.add(FLAKE_ID_STEP * SHORT_TERM_BATCH_SIZE);
             return expect(secondId.greaterThan(borderId), 'Expected ' + secondId + ' to be greater than ' + borderId).to.be.true;
-        });;
+        });
+        ;
     });
 });

--- a/test/map/NearCachedMapStressTest.js
+++ b/test/map/NearCachedMapStressTest.js
@@ -15,12 +15,14 @@
  */
 
 var expect = require('chai').expect;
-var Promise = require('bluebird');
+var fs = require('fs');
+
+var DeferredPromise = require('../Util').DeferredPromise;
+var getRandomInt = require('../Util').getRandomInt;
+var Controller = require('../RC');
+
 var Config = require('../../.').Config;
 var HazelcastClient = require('../../.').Client;
-var Controller = require('../RC');
-var fs = require('fs');
-var getRandomInt = require('../Util').getRandomInt;
 
 describe('NearCachedMapStress', function () {
 
@@ -33,7 +35,7 @@ describe('NearCachedMapStress', function () {
     var completedOperations = 0;
     var concurrencyLevel = 32;
     var totalNumOperations = 100000;
-    var completedDeferred = Promise.defer();
+    var completedDeferred = DeferredPromise();
     var putPercent = 15;
     var removePercent = 20;
     var getPercent = 100 - putPercent - removePercent;

--- a/test/map/NearCachedMapStressTest.js
+++ b/test/map/NearCachedMapStressTest.js
@@ -17,7 +17,7 @@
 var expect = require('chai').expect;
 var fs = require('fs');
 
-var DeferredPromise = require('../Util').DeferredPromise;
+var DeferredPromise = require('../../lib/Util').DeferredPromise;
 var getRandomInt = require('../Util').getRandomInt;
 var Controller = require('../RC');
 

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -21,7 +21,7 @@ var Config = require('../../').Config;
 var fs = require('fs');
 var Long = require('long');
 var Util = require('../Util');
-var DeferredPromise = require('../Util').DeferredPromise;
+var DeferredPromise = require('../../lib/Util').DeferredPromise;
 
 describe('LostInvalidation', function () {
     this.timeout(30000);

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -21,7 +21,7 @@ var Config = require('../../').Config;
 var fs = require('fs');
 var Long = require('long');
 var Util = require('../Util');
-var Promise = require('bluebird');
+var DeferredPromise = require('../Util').DeferredPromise;
 
 describe('LostInvalidation', function () {
     this.timeout(30000);
@@ -159,7 +159,7 @@ describe('LostInvalidation', function () {
         var correlationId = clientRegistrationKey.correlationId;
         var handler = client.getInvocationService().eventHandlers[correlationId.toNumber()].handler;
         var numberOfBlockedInvalidations = 0;
-        var deferred = Promise.defer();
+        var deferred = DeferredPromise();
         client.getInvocationService().eventHandlers[correlationId.toNumber()].handler = function () {
             numberOfBlockedInvalidations++;
             if (notifyAfterNumberOfEvents !== undefined && notifyAfterNumberOfEvents === numberOfBlockedInvalidations) {

--- a/test/nearcache/MigratedDataTest.js
+++ b/test/nearcache/MigratedDataTest.js
@@ -21,7 +21,7 @@ var Config = require('../../').Config;
 var fs = require('fs');
 var Long = require('long');
 var Util = require('../Util');
-var Promise = require('bluebird');
+var DeferredPromise = require('../Util').DeferredPromise;
 var Address = require('../../.').Address;
 
 describe('MigratedData', function () {
@@ -110,7 +110,7 @@ describe('MigratedData', function () {
     });
 
     function waitUntilPartitionMovesTo(partitionService, partitionId, address) {
-        var deferred = Promise.defer();
+        var deferred = DeferredPromise();
         (function resolveOrTimeout(remainingTries) {
             if (partitionService.getAddressForPartition(partitionId).equals(address)) {
                 deferred.resolve();

--- a/test/nearcache/MigratedDataTest.js
+++ b/test/nearcache/MigratedDataTest.js
@@ -21,7 +21,7 @@ var Config = require('../../').Config;
 var fs = require('fs');
 var Long = require('long');
 var Util = require('../Util');
-var DeferredPromise = require('../Util').DeferredPromise;
+var DeferredPromise = require('../../lib/Util').DeferredPromise;
 var Address = require('../../.').Address;
 
 describe('MigratedData', function () {

--- a/test/serialization/config/CustomSerializerTest.js
+++ b/test/serialization/config/CustomSerializerTest.js
@@ -43,7 +43,7 @@ describe('CustomSerializer', function () {
             var map;
             return client.getMap('musicians').then(function (mp) {
                 map = mp;
-                return map.put('neyzen',m);
+                return map.put('neyzen', m);
             }).then(function () {
                 return map.get('neyzen');
             }).then(function (res) {

--- a/test/statistics/StatisticsTest.js
+++ b/test/statistics/StatisticsTest.js
@@ -15,7 +15,7 @@
  */
 
 var expect = require('chai').expect;
-var Promise = require('bluebird');
+var DeferredPromise = require('../Util').DeferredPromise;
 
 var RC = require('../RC');
 var Client = require('../../').Client;
@@ -211,7 +211,7 @@ describe('Statistics with negative period', function () {
 });
 
 function getClientStatisticsFromServer(cluster) {
-    var deferred = Promise.defer();
+    var deferred = DeferredPromise();
     var script = 'client0=instance_0.getClientService().getConnectedClients().' +
         'toArray()[0]\nresult=client0.getClientStatistics();';
     RC.executeOnController(cluster.id, script, 1).then(function (response) {

--- a/test/statistics/StatisticsTest.js
+++ b/test/statistics/StatisticsTest.js
@@ -15,7 +15,7 @@
  */
 
 var expect = require('chai').expect;
-var DeferredPromise = require('../Util').DeferredPromise;
+var DeferredPromise = require('../../lib/Util').DeferredPromise;
 
 var RC = require('../RC');
 var Client = require('../../').Client;


### PR DESCRIPTION
Bluebird's `Promise.defer` deprecated and logs lots of warnings. This PR migrates to `new Promise` via an easy way.
fixes #251 