### PR TITLE
marks some tests with minimum required server versions

### DIFF
--- a/test/HeartbeatTest.js
+++ b/test/HeartbeatTest.js
@@ -22,7 +22,7 @@ var Util = require('./Util');
 var Address = require('../.').Address;
 
 describe('Heartbeat', function () {
-    this.timeout(30000);
+    this.timeout(50000);
 
     var cluster;
 

--- a/test/LostConnectionTest.js
+++ b/test/LostConnectionTest.js
@@ -47,7 +47,7 @@ describe('Lost connection', function () {
     });
 
     it('M2 starts, M1 goes down, client sets M2 as owner', function (done) {
-        this.timeout(12000);
+        this.timeout(32000);
         var newMember;
         var membershipListener = {
             memberAdded: function (membershipEvent) {

--- a/test/ssl/ClientSSLTest.js
+++ b/test/ssl/ClientSSLTest.js
@@ -20,6 +20,7 @@ var expect = chai.expect;
 var fs = require('fs');
 var Promise = require('bluebird');
 var path = require('path');
+var Util = require('../Util');
 
 var markEnterprise = require('../Util').markEnterprise;
 var Controller = require('./../RC');
@@ -35,14 +36,16 @@ describe("Client with SSL enabled", function () {
     var serverConfig;
 
     beforeEach(function () {
-        this.timeout(10000);
+        this.timeout(20000);
         markEnterprise(this);
+        Util.markServerVersionAtLeast(this, null, '3.8.1');
         serverConfig = fs.readFileSync(__dirname + '/hazelcast-ssl.xml', 'utf8');
     });
 
     afterEach(function () {
-        this.timeout(12000);
+        this.timeout(20000);
         markEnterprise(this);
+        Util.markServerVersionAtLeast(this, null, '3.8.1');
         if (client) {
             client.shutdown();
             client = null;

--- a/test/statistics/StatisticsTest.js
+++ b/test/statistics/StatisticsTest.js
@@ -29,6 +29,7 @@ describe('Statistics with default period', function () {
     var map;
 
     before(function () {
+        Util.markServerVersionAtLeast(this, null, '3.9.0');
         return RC.createCluster(null, null).then(function (res) {
             cluster = res;
         }).then(function () {
@@ -47,6 +48,7 @@ describe('Statistics with default period', function () {
     });
 
     after(function () {
+        Util.markServerVersionAtLeast(this, null, '3.9.0');
         client.shutdown();
         return RC.shutdownCluster(cluster.id);
     });
@@ -131,6 +133,7 @@ describe('Statistics with non-default period', function () {
     var client;
 
     before(function () {
+        Util.markServerVersionAtLeast(this, null, '3.9.0');
         return RC.createCluster(null, null).then(function (res) {
             cluster = res;
         }).then(function () {
@@ -146,6 +149,7 @@ describe('Statistics with non-default period', function () {
     });
 
     after(function () {
+        Util.markServerVersionAtLeast(this, null, '3.9.0');
         client.shutdown();
         return RC.shutdownCluster(cluster.id);
     });
@@ -182,6 +186,7 @@ describe('Statistics with negative period', function () {
     var cluster;
 
     before(function () {
+        Util.markServerVersionAtLeast(this, null, '3.9.0');
         return RC.createCluster(null, null).then(function (res) {
             cluster = res;
         }).then(function () {
@@ -197,6 +202,7 @@ describe('Statistics with negative period', function () {
     });
 
     after(function () {
+        Util.markServerVersionAtLeast(this, null, '3.9.0');
         client.shutdown();
         return RC.shutdownCluster(cluster.id);
     });

--- a/test/topic/TopicTest.js
+++ b/test/topic/TopicTest.js
@@ -58,10 +58,10 @@ describe("Reliable Topic Proxy", function () {
     var clientOne;
     var clientTwo;
 
-    this.timeout(5000);
+    this.timeout(40000);
 
     before(function () {
-        this.timeout(10000);
+        this.timeout(40000);
         var config = fs.readFileSync(__dirname + '/hazelcast_topic.xml', 'utf8');
         return Controller.createCluster(null, config).then(function (response) {
             cluster = response;


### PR DESCRIPTION
also increases timeout for some server start heavy tests. Compatibility job fails because of these short timeouts. That job probably runs on a weaker computer.