### PR TITLE
Isolate MembershipListenerTest tests by using seperate cluster for ea…

### DIFF
--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 var HazelcastClient = require('../.').Client;
 var Controller = require('./RC');
 var expect = require('chai').expect;
@@ -27,31 +26,25 @@ describe('MembershipListener', function () {
     var cluster;
     var member;
     var client;
-    before(function (done) {
-        Controller.createCluster(null, null).then(function (res) {
+    beforeEach(function () {
+        return Controller.createCluster(null, null).then(function (res) {
             cluster = res;
-            return Controller.startMember(cluster.id).then(function (res) {
-                member = res;
-                return HazelcastClient.newHazelcastClient();
-            }).then(function (res) {
-                client = res;
-                done();
-            }).catch(function (err) {
-                done(err);
-            });
-        }).catch(function (err) {
-            done(err);
+            return Controller.startMember(cluster.id)
+        }).then(function (res) {
+            member = res;
+            return HazelcastClient.newHazelcastClient();
+        }).then(function (res) {
+            client = res;
         });
     });
 
-    after(function () {
+    afterEach(function () {
         client.shutdown();
         return Controller.shutdownCluster(cluster.id);
     });
 
-    it('sees member added event', function (done) {
+    it('sees member added event', function () {
         var newMember;
-        var err = undefined;
         var listenerCalledResolver = DeferredPromise();
 
         var membershipListener = {
@@ -61,7 +54,7 @@ describe('MembershipListener', function () {
         };
         client.clusterService.addMembershipListener(membershipListener);
 
-        Controller.startMember(cluster.id).then(function (res) {
+        return Controller.startMember(cluster.id).then(function (res) {
             newMember = res;
             return listenerCalledResolver.promise;
         }).then(function (membershipEvent) {
@@ -69,17 +62,10 @@ describe('MembershipListener', function () {
             expect(membershipEvent.member.address.port).to.equal(newMember.port);
             expect(membershipEvent.eventType).to.equal(MemberEvent.ADDED);
             expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
-        }).catch(function (e) {
-            err = e;
-        }).finally(function (e) {
-            Controller.shutdownMember(cluster.id, newMember.uuid).then(function () {
-                done(err);
-            });
         });
-
     });
 
-    it('sees member added event and other listener\'s event ', function (done) {
+    it('sees member added event and other listener\'s event ', function () {
         var newMember;
         var err = undefined;
         var listenerCalledResolver = DeferredPromise();
@@ -99,7 +85,7 @@ describe('MembershipListener', function () {
         client.clusterService.addMembershipListener(membershipListener);
         client.clusterService.addMembershipListener(membershipListener2);
 
-        Controller.startMember(cluster.id).then(function (res) {
+        return Controller.startMember(cluster.id).then(function (res) {
             newMember = res;
             return listenerCalledResolver.promise;
         }).then(function (membershipEvent) {
@@ -108,39 +94,29 @@ describe('MembershipListener', function () {
             expect(membershipEvent.eventType).to.equal(MemberEvent.ADDED);
             expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
             expect(listenedSecondListener).to.be.true;
-        }).catch(function (e) {
-            err = e;
-        }).finally(function (e) {
-            Controller.shutdownMember(cluster.id, newMember.uuid).then(function () {
-                done(err);
-            });
         });
 
     });
 
-    it('if same listener is added twice, gets same event twice', function (done) {
+    it('if same listener is added twice, gets same event twice', function () {
         var newMember;
         var counter = 0;
 
         var membershipListener = {
-            memberAdded: function (membershipEvent) {
+            memberAdded: function () {
                 counter++;
             }
         };
         client.clusterService.addMembershipListener(membershipListener);
         client.clusterService.addMembershipListener(membershipListener);
 
-        Controller.startMember(cluster.id).then(function (m) {
+        return Controller.startMember(cluster.id).then(function (m) {
             newMember = m;
             expect(counter).to.equal(2);
-        }).finally(function (e) {
-            Controller.shutdownMember(cluster.id, newMember.uuid).then(function () {
-                done();
-            });
         });
     });
 
-    it('sees member removed event', function (done) {
+    it('sees member removed event', function () {
         var newMember;
         var listenerCalledResolver = DeferredPromise();
 
@@ -152,50 +128,52 @@ describe('MembershipListener', function () {
 
         client.clusterService.addMembershipListener(membershipListener);
 
-        Controller.startMember(cluster.id).then(function (res) {
+        return Controller.startMember(cluster.id).then(function (res) {
             newMember = res;
             return Controller.shutdownMember(cluster.id, newMember.uuid);
         }).then(function () {
             return listenerCalledResolver.promise;
         }).then(function (membershipEvent) {
-            try {
-                expect(membershipEvent.member.address.host).to.equal(newMember.host);
-                expect(membershipEvent.member.address.port).to.equal(newMember.port);
-                expect(membershipEvent.eventType).to.equal(MemberEvent.REMOVED);
-                expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
-                done();
-            } catch (e) {
-                done(e);
-            }
+            expect(membershipEvent.member.address.host).to.equal(newMember.host);
+            expect(membershipEvent.member.address.port).to.equal(newMember.port);
+            expect(membershipEvent.eventType).to.equal(MemberEvent.REMOVED);
+            expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
         });
     });
 
-    it('sees member attribute change put event', function (done) {
+    it('sees member attribute change put event', function () {
+        var attributeChangePromise = new DeferredPromise();
 
         var membershipListener = {
             memberAttributeChanged: function (memberAttributeEvent) {
-                if (memberAttributeEvent.operationType === MemberAttributeOperationType.PUT) {
-                    expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
-                    expect(memberAttributeEvent.key).to.equal('test');
-                    expect(memberAttributeEvent.value).to.equal('123');
-                    done();
-                }
-            },
+                attributeChangePromise.resolve(memberAttributeEvent);
+            }
         };
         client.clusterService.addMembershipListener(membershipListener);
 
         var script = 'function attrs() { ' +
             'return instance_0.getCluster().getLocalMember().setIntAttribute("test", 123); }; result=attrs();';
-        Controller.executeOnController(cluster.id, script, 1);
+        return Controller.executeOnController(cluster.id, script, 1).then(function () {
+            return attributeChangePromise.promise;
+        }).then(function (memberAttributeEvent) {
+            expect(memberAttributeEvent.operationType === MemberAttributeOperationType.PUT);
+            expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
+            expect(memberAttributeEvent.key).to.equal('test');
+            expect(memberAttributeEvent.value).to.equal('123');
+        });
     });
 
-    it('sees member attribute change remove event', function (done) {
+    it('sees member attribute change remove event', function () {
+        var attributeRemovePromise = new DeferredPromise();
+        var attributeAddPromise = new DeferredPromise();
         var membershipListener = {
             memberAttributeChanged: function (memberAttributeEvent) {
-                if (memberAttributeEvent.operationType === MemberAttributeOperationType.REMOVE) {
-                    expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
-                    expect(memberAttributeEvent.key, 'test');
-                    done();
+                if (memberAttributeEvent.operationType === MemberAttributeOperationType.PUT) {
+                    attributeAddPromise.resolve(memberAttributeEvent);
+                } else if (memberAttributeEvent.operationType === MemberAttributeOperationType.REMOVE) {
+                    attributeRemovePromise.resolve(memberAttributeEvent);
+                } else {
+                    attributeAddPromise.reject(undefined);
                 }
             }
         };
@@ -205,7 +183,16 @@ describe('MembershipListener', function () {
             'return instance_0.getCluster().getLocalMember().setIntAttribute("test", 123); }; result=attrs();';
         var removeScript = 'function attrs() { ' +
             'return instance_0.getCluster().getLocalMember().removeAttribute("test"); }; result=attrs();';
-        Controller.executeOnController(cluster.id, addScript, 1)
-            .then(Controller.executeOnController.bind(this, cluster.id, removeScript, 1));
+        return Controller.executeOnController(cluster.id, addScript, 1).then(function () {
+            return attributeAddPromise.promise;
+        }).then(function () {
+            return Controller.executeOnController(cluster.id, removeScript, 1);
+        }).then(function () {
+            return attributeRemovePromise.promise;
+        }).then(function (memberAttributeEvent) {
+            expect(memberAttributeEvent.operationType === MemberAttributeOperationType.REMOVE);
+            expect(memberAttributeEvent.member.uuid).to.equal(member.uuid);
+            expect(memberAttributeEvent.key, 'test3');
+        });
     });
 });

--- a/test/lock/LockProxyTest.js
+++ b/test/lock/LockProxyTest.js
@@ -118,13 +118,12 @@ describe("Lock Proxy", function () {
             return lockTwo.tryLock(2000, 1000);
         }).then(function () {
             var elapsed = Date.now() - startTime;
-            expect(elapsed).to.be.greaterThan(1000);
+            expect(elapsed).to.be.at.least(1000);
             return lockOne.lock(2000);
         }).then(function () {
             var elapsed = Date.now() - startTime;
-            expect(elapsed).to.be.greaterThan(1000);
+            expect(elapsed).to.be.at.least(1000);
         });
-
     });
 
     it("correctly reports lock status when unlocked", function () {
@@ -132,7 +131,6 @@ describe("Lock Proxy", function () {
             expect(locked).to.be.false;
         });
     });
-
 
     it("correctly reports lock status when locked", function () {
         return lockOne.lock().then(function () {
@@ -198,6 +196,4 @@ describe("Lock Proxy", function () {
             expect(locked).to.be.false;
         });
     });
-
-
 });


### PR DESCRIPTION
…ch test

Since the same cluster is used for all tests, test failures are not isolated. One test may fail silently and cause a false negative for another test. These tests now use seperate clusters for each test case.

fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/447
fixes https://github.com/hazelcast/hazelcast-nodejs-client/issues/449