### PR TITLE
refactor membership listener

### DIFF
--- a/code_samples/membership_listener.js
+++ b/code_samples/membership_listener.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Client = require('hazelcast-client').Client;
+
+Client.newHazelcastClient().then(function (client) {
+
+    // when a member is added and removed or its attribute is changed, member events are invoked.
+    var membershipListener = {
+        memberAdded: function (membershipEvent) {
+            console.log('Member Added:', membershipEvent.member.address);
+        },
+        memberRemoved: function (membershipEvent) {
+            console.log('Member Removed:', membershipEvent.member.address);
+        },
+        memberAttributeChanged: function (memberAttributeEvent) {
+            console.log('Member Attribute Changed:', memberAttributeEvent.member.address);
+        }
+    }
+
+    client.clusterService.addMembershipListener(membershipListener);
+});

--- a/src/core/MembershipEvent.ts
+++ b/src/core/MembershipEvent.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Member} from './Member';
+
+/**
+ * Membership event fired when a new member is added to the cluster and/or when a member leaves the cluster
+ * or when there is a member attribute change.
+ */
+export class MembershipEvent {
+    /**
+     * the removed or added member.
+     */
+    private member: Member;
+
+    /**
+     * the membership event type.
+     */
+    private eventType: number;
+
+    /**
+     * the members at the moment after this event.
+     */
+    private members: Member[];
+
+    constructor(member: Member, eventType: number, members: Member[]) {
+        this.member = member;
+        this.eventType = eventType;
+        this.members = members;
+    }
+
+}

--- a/src/core/MembershipListener.ts
+++ b/src/core/MembershipListener.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {MemberAttributeEvent} from './MemberAttributeEvent';
+import {MembershipEvent} from './MembershipEvent';
+
+/**
+ * Cluster membership listener.
+ */
+export interface MembershipListener {
+    /**
+     * Invoked when a new member is added to the cluster.
+     * @param {MembershipEvent} membership event
+     */
+    memberAdded(membership: MembershipEvent): void;
+
+    /**
+     * Invoked when an existing member leaves the cluster.
+     * @param {MembershipEvent} membership event when an existing member leaves the cluster
+     */
+    memberRemoved(membership: MembershipEvent): void;
+
+    /**
+     * Invoked when an attribute of a member was changed.
+     * @param {MemberAttributeEvent} member attribute event when an attribute of a member was changed
+     */
+    memberAttributeChanged(memberAttributeEvent: MemberAttributeEvent): void;
+}

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -167,7 +167,8 @@ export class ClusterService {
     }
 
     /**
-     * Adds MembershipListener to listen for membership updates.
+     * Adds MembershipListener to listen for membership updates. There is no check for duplicate registrations,
+     * so if you register the listener twice, it will get events twice.
      * @param {MembershipListener} The listener to be registered
      * @return The registration ID
      */

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -19,7 +19,6 @@ import * as Promise from 'bluebird';
 import {ClientAddMembershipListenerCodec} from '../codec/ClientAddMembershipListenerCodec';
 import {Member} from '../core/Member';
 import {LoggingService} from '../logging/LoggingService';
-import {EventEmitter} from 'events';
 import {ClientInfo} from '../ClientInfo';
 import HazelcastClient from '../HazelcastClient';
 import {IllegalStateError} from '../HazelcastError';
@@ -27,20 +26,21 @@ import * as assert from 'assert';
 import {MemberSelector} from '../core/MemberSelector';
 import {AddressHelper, DeferredPromise} from '../Util';
 import {MemberAttributeEvent, MemberAttributeOperationType} from '../core/MemberAttributeEvent';
+import {MembershipListener} from '../core/MembershipListener';
+import {MembershipEvent} from '../core/MembershipEvent';
+import {UuidUtil} from '../util/UuidUtil';
 import Address = require('../Address');
 import ClientMessage = require('../ClientMessage');
 
