### PR TITLE
Adds missing os.systemLoadAverage

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -330,3 +330,9 @@ export function DeferredPromise<T>(): Promise.Resolver<T> {
         promise,
     } as Promise.Resolver<T>;
 }
+
+export function getNodejsMajorVersion(): number {
+    const versionString = process.version;
+    const versions = versionString.split('.');
+    return Number.parseInt(versions[0].substr(1));
+}

--- a/src/statistics/Statistics.ts
+++ b/src/statistics/Statistics.ts
@@ -153,15 +153,22 @@ export class Statistics {
         this.registerGauge('os.freeSwapSpaceSize', () => Statistics.EMPTY_STAT_VALUE);
         this.registerGauge('os.maxFileDescriptorCount', () => Statistics.EMPTY_STAT_VALUE);
         this.registerGauge('os.openFileDescriptorCount', () => Statistics.EMPTY_STAT_VALUE);
-        this.registerGauge('os.processCpuTime', () => Statistics.EMPTY_STAT_VALUE);
-        this.registerGauge('os.systemLoadAverage', () => '[' + os.loadavg().toString() + ']');
+        this.registerGauge('os.processCpuTime', () => {
+            // Nodejs 4 does not support this metric. So we do not print an ugly warning for that.
+            if (Util.getNodejsMajorVersion() >= 6) {
+                return process.cpuUsage().user * 1000; // process.cpuUsage returns micoseconds. We convert to nanoseconds.
+            } else {
+                return Statistics.EMPTY_STAT_VALUE;
+            }
+        });
+        this.registerGauge('os.systemLoadAverage', () => os.loadavg()[0]);
         this.registerGauge('os.totalPhysicalMemorySize', () => os.totalmem());
         this.registerGauge('os.totalSwapSpaceSize', () => Statistics.EMPTY_STAT_VALUE);
         this.registerGauge('runtime.availableProcessors', () => os.cpus().length);
         this.registerGauge('runtime.freeMemory', () => Statistics.EMPTY_STAT_VALUE);
         this.registerGauge('runtime.maxMemory', () => Statistics.EMPTY_STAT_VALUE);
         this.registerGauge('runtime.totalMemory', () => process.memoryUsage().heapTotal);
-        this.registerGauge('runtime.uptime', () => process.uptime());
+        this.registerGauge('runtime.uptime', () => process.uptime() * 1000);
         this.registerGauge('runtime.usedMemory', () => process.memoryUsage().heapUsed);
         this.registerGauge('executionService.userExecutorQueueSize', () => Statistics.EMPTY_STAT_VALUE);
     }


### PR DESCRIPTION
os.systemLoadAverage statistic is an array of 1, 5 and 15 minute averages in Node.js. However client statistics prd defines this as a single value coverring only last minute.
This also adds missing os.processCpuTime statistic which was missing. This metric is not supported in Node.js 4 so we silently ignore it in that case.

Fixes #446