### PR TITLE
add missing line to the cluster section

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ The following is an example configuration when you are adding an `IdentifiedData
 ```
 If you want to add a `Portable` class, you should use `<portable-factories>` instead of `<data-serializable-factories>` in the above configuration.
 
+See the [Hazelcast IMDG Reference Manual](http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#getting-started) for more information on setting up the clusters.
+
 ## 1.3. Downloading and Installing
 
 Hazelcast Node.js client is on NPM. Just add `hazelcast-client` as a dependency to your Node.js project and you are good to go.


### PR DESCRIPTION
link to the getting started section of the hazelcast reference manual was removed mistakenly with the #458  . this pr adds that line again