-const MEMBER_ADDED = 1;
-const MEMBER_REMOVED = 2;
-
-const EMIT_MEMBER_ADDED = 'memberAdded';
-const EMIT_MEMBER_REMOVED = 'memberRemoved';
-const EMIT_ATTRIBUTE_CHANGE = 'memberAttributeChange';
+export enum MemberEvent {
+    ADDED = 1,
+    REMOVED = 2,
+}
 
 /**
  * Manages the relationship of this client with the cluster.
  */
-export class ClusterService extends EventEmitter {
+export class ClusterService {
 
     /**
      * The unique identifier of the owner server node. This node is responsible for resource cleanup
@@ -54,13 +54,12 @@ export class ClusterService extends EventEmitter {
 
     private knownAddresses: Address[] = [];
     private members: Member[] = [];
-
     private client: HazelcastClient;
     private ownerConnection: ClientConnection;
     private logger = LoggingService.getLoggingService();
+    private membershipListeners: Map<string, MembershipListener> = new Map();
 
     constructor(client: HazelcastClient) {
-        super();
         this.client = client;
         this.members = [];
     }
@@ -167,7 +166,30 @@ export class ClusterService extends EventEmitter {
         return this.ownerConnection;
     }
 
-    initMemberShipListener(): Promise<void> {
+    /**
+     * Adds MembershipListener to listen for membership updates.
+     * @param {MembershipListener} The listener to be registered
+     * @return The registration ID
+     */
+    addMembershipListener(membershipListener: MembershipListener): string {
+        const registrationId = UuidUtil.generate().toString();
+        this.membershipListeners.set(registrationId, membershipListener);
+        return registrationId;
+    }
+
+    /**
+     * Removes registered MembershipListener.
+     * @param {string} The registration ID
+     * @return {boolean} true if successfully removed, false otherwise
+     */
+    removeMembershipListener(registrationId: string): boolean {
+        if (registrationId === null) {
+            throw new RangeError('registrationId cannot be null');
+        }
+        return this.membershipListeners.delete(registrationId);
+    }
+
+    initMembershipListener(): Promise<void> {
         const request = ClientAddMembershipListenerCodec.encodeRequest(false);
 
         const handler = (m: ClientMessage) => {
@@ -241,7 +263,7 @@ export class ClusterService extends EventEmitter {
             return this.client.getConnectionManager().getOrConnect(currentAddress, true).then((connection: ClientConnection) => {
                 connection.setAuthenticatedAsOwner(true);
                 this.ownerConnection = connection;
-                return this.initMemberShipListener();
+                return this.initMembershipListener();
             }).catch((e) => {
                 this.logger.warn('ClusterService', e);
                 return this.tryConnectingToAddresses(index + 1, remainingAttemptLimit, attemptPeriod, e);
@@ -250,10 +272,10 @@ export class ClusterService extends EventEmitter {
     }
 
     private handleMember(member: Member, eventType: number): void {
-        if (eventType === MEMBER_ADDED) {
+        if (eventType === MemberEvent.ADDED) {
             this.logger.info('ClusterService', member.toString() + ' added to cluster');
             this.memberAdded(member);
-        } else if (eventType === MEMBER_REMOVED) {
+        } else if (eventType === MemberEvent.REMOVED) {
             this.logger.info('ClusterService', member.toString() + ' removed from cluster');
             this.memberRemoved(member);
         }
@@ -268,14 +290,24 @@ export class ClusterService extends EventEmitter {
 
     private handleMemberAttributeChange(
         uuid: string, key: string, operationType: MemberAttributeOperationType, value: string): void {
-        const member = this.getMember(uuid);
-        const memberAttributeEvent = new MemberAttributeEvent(member, key, operationType, value);
-        this.emit(EMIT_ATTRIBUTE_CHANGE, memberAttributeEvent);
+
+        this.membershipListeners.forEach((membershipListener, registrationId) => {
+            if (membershipListener && membershipListener.memberAttributeChanged) {
+                const member = this.getMember(uuid);
+                const memberAttributeEvent = new MemberAttributeEvent(member, key, operationType, value);
+                membershipListener.memberAttributeChanged(memberAttributeEvent);
+            }
+        });
     }
 
     private memberAdded(member: Member): void {
         this.members.push(member);
-        this.emit(EMIT_MEMBER_ADDED, member);
+        this.membershipListeners.forEach((membershipListener, registrationId) => {
+            if (membershipListener && membershipListener.memberAdded) {
+                const membershipEvent = new MembershipEvent(member, MemberEvent.ADDED, this.members);
+                membershipListener.memberAdded(membershipEvent);
+            }
+        });
     }
 
     private memberRemoved(member: Member): void {
@@ -285,6 +317,11 @@ export class ClusterService extends EventEmitter {
             assert(removedMemberList.length === 1);
         }
         this.client.getConnectionManager().destroyConnection(member.address);
-        this.emit(EMIT_MEMBER_REMOVED, member);
+        this.membershipListeners.forEach((membershipListener, registrationId) => {
+            if (membershipListener && membershipListener.memberRemoved) {
+                const membershipEvent = new MembershipEvent(member, MemberEvent.REMOVED, this.members);
+                membershipListener.memberRemoved(membershipEvent);
+            }
+        });
     }
 }

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -56,10 +56,14 @@ describe('ClusterService', function () {
     it('should know when a new member joins to cluster', function (done) {
         var member2;
 
-        client.getClusterService().once('memberAdded', function () {
-            expect(client.clusterService.getSize()).to.be.eq(2);
-            done();
-        });
+        var membershipListener = {
+            memberAdded: function (membershipEvent) {
+                expect(client.clusterService.getSize()).to.be.eq(2);
+                done();
+            }
+        }
+
+        client.clusterService.addMembershipListener(membershipListener);
 
         Controller.startMember(cluster.id).then(function (res) {
             member2 = res;
@@ -69,10 +73,14 @@ describe('ClusterService', function () {
     it('should know when a member leaves cluster', function (done) {
         var member2;
 
-        client.getClusterService().once('memberRemoved', function () {
-            expect(client.getClusterService().getSize()).to.be.eq(1);
-            done();
-        });
+        var membershipListener = {
+            memberRemoved: function (membershipEvent) {
+                expect(client.getClusterService().getSize()).to.be.eq(1);
+                done();
+            }
+        }
+
+        client.clusterService.addMembershipListener(membershipListener);
 
         Controller.startMember(cluster.id).then(function (res) {
             member2 = res;
@@ -84,17 +92,19 @@ describe('ClusterService', function () {
         this.timeout(20000);
         var member2;
         var member3;
-        client.getClusterService().once('memberRemoved', function () {
-            var remainingMemberList = client.getClusterService().getMembers();
-            try {
+
+        var membershipListener = {
+            memberRemoved: function (membershipEvent) {
+                var remainingMemberList = client.getClusterService().getMembers();
                 expect(remainingMemberList).to.have.length(2);
                 expect(remainingMemberList[0].address.port).to.equal(ownerMember.port);
                 expect(remainingMemberList[1].address.port).to.equal(member3.port);
                 done();
-            } catch (e) {
-                done(e);
             }
-        });
+        }
+
+        client.clusterService.addMembershipListener(membershipListener);
+
         Controller.startMember(cluster.id).then(function (res) {
             member2 = res;
             return Controller.startMember(cluster.id);

--- a/test/LostConnectionTest.js
+++ b/test/LostConnectionTest.js
@@ -49,19 +49,23 @@ describe('Lost connection', function () {
     it('M2 starts, M1 goes down, client sets M2 as owner', function (done) {
         this.timeout(12000);
         var newMember;
-        client.clusterService.on('memberAdded', function () {
-            Controller.shutdownMember(cluster.id, oldMember.uuid).then(function () {
-                return Util.promiseWaitMilliseconds(4000);
-            }).then(function () {
-                try {
-                    expect(client.clusterService.getOwnerConnection().address.host).to.be.eq(newMember.host);
-                    expect(client.clusterService.getOwnerConnection().address.port).to.be.eq(newMember.port);
-                    done();
-                } catch (e) {
-                    done(e);
-                }
-            });
-        });
+        var membershipListener = {
+            memberAdded: function (membershipEvent) {
+                Controller.shutdownMember(cluster.id, oldMember.uuid).then(function () {
+                    return Util.promiseWaitMilliseconds(4000);
+                }).then(function () {
+                    try {
+                        expect(client.clusterService.getOwnerConnection().address.host).to.be.eq(newMember.host);
+                        expect(client.clusterService.getOwnerConnection().address.port).to.be.eq(newMember.port);
+                        done();
+                    } catch (e) {
+                        done(e);
+                    }
+                });
+            }
+        }
+
+        client.clusterService.addMembershipListener(membershipListener);
         Controller.startMember(cluster.id).then(function (m) {
             newMember = m;
         });

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+
 var HazelcastClient = require('../.').Client;
 var Controller = require('./RC');
 var expect = require('chai').expect;
 var DeferredPromise = require('../lib/Util').DeferredPromise;
 var MemberAttributeOperationType = require('../.').MemberAttributeOperationType;
+var MemberEvent = require('../lib/invocation/ClusterService').MemberEvent;
 
 describe('MembershipListener', function () {
     this.timeout(10000);
@@ -52,16 +54,60 @@ describe('MembershipListener', function () {
         var err = undefined;
         var listenerCalledResolver = DeferredPromise();
 
-        client.clusterService.on('memberAdded', function (member) {
-            listenerCalledResolver.resolve(member);
-        });
+        var membershipListener = {
+            memberAdded: function (membershipEvent) {
+                listenerCalledResolver.resolve(membershipEvent);
+            }
+        }
+        client.clusterService.addMembershipListener(membershipListener);
 
         Controller.startMember(cluster.id).then(function (res) {
             newMember = res;
             return listenerCalledResolver.promise;
-        }).then(function (addedMember) {
-            expect(addedMember.address.host).to.equal(newMember.host);
-            expect(addedMember.address.port).to.equal(newMember.port);
+        }).then(function (membershipEvent) {
+            expect(membershipEvent.member.address.host).to.equal(newMember.host);
+            expect(membershipEvent.member.address.port).to.equal(newMember.port);
+            expect(membershipEvent.eventType).to.equal(MemberEvent.ADDED);
+            expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
+        }).catch(function (e) {
+            err = e;
+        }).finally(function (e) {
+            Controller.shutdownMember(cluster.id, newMember.uuid).then(function () {
+                done(err);
+            });
+        });
+
+    });
+
+    it('sees member added event and other listener\'s event ', function (done) {
+        var newMember;
+        var err = undefined;
+        var listenerCalledResolver = DeferredPromise();
+        var listenedSecondListener = false;
+
+        var membershipListener = {
+            memberAdded: function (membershipEvent) {
+                listenerCalledResolver.resolve(membershipEvent);
+            }
+        }
+
+        var membershipListener2 = {
+            memberAdded: function (membershipEvent) {
+                listenedSecondListener = true;
+            }
+        }
+        var id = client.clusterService.addMembershipListener(membershipListener2);
+        client.clusterService.addMembershipListener(membershipListener);
+
+        Controller.startMember(cluster.id).then(function (res) {
+            newMember = res;
+            return listenerCalledResolver.promise;
+        }).then(function (membershipEvent) {
+            expect(membershipEvent.member.address.host).to.equal(newMember.host);
+            expect(membershipEvent.member.address.port).to.equal(newMember.port);
+            expect(membershipEvent.eventType).to.equal(MemberEvent.ADDED);
+            expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
+            expect(listenedSecondListener).to.be.true;
         }).catch(function (e) {
             err = e;
         }).finally(function (e) {
@@ -76,19 +122,25 @@ describe('MembershipListener', function () {
         var newMember;
         var listenerCalledResolver = DeferredPromise();
 
-        client.clusterService.on('memberRemoved', function (member) {
-            listenerCalledResolver.resolve(member);
-        });
+        var membershipListener = {
+            memberRemoved: function (membershipEvent) {
+                listenerCalledResolver.resolve(membershipEvent);
+            }
+        }
+
+        client.clusterService.addMembershipListener(membershipListener);
 
         Controller.startMember(cluster.id).then(function (res) {
             newMember = res;
             return Controller.shutdownMember(cluster.id, newMember.uuid);
         }).then(function () {
             return listenerCalledResolver.promise;
-        }).then(function (removedMember) {
+        }).then(function (membershipEvent) {
             try {
-                expect(removedMember.address.host).to.equal(newMember.host);
-                expect(removedMember.address.port).to.equal(newMember.port);
+                expect(membershipEvent.member.address.host).to.equal(newMember.host);
+                expect(membershipEvent.member.address.port).to.equal(newMember.port);
+                expect(membershipEvent.eventType).to.equal(MemberEvent.REMOVED);
+                expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
                 done();
             } catch (e) {
                 done(e);
@@ -97,27 +149,37 @@ describe('MembershipListener', function () {
     });
 
     it('sees member attribute change put event', function (done) {
-        client.clusterService.on('memberAttributeChange', function (memberAttributeEvent) {
-            if (memberAttributeEvent.operationType === MemberAttributeOperationType.PUT) {
-                expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
-                expect(memberAttributeEvent.key).to.equal('test');
-                expect(memberAttributeEvent.value).to.equal('123');
-                done();
-            }
-        });
+
+        var membershipListener = {
+            memberAttributeChanged: function (memberAttributeEvent) {
+                if (memberAttributeEvent.operationType === MemberAttributeOperationType.PUT) {
+                    expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
+                    expect(memberAttributeEvent.key).to.equal('test');
+                    expect(memberAttributeEvent.value).to.equal('123');
+                    done();
+                }
+            },
+        };
+        client.clusterService.addMembershipListener(membershipListener)
+
+
         var script = 'function attrs() { ' +
             'return instance_0.getCluster().getLocalMember().setIntAttribute("test", 123); }; result=attrs();';
         Controller.executeOnController(cluster.id, script, 1);
     });
 
     it('sees member attribute change remove event', function (done) {
-        client.clusterService.on('memberAttributeChange', function (memberAttributeEvent) {
-            if (memberAttributeEvent.operationType === MemberAttributeOperationType.REMOVE) {
-                expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
-                expect(memberAttributeEvent.key, 'test');
-                done();
+        var membershipListener = {
+            memberAttributeChanged: function (memberAttributeEvent) {
+                if (memberAttributeEvent.operationType === MemberAttributeOperationType.REMOVE) {
+                    expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
+                    expect(memberAttributeEvent.key, 'test');
+                    done();
+                }
             }
-        });
+        }
+        client.clusterService.addMembershipListener(membershipListener)
+
         var addScript = 'function attrs() { ' +
             'return instance_0.getCluster().getLocalMember().setIntAttribute("test", 123); }; result=attrs();';
         var removeScript = 'function attrs() { ' +

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -96,8 +96,8 @@ describe('MembershipListener', function () {
                 listenedSecondListener = true;
             }
         }
-        var id = client.clusterService.addMembershipListener(membershipListener2);
         client.clusterService.addMembershipListener(membershipListener);
+        client.clusterService.addMembershipListener(membershipListener2);
 
         Controller.startMember(cluster.id).then(function (res) {
             newMember = res;
@@ -116,6 +116,28 @@ describe('MembershipListener', function () {
             });
         });
 
+    });
+
+    it('if same listener is added twice, gets same event twice', function (done) {
+        var newMember;
+        var counter = 0;
+
+        var membershipListener = {
+            memberAdded: function (membershipEvent) {
+                counter++;
+            }
+        }
+        client.clusterService.addMembershipListener(membershipListener);
+        client.clusterService.addMembershipListener(membershipListener);
+
+        Controller.startMember(cluster.id).then(function (m) {
+            newMember = m;
+            expect(counter).to.equal(2);
+        }).finally(function (e) {
+            Controller.shutdownMember(cluster.id, newMember.uuid).then(function () {
+                done();
+            });
+        });
     });
 
     it('sees member removed event', function (done) {


### PR DESCRIPTION
This PR refactors membership listener API. User can register a membership listener by using `addMembershipListener` function of `ClusterService`.  Fixes #355 