### PR TITLE
update readme and code samples

### DIFF
--- a/code_samples/org-website/AtomicLongSample.js
+++ b/code_samples/org-website/AtomicLongSample.js
@@ -3,7 +3,7 @@ var Client = require('hazelcast-client').Client;
 Client.newHazelcastClient().then(function (hz) {
     var counter;
     // Get an Atomic Counter, we'll call it "counter"
-    hz.getAtomicLong("counter").then(function (c) {
+    hz.getAtomicLong('counter').then(function (c) {
         counter = c;
         // Add and Get the "counter"
         return counter.addAndGet(3);
@@ -11,7 +11,7 @@ Client.newHazelcastClient().then(function (hz) {
         return counter.get();
     }).then(function (value) {
         // Display the "counter" value
-        console.log("counter: " + value);
+        console.log('counter: ' + value);
         // Shutdown this Hazelcast Client
         hz.shutdown();
     });

--- a/code_samples/org-website/LockSample.js
+++ b/code_samples/org-website/LockSample.js
@@ -3,7 +3,7 @@ var Client = require('hazelcast-client').Client;
 Client.newHazelcastClient().then(function (hz) {
     var lock;
     // Get a distributed lock called "my-distributed-lock"
-    hz.getLock("my-distributed-lock").then(function (l) {
+    hz.getLock('my-distributed-lock').then(function (l) {
         lock = l;
         // Now create a lock and execute some guarded code.
         return lock.lock();

--- a/code_samples/org-website/ReliableTopicSample.js
+++ b/code_samples/org-website/ReliableTopicSample.js
@@ -3,7 +3,7 @@ var Client = require('hazelcast-client').Client;
 Client.newHazelcastClient().then(function (hz) {
     var topic;
     // Get a Topic called "my-distributed-topic"
-    hz.getReliableTopic("my-distributed-topic").then(function (t) {
+    hz.getReliableTopic('my-distributed-topic').then(function (t) {
         topic = t;
         // Add a Listener to the Topic
         topic.addMessageListener(function (message) {

--- a/hazelcast-client-full.json
+++ b/hazelcast-client-full.json
@@ -14,11 +14,12 @@
         "hazelcast.invalidation.reconciliation.interval.seconds": 60,
         "hazelcast.invalidation.max.tolerated.miss.count": 10,
         "hazelcast.invalidation.min.reconciliation.interval.seconds": 30,
+        "hazelcast.logging.level": 2
     },
     "network": {
         "clusterMembers": [
-            "127.0.0.1:5701",
-            "127.0.0.2:5703"
+            "127.0.0.1",
+            "127.0.0.2:5702"
         ],
         "smartRouting": true,
         "redoOperation": false,
@@ -27,6 +28,7 @@
         "connectionAttemptLimit": 2,
         "ssl": {
             "enabled": false,
+            "sslOptions": null,
             "factory": {
                 "path": "path/to/file",
                 "exportedName": "exportedName",
@@ -55,6 +57,7 @@
     "serialization": {
         "defaultNumberType": "double",
         "isBigEndian": true,
+        "jsonStringDeserializationPolicy": "eager",
         "dataSerializableFactories": [
             {
                 "path": "path/to/file",
@@ -115,13 +118,13 @@
     "flakeIdGeneratorConfigs": [
         {
             "name": "flakeid",
-            "prefetchCount": 123,
-            "prefetchValidityMillis": 150000
+            "prefetchCount": 1000,
+            "prefetchValidityMillis": 30000
         },
         {
             "name": "flakeid2",
-            "prefetchCount": 1234,
-            "prefetchValidityMillis": 1900000
+            "prefetchCount": 5000,
+            "prefetchValidityMillis": 500000
         }
     ],
     "import": [


### PR DESCRIPTION
Updated Readme to get rid of the repetitive names. Renamed `hazelcast-client-sample.json` as `hazelcast-client-full.json` and  added missing properties. Also, changed some single quotes to double quotes in the code samples.