### PR TITLE
add jaas code samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1470,7 +1470,7 @@ To use this feature, you need to
 * have a class implementing the [`LoginModule`](https://docs.oracle.com/javase/6/docs/api/javax/security/auth/spi/LoginModule.html?is-external=true) interface which uses the `Credentials` object during the authentication process
 * configure your Hazelcast member's security properties with respect to these classes before starting it. If you have started your member as described in the [Running Standalone JARs section](#1211-running-standalone-jars), see the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
-[`UsernamePasswordCredentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/UsernamePasswordCredentials.html), a custom implementation of the `Credentials` interface, is available in the Hazelcast `com.hazelcast.security` package. 
+[`UsernamePasswordCredentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/UsernamePasswordCredentials.html), a basic implementation of the `Credentials` interface, is available in the Hazelcast `com.hazelcast.security` package. 
 `UsernamePasswordCredentials` is used for default configuration during the authentication process of both members and clients. You can also use this class to carry the security attributes of your client.
 
 Hazelcast also has an abstract implementation of the `LoginModule` interface which is the `ClusterLoginModule` class in the `com.hazelcast.security` package. 

--- a/README.md
+++ b/README.md
@@ -1461,23 +1461,23 @@ For information about the path resolution, see the [Loading Objects and Path Res
 
 ## 6.2. Credentials
 
-One of the key elements in Hazelcast security is `Credentials` object, which can be used to carry all security attributes of the
-Hazelcast Node.js client to Hazelcast members. Then, Hazelcast members can authenticate clients and perform access control
-checks on client operations using this `Credentials` object.
+One of the key elements in Hazelcast security is the `Credentials` object, which can be used to carry all security attributes of the
+Hazelcast Node.js client to Hazelcast members. Then, Hazelcast members can authenticate the clients and perform access control
+checks on the client operations using this `Credentials` object.
 
 To use this feature, you need to 
-* have a class that implements [`Credentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/Credentials.html) interface that contains security attributes of your client
-* have a class that implements [`LoginModule`](https://docs.oracle.com/javase/6/docs/api/javax/security/auth/spi/LoginModule.html?is-external=true) interface which uses `Credentials` object during the authentication process
-* configure your Hazelcast member's security properties with respect to these classes before starting it. If you have started your member as described in [Running Standalone JARs section](#1211-running-standalone-jars), see [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
+* have a class implementing the [`Credentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/Credentials.html) interface which contains the security attributes of your client
+* have a class implementing the [`LoginModule`](https://docs.oracle.com/javase/6/docs/api/javax/security/auth/spi/LoginModule.html?is-external=true) interface which uses the `Credentials` object during the authentication process
+* configure your Hazelcast member's security properties with respect to these classes before starting it. If you have started your member as described in the [Running Standalone JARs section](#1211-running-standalone-jars), see the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
-[`UsernamePasswordCredentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/UsernamePasswordCredentials.html), a custom implementation of `Credentials` interface, is available in the Hazelcast `com.hazelcast.security` package. 
-`UsernamePasswordCredentials` is used for default configuration during the authentication process of both members and clients. You can also use this class to carry security attributes of your client.
+[`UsernamePasswordCredentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/UsernamePasswordCredentials.html), a custom implementation of the `Credentials` interface, is available in the Hazelcast `com.hazelcast.security` package. 
+`UsernamePasswordCredentials` is used for default configuration during the authentication process of both members and clients. You can also use this class to carry the security attributes of your client.
 
-Hazelcast also has an abstract implementation of `LoginModule` interface which is the `ClusterLoginModule` class in the `com.hazelcast.security` package. 
+Hazelcast also has an abstract implementation of the `LoginModule` interface which is the `ClusterLoginModule` class in the `com.hazelcast.security` package. 
 You can extend this class and do the authentication on the `onLogin()` method. 
 
 Below is an example for the extension of abstract `ClusterLoginModule` class. 
-On the `ClientLoginModule#onLogin()` method, we are doing simple authentication against a hardcoded username and password just for illustrative purposes. You should carry out the authentication against a security service of your choice.
+On the `ClientLoginModule#onLogin()` method, we are doing a simple authentication against a hardcoded username and password just for illustrative purposes. You should carry out the authentication against a security service of your choice.
  
 ```java
 import com.hazelcast.security.ClusterLoginModule;
@@ -1540,7 +1540,7 @@ and give the user with the name `admin` all the permissions over the map named `
 </hazelcast>
 ```
 
-After successfully starting Hazelcast member as described above, you need to implement `Portable` equivalent of the `UsernamePasswordCredentials`
+After successfully starting a Hazelcast member as described above, you need to implement `Portable` equivalent of the `UsernamePasswordCredentials`
 and register it to your client configuration.
 
 Below is the code for that.
@@ -1623,12 +1623,12 @@ Client.newHazelcastClient(config).then(function (client) {
 });
 ```
 
-> NOTE: It is almost always a bad idea to write the credentials to wire in a clear-text format. Therefore, using TLS/SSL encryption is highly recommended while using custom credentials as described in [TLS/SSL section]((#61-tlsssl)).
+> NOTE: It is almost always a bad idea to write the credentials to wire in a clear-text format. Therefore, using TLS/SSL encryption is highly recommended while using the custom credentials as described in [TLS/SSL section]((#61-tlsssl)).
 
 With Hazelcast's extensible, `JAAS` based security features you can do much more than just authentication. 
-See [JAAS code sample](code_samples/jaas_sample) to see how to perform access control checks on client operations based on user groups.
+See the [JAAS code sample](code_samples/jaas_sample) to learn how to perform access control checks on the client operations based on user groups.
 
-Also, see the [Security section](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#security) of Hazelcast Reference Manual for more information.
+Also, see the [Security section](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#security) of Hazelcast IMDG Reference Manual for more information.
  
 
 # 7. Using Node.js Client with Hazelcast IMDG

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
     * [6.1.1. TLS/SSL for Hazelcast Members](#611-tlsssl-for-hazelcast-members)
     * [6.1.2. TLS/SSL for Hazelcast Node.js Clients](#612-tlsssl-for-hazelcast-nodejs-clients)
     * [6.1.3. Mutual Authentication](#613-mutual-authentication)
+  * [6.2. Credentials](#62-credentials)
 * [7. Using Node.js Client with Hazelcast IMDG](#7-using-nodejs-client-with-hazelcast-imdg)
   * [7.1. Node.js Client API Overview](#71-nodejs-client-api-overview)
   * [7.2. Node.js Client Operation Modes](#72-nodejs-client-operation-modes)
@@ -1297,7 +1298,7 @@ To be able to connect to the provided IP addresses, you should use secure TLS/SS
 
 # 6. Securing Client Connection
 
-This chapter describes the security features of Hazelcast Node.js client. These include using TLS/SSL for connections between members and between clients and members, and mutual authentication. These security features require **Hazelcast IMDG Enterprise** edition.
+This chapter describes the security features of Hazelcast Node.js client. These include using TLS/SSL for connections between members and between clients and members, mutual authentication and credentials. These security features require **Hazelcast IMDG Enterprise** edition.
 
 ### 6.1. TLS/SSL
 
@@ -1458,6 +1459,177 @@ the properties section in the JSON configuration file. Lastly, the client calls 
 
 For information about the path resolution, see the [Loading Objects and Path Resolution section](#33-loading-objects-and-path-resolution).
 
+## 6.2. Credentials
+
+One of the key elements in Hazelcast security is `Credentials` object, which can be used to carry all security attributes of the
+Hazelcast Node.js client to Hazelcast members. Then, Hazelcast members can authenticate clients and perform access control
+checks on client operations using this `Credentials` object.
+
+To use this feature, you need to 
+* have a class that implements [`Credentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/Credentials.html) interface that contains security attributes of your client
+* have a class that implements [`LoginModule`](https://docs.oracle.com/javase/6/docs/api/javax/security/auth/spi/LoginModule.html?is-external=true) interface which uses `Credentials` object during the authentication process
+* configure your Hazelcast member's security properties with respect to these classes before starting it. If you have started your member as described in [Running Standalone JARs section](#1211-running-standalone-jars), see [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
+
+[`UsernamePasswordCredentials`](https://docs.hazelcast.org/docs/latest/javadoc/com/hazelcast/security/UsernamePasswordCredentials.html), a custom implementation of `Credentials` interface, is available in the Hazelcast `com.hazelcast.security` package. 
+`UsernamePasswordCredentials` is used for default configuration during the authentication process of both members and clients. You can also use this class to carry security attributes of your client.
+
+Hazelcast also has an abstract implementation of `LoginModule` interface which is the `ClusterLoginModule` class in the `com.hazelcast.security` package. 
+You can extend this class and do the authentication on the `onLogin()` method. 
+
+Below is an example for the extension of abstract `ClusterLoginModule` class. 
+On the `ClientLoginModule#onLogin()` method, we are doing simple authentication against a hardcoded username and password just for illustrative purposes. You should carry out the authentication against a security service of your choice.
+ 
+```java
+import com.hazelcast.security.ClusterLoginModule;
+import com.hazelcast.security.UsernamePasswordCredentials;
+
+import javax.security.auth.login.FailedLoginException;
+import javax.security.auth.login.LoginException;
+
+public class ClientLoginModule extends ClusterLoginModule {
+
+  @Override
+  protected boolean onLogin() throws LoginException {
+      if (credentials instanceof UsernamePasswordCredentials) {
+          UsernamePasswordCredentials usernamePasswordCredentials = (UsernamePasswordCredentials) credentials;
+          String username = usernamePasswordCredentials.getUsername();
+          String password = usernamePasswordCredentials.getPassword();
+          
+          if (username.equals("admin") && password.equals("password")) {
+              return true;
+          }
+          throw new FailedLoginException("Username or password doesn't match expected value.");
+      }
+      return false;
+  }
+
+  @Override
+  public boolean onCommit() {
+      return loginSucceeded;
+  }
+
+  @Override
+  protected boolean onAbort() {
+      return true;
+  }
+
+  @Override
+  protected boolean onLogout() {
+      return true;
+  }
+}
+```
+
+Finally, you can configure `hazelcast.xml` as follows to enable Hazelcast security, do mandatory authentication with `ClientLoginModule`
+and give the user with the name `admin` all the permissions over the map named `importantMap`.
+
+```xml
+<hazelcast>
+    <security enabled="true">
+        <client-login-modules>
+            <login-module class-name="com.company.ClientLoginModule" usage="REQUIRED"/>
+        </client-login-modules>
+        <client-permissions>
+            <map-permission name="importantMap" principal="admin">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </map-permission>
+        </client-permissions>
+    </security>
+</hazelcast>
+```
+
+After successfully starting Hazelcast member as described above, you need to implement `Portable` equivalent of the `UsernamePasswordCredentials`
+and register it to your client configuration.
+
+Below is the code for that.
+
+**user_pass_cred.js**
+```javascript
+function UsernamePasswordCredentials(username, password, endpoint) {
+    this.username = username;
+    this.password = Buffer.from(password, 'utf8');
+    this.endpoint = endpoint;
+}
+
+UsernamePasswordCredentials.prototype.readPortable = function (reader) {
+    this.username = reader.readUTF('principal');
+    this.endpoint = reader.readUTF('endpoint');
+    this.password = reader.readByteArray('pwd');
+};
+
+UsernamePasswordCredentials.prototype.writePortable = function (writer) {
+    writer.writeUTF('principal', this.username);
+    writer.writeUTF('endpoint', this.endpoint);
+    writer.writeByteArray('pwd', this.password);
+};
+
+UsernamePasswordCredentials.prototype.getFactoryId = function () {
+    return -1;
+};
+
+UsernamePasswordCredentials.prototype.getClassId = function () {
+    return 1;
+};
+
+exports.UsernamePasswordCredentials = UsernamePasswordCredentials;
+```
+
+And below is the `Factory` implementation for the `Portable` implementation of `UsernamePasswordCredentials`.
+
+**user_pass_cred_factory.js**
+```javascript
+var UsernamePasswordCredentials = require('./user_pass_cred').UsernamePasswordCredentials;
+
+function UsernamePasswordCredentialsFactory() {
+}
+
+UsernamePasswordCredentialsFactory.prototype.create = function (classId) {
+    if(classId === 1){
+        return new UsernamePasswordCredentials();
+    }
+    return null;
+};
+
+exports.UsernamePasswordCredentialsFactory = UsernamePasswordCredentialsFactory;
+```
+
+Now, you can start your client by registering the `Portable` factory and giving the credentials as follows.
+
+```javascript
+var Client = require('hazelcast-client').Client;
+var ClientConfig = require('hazelcast-client').Config.ClientConfig;
+
+var UsernamePasswordCredentials = require('./user_pass_cred').UsernamePasswordCredentials;
+var UsernamePasswordCredentialsFactory = require('./user_pass_cred_factory').UsernamePasswordCredentialsFactory;
+
+var config = new ClientConfig();
+config.serializationConfig.portableVersion = 1;
+config.serializationConfig.portableFactories[-1] = new UsernamePasswordCredentialsFactory();
+config.customCredentials = new UsernamePasswordCredentials('admin', 'password', '127.0.0.1');
+
+Client.newHazelcastClient(config).then(function (client) {
+    var map;
+    return client.getMap('importantMap').then(function (mp) {
+        map = mp;
+        return map.put('key', 'value');
+    }).then(function () {
+        return map.get('key');
+    }).then(function (value) {
+        console.log(value);
+        return client.shutdown();
+    });
+});
+```
+
+> NOTE: It is almost always a bad idea to write the credentials to wire in a clear-text format. Therefore, using TLS/SSL encryption is highly recommended while using custom credentials as described in [TLS/SSL section]((#61-tlsssl)).
+
+With Hazelcast's extensible, `JAAS` based security features you can do much more than just authentication. 
+See [JAAS code sample](code_samples/jaas_sample) to see how to perform access control checks on client operations based on user groups.
+
+Also, see the [Security section](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#security) of Hazelcast Reference Manual for more information.
+ 
 
 # 7. Using Node.js Client with Hazelcast IMDG
 
@@ -2211,7 +2383,7 @@ IdentifiedEntryProcessor.prototype.getClassId = function () {
 };
 ```
 
-Now, you need to make sure that the Hazelcast member recognizes the entry processor. For this, you need to implement the Java equivalent of your entry processor and its factory, and create your own compiled class or JAR files. For adding your own compiled class or JAR files to the server's `CLASSPATH`, see the [Adding User Library to CLASSPATH section](#1213-adding-user-library-to-classpath).
+Now, you need to make sure that the Hazelcast member recognizes the entry processor. For this, you need to implement the Java equivalent of your entry processor and its factory, and create your own compiled class or JAR files. For adding your own compiled class or JAR files to the server's `CLASSPATH`, see the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
 The following is the Java equivalent of the entry processor in Node.js client given above:
 
@@ -2380,7 +2552,7 @@ Employee.prototype.writePortable = function (writer) {
 
 Note that `Employee` is a `Portable` object. As portable types are not deserialized on the server side for querying, you don't need to implement its Java equivalent on the server side.
 
-For the non-portable types, you need to implement its Java equivalent and its serializable factory on the server side for server to reconstitute the objects from binary formats. In this case before starting the server, you need to compile the Employee and related factory classes with server's CLASSPATH and add them to the user-lib directory in the extracted hazelcast-<version>.zip (or tar).  See the [Adding User Library to CLASSPATH section](#1213-adding-user-library-to-classpath).
+For the non-portable types, you need to implement its Java equivalent and its serializable factory on the server side for server to reconstitute the objects from binary formats. In this case before starting the server, you need to compile the Employee and related factory classes with server's CLASSPATH and add them to the user-lib directory in the extracted hazelcast-<version>.zip (or tar).  See the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
 > **NOTE: Querying with `Portable` object is faster as compared to `IdentifiedDataSerializable`.**
 
@@ -2539,7 +2711,7 @@ hazelcastClient.getMap('students').then(function (mp) {
 });
 ```
 
-If you want to sort the result before paging, you need to specify a comparator object that implements the `Comparator` interface. Also, this comparator object should be one of `IdentifiedDataSerializable` or `Portable`. After implementing this object in Node.js, you need to implement the Java equivalent of it and its factory. The Java equivalent of the comparator should implement `java.util.Comparator`. Note that the `compare` function of `Comparator` on the Java side is the equivalent of the `sort` function of `Comparator` on the Node.js side. When you implement the `Comparator` and its factory, you can add them to the `CLASSPATH` of the server side.  See the [Adding User Library to CLASSPATH section](#1213-adding-user-library-to-classpath).
+If you want to sort the result before paging, you need to specify a comparator object that implements the `Comparator` interface. Also, this comparator object should be one of `IdentifiedDataSerializable` or `Portable`. After implementing this object in Node.js, you need to implement the Java equivalent of it and its factory. The Java equivalent of the comparator should implement `java.util.Comparator`. Note that the `compare` function of `Comparator` on the Java side is the equivalent of the `sort` function of `Comparator` on the Node.js side. When you implement the `Comparator` and its factory, you can add them to the `CLASSPATH` of the server side.  See the [Adding User Library to CLASSPATH section](#1212-adding-user-library-to-classpath).
 
 Also, you can access a specific page more easily with the help of the `setPage` function. This way, if you make a query for the 100th page, for example, it will get all 100 pages at once instead of reaching the 100th page one by one using the `nextPage` function.
 

--- a/code_samples/jaas_sample/README.md
+++ b/code_samples/jaas_sample/README.md
@@ -1,6 +1,9 @@
 # JAAS Code Sample
 
-This code sample demonstrates how to assign different permission policies for different user groups with the Hazelcast JAAS based security features.
+This code sample demonstrates how to assign different permission policies for different user groups with the Hazelcast's JAAS based security features.
+Security features used in this code sample requires **Hazelcast IMDG Enterprise** edition.
+
+---
 
 Users within the `adminGroup` have create, destroy, read and put permissions over the `importantAdminMap`.
 
@@ -12,18 +15,25 @@ To test the code sample,
 
 * Start the Hazelcast member with [Bootstrap.java](hazelcast-member/src/main/java/com/company/Bootstrap.java).
 
-* Run the [clien.js](client.js) with the command `node client.js`.
+* Run the [admin_client.js](admin_client.js) with the command `node admin_client.js` to see what can the users within the `adminGroup` do.
 
-You should see an output similar to below.
+* Run the [reader_client.js](reader_client.js) with the command `node reader_client.js` to see what can the users within the `readerGroup` do.
+
+You should see an output similar to below for the `admin_client.js`.
+
+```
+Admin client connected
+Admin can create a map
+Admin can read from map: null
+Admin can put to map
+Value for the "anotherKey" is anotherValue
+```
+
+And, for the `reader_client.js` you should see an output similar to below.
 
 ```
 Reader client connected
-Admin client connected
 Reader can create a map
-Admin can create a map
 Reader can read from map: null
-Admin can read from map: null
 Reader cannot put to map. Reason: Error: Class name: java.security.AccessControlException , Message: Permission ("com.hazelcast.security.permission.MapPermission" "importantReaderMap" "put") denied!
-Admin can put to map
-Value for the "anotherKey" is anotherValue
 ```

--- a/code_samples/jaas_sample/README.md
+++ b/code_samples/jaas_sample/README.md
@@ -1,0 +1,29 @@
+# JAAS Code Sample
+
+This code sample demonstrates how to assign different permission policies for different user groups with the Hazelcast JAAS based security features.
+
+Users within the `adminGroup` have crate, destroy, read and put permissions over the `importantAdminMap`.
+
+Users within the `readerGroup` have just create and read permissions over the `importantReaderMap`.
+
+To test the code sample,
+
+* Make sure you have [hazelcast.xml](hazelcast-member/src/main/resources/hazelcast.xml) is in your class path.
+
+* Start the Hazelcast member with [Bootstrap.java](hazelcast-member/src/main/java/com/company/Bootstrap.java).
+
+* Run the [clien.js](client.js) with the command `node client.js`.
+
+You should see an output similar to below.
+
+```
+Reader client connected
+Admin client connected
+Reader can create a map
+Admin can create a map
+Reader can read from map: null
+Admin can read from map: null
+Reader cannot put to map. Reason: Error: Class name: java.security.AccessControlException , Message: Permission ("com.hazelcast.security.permission.MapPermission" "importantReaderMap" "put") denied!
+Admin can put to map
+Value for the "anotherKey" is anotherValue
+```

--- a/code_samples/jaas_sample/README.md
+++ b/code_samples/jaas_sample/README.md
@@ -13,7 +13,7 @@ To test the code sample,
 
 * Make sure [hazelcast.xml](hazelcast-member/src/main/resources/hazelcast.xml) is in your class path.
 
-* Start the Hazelcast member with [Bootstrap.java](hazelcast-member/src/main/java/com/company/Bootstrap.java).
+* Start the Hazelcast member with [Bootstrap.java](hazelcast-member/src/main/java/com/company/Bootstrap.java). If you are unsure about how to do that, see [the notes on starting `Bootstrap.java`](hazelcast-member/README.md).
 
 * Run the [admin_client.js](admin_client.js) with the command `node admin_client.js` to see what can the users within the `adminGroup` do.
 

--- a/code_samples/jaas_sample/README.md
+++ b/code_samples/jaas_sample/README.md
@@ -2,13 +2,13 @@
 
 This code sample demonstrates how to assign different permission policies for different user groups with the Hazelcast JAAS based security features.
 
-Users within the `adminGroup` have crate, destroy, read and put permissions over the `importantAdminMap`.
+Users within the `adminGroup` have create, destroy, read and put permissions over the `importantAdminMap`.
 
 Users within the `readerGroup` have just create and read permissions over the `importantReaderMap`.
 
 To test the code sample,
 
-* Make sure you have [hazelcast.xml](hazelcast-member/src/main/resources/hazelcast.xml) is in your class path.
+* Make sure [hazelcast.xml](hazelcast-member/src/main/resources/hazelcast.xml) is in your class path.
 
 * Start the Hazelcast member with [Bootstrap.java](hazelcast-member/src/main/java/com/company/Bootstrap.java).
 

--- a/code_samples/jaas_sample/admin_client.js
+++ b/code_samples/jaas_sample/admin_client.js
@@ -5,13 +5,9 @@ var UsernamePasswordCredentials = require('./user_pass_cred').UsernamePasswordCr
 var UsernamePasswordCredentialsFactory = require('./user_pass_cred_factory').UsernamePasswordCredentialsFactory;
 
 var adminClientConfig = new Config();
-var readerClientConfig = new Config();
 
 adminClientConfig.serializationConfig.portableFactories[1] = new UsernamePasswordCredentialsFactory();
-readerClientConfig.serializationConfig.portableFactories[1] = new UsernamePasswordCredentialsFactory();
-
 adminClientConfig.customCredentials = new UsernamePasswordCredentials('admin', 'password1', '127.0.0.1');
-readerClientConfig.customCredentials = new UsernamePasswordCredentials('reader', 'password2', '127.0.0.1');
 
 Client.newHazelcastClient(adminClientConfig).then(function (adminClient) {
     console.log('Admin client connected');
@@ -29,21 +25,5 @@ Client.newHazelcastClient(adminClientConfig).then(function (adminClient) {
     }).then(function (value) {
         console.log('Value for the "anotherKey" is ' + value);
         return adminClient.shutdown();
-    });
-});
-
-Client.newHazelcastClient(readerClientConfig).then(function (readerClient) {
-    console.log('Reader client connected');
-    var readerMap;
-    return readerClient.getMap('importantReaderMap').then(function (map) {
-        console.log('Reader can create a map');
-        readerMap = map;
-        return readerMap.get('someKey');
-    }).then(function (value) {
-        console.log('Reader can read from map: ' + value);
-        return readerMap.put('anotherKey', 'anotherValue'); // Should reject
-    }).catch(function (err) {
-        console.log('Reader cannot put to map. Reason: ' + err);
-        return readerClient.shutdown();
     });
 });

--- a/code_samples/jaas_sample/client.js
+++ b/code_samples/jaas_sample/client.js
@@ -1,0 +1,49 @@
+var Client = require('hazelcast-client').Client;
+var Config = require('hazelcast-client').Config.ClientConfig;
+
+var UsernamePasswordCredentials = require('./user_pass_cred').UsernamePasswordCredentials;
+var UsernamePasswordCredentialsFactory = require('./user_pass_cred_factory').UsernamePasswordCredentialsFactory;
+
+var adminClientConfig = new Config();
+var readerClientConfig = new Config();
+
+adminClientConfig.serializationConfig.portableFactories[1] = new UsernamePasswordCredentialsFactory();
+readerClientConfig.serializationConfig.portableFactories[1] = new UsernamePasswordCredentialsFactory();
+
+adminClientConfig.customCredentials = new UsernamePasswordCredentials('admin', 'password1', '127.0.0.1');
+readerClientConfig.customCredentials = new UsernamePasswordCredentials('reader', 'password2', '127.0.0.1');
+
+Client.newHazelcastClient(adminClientConfig).then(function (adminClient) {
+    console.log('Admin client connected');
+    var adminMap;
+    return adminClient.getMap('importantAdminMap').then(function (map) {
+        console.log('Admin can create a map');
+        adminMap = map;
+        return adminMap.get('someKey');
+    }).then(function (value) {
+        console.log('Admin can read from map: ' + value);
+        return adminMap.put('anotherKey', 'anotherValue'); // Should resolve
+    }).then(function () {
+        console.log('Admin can put to map');
+        return adminMap.get('anotherKey');
+    }).then(function (value) {
+        console.log('Value for the "anotherKey" is ' + value);
+        return adminClient.shutdown();
+    });
+});
+
+Client.newHazelcastClient(readerClientConfig).then(function (readerClient) {
+    console.log('Reader client connected');
+    var readerMap;
+    return readerClient.getMap('importantReaderMap').then(function (map) {
+        console.log('Reader can create a map');
+        readerMap = map;
+        return readerMap.get('someKey');
+    }).then(function (value) {
+        console.log('Reader can read from map: ' + value);
+        return readerMap.put('anotherKey', 'anotherValue'); // Should reject
+    }).catch(function (err) {
+        console.log('Reader cannot put to map. Reason: ' + err);
+        return readerClient.shutdown();
+    });
+});

--- a/code_samples/jaas_sample/hazelcast-member/README.md
+++ b/code_samples/jaas_sample/hazelcast-member/README.md
@@ -1,0 +1,17 @@
+Make sure you have
+* [Java 6+](https://www.java.com/en/download/) installed on your system.
+* [Hazelcast IMDG Enterprise JAR](https://hazelcast.com/download/) available in your system.
+
+Then, put your Hazelcast IMDG Enterprise license key into the [hazelcast.xml](src/main/resources/hazelcast.xml).
+
+Compile the Java files with the following command:
+
+```
+javac -cp /path/to/enterprise/hazelcast-enterprise.jar src/main/java/com/company/security/*.java src/main/java/com/company/Bootstrap.java
+```
+
+Finally, run the `Bootstrap` with the following command:
+
+```
+java -cp /path/to/enterprise/hazelcast-enterprise.jar:src/main/resources:src/main/java com.company.Bootstrap
+```

--- a/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/Bootstrap.java
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/Bootstrap.java
@@ -1,0 +1,10 @@
+package com.company;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+public class Bootstrap {
+    public static void main(String[] args){
+        HazelcastInstance member = Hazelcast.newHazelcastInstance();
+    }
+}

--- a/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/ClientLoginModule.java
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/ClientLoginModule.java
@@ -1,0 +1,95 @@
+package com.company.security;
+
+import com.hazelcast.security.ClusterPrincipal;
+import com.hazelcast.security.Credentials;
+import com.hazelcast.security.CredentialsCallback;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+public class ClientLoginModule implements LoginModule {
+    private UsernamePasswordCredentials usernamePasswordCredentials;
+    private Subject subject;
+    private CallbackHandler callbackHandler;
+    private DummyAuthenticator authenticator;
+
+    public void initialize(Subject subject,
+                           CallbackHandler callbackHandler,
+                           Map<String, ?> sharedState,
+                           Map<String, ?> options) {
+        this.subject = subject;
+        this.callbackHandler = callbackHandler;
+        this.authenticator = new DummyAuthenticator();
+    }
+
+    public boolean login() throws LoginException {
+        return authenticateUser(getCredentials());
+    }
+
+    public boolean commit() throws LoginException {
+        storeRolesOnPrincipal();
+        return true;
+    }
+
+    public boolean abort() throws LoginException {
+        clearSubject();
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        clearSubject();
+        return true;
+    }
+
+    private UsernamePasswordCredentials getCredentials() throws LoginException {
+        final CredentialsCallback cb = new CredentialsCallback();
+        Credentials credentials;
+        try {
+            callbackHandler.handle(new Callback[]{cb});
+            credentials = cb.getCredentials();
+        } catch (Exception e) {
+            throw new LoginException(e.getClass().getName() + ":" + e.getMessage());
+        }
+        if (credentials == null) {
+            throw new LoginException("Credentials could not be retrieved!");
+        }
+
+        if (credentials instanceof UsernamePasswordCredentials) {
+            usernamePasswordCredentials = (UsernamePasswordCredentials) credentials;
+            return usernamePasswordCredentials;
+        } else {
+            throw new LoginException("Credentials is not an instance of UsernamePasswordCredentials!");
+        }
+    }
+
+    private boolean authenticateUser(UsernamePasswordCredentials credentials) {
+        String username = credentials.getUsername();
+        String password = credentials.getPassword();
+        return authenticator.authenticate(username, password);
+    }
+
+    private void storeRolesOnPrincipal() throws LoginException {
+        List<String> userGroups = authenticator.getRoles(usernamePasswordCredentials.getUsername());
+        if (userGroups != null) {
+            for (String userGroup : userGroups) {
+                Principal principal = new ClusterPrincipal(new UserGroupCredentials(usernamePasswordCredentials.getEndpoint(), userGroup));
+                subject.getPrincipals().add(principal);
+            }
+        } else {
+            throw new LoginException("User Group(s) not found for user " + usernamePasswordCredentials.getUsername());
+        }
+    }
+
+    private void clearSubject() {
+        subject.getPrincipals().clear();
+        subject.getPrivateCredentials().clear();
+        subject.getPublicCredentials().clear();
+    }
+}

--- a/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/DummyAuthenticator.java
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/DummyAuthenticator.java
@@ -1,0 +1,34 @@
+package com.company.security;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DummyAuthenticator {
+    private Map<String, String> users;
+    private Map<String, List<String>> userGrous;
+
+    public DummyAuthenticator(){
+        userGrous = new HashMap<>();
+        users = new HashMap<>();
+
+        users.put("admin", "password1");
+        users.put("reader", "password2");
+
+        userGrous.put("admin", Arrays.asList("adminGroup"));
+        userGrous.put("reader", Arrays.asList("readerGroup"));
+    }
+
+    public boolean authenticate(String username, String password){
+        String userPassword = users.get(username);
+        if (userPassword != null){
+            return userPassword.equals(password);
+        }
+        return false;
+    }
+
+    public List<String> getRoles(String username){
+        return userGrous.get(username);
+    }
+}

--- a/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/UserGroupCredentials.java
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/UserGroupCredentials.java
@@ -1,0 +1,48 @@
+package com.company.security;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.security.Credentials;
+
+import java.io.IOException;
+
+public class UserGroupCredentials implements Credentials, DataSerializable {
+    private String endpoint;
+    private String userGroup;
+
+    public UserGroupCredentials(){
+    }
+
+    public UserGroupCredentials(String endpoint, String userGroup){
+        this.endpoint = endpoint;
+        this.userGroup = userGroup;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return userGroup;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
+        objectDataOutput.writeUTF(endpoint);
+        objectDataOutput.writeUTF(userGroup);
+    }
+
+    @Override
+    public void readData(ObjectDataInput objectDataInput) throws IOException {
+        endpoint = objectDataInput.readUTF();
+        userGroup = objectDataInput.readUTF();
+    }
+}

--- a/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/UsernamePasswordCredentials.java
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/UsernamePasswordCredentials.java
@@ -1,0 +1,71 @@
+package com.company.security;
+
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.security.Credentials;
+
+import java.io.IOException;
+
+public class UsernamePasswordCredentials implements Credentials, Portable {
+    public static final int CLASS_ID = 1;
+
+    private String username;
+    private String password;
+    private String endpoint;
+
+    public UsernamePasswordCredentials() {
+    }
+
+    public UsernamePasswordCredentials(String username, String password, String endpoint) {
+        this.username = username;
+        this.password = password;
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    @Override
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public String getPrincipal() {
+        return getUsername();
+    }
+
+    public String getUsername(){
+        return username;
+    }
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public void readPortable(PortableReader portableReader) throws IOException {
+        username = portableReader.readUTF("username");
+        password = portableReader.readUTF("password");
+        endpoint = portableReader.readUTF("endpoint");
+    }
+
+    @Override
+    public void writePortable(PortableWriter portableWriter) throws IOException {
+        portableWriter.writeUTF("username", username);
+        portableWriter.writeUTF("password", password);
+        portableWriter.writeUTF("endpoint", endpoint);
+    }
+
+    @Override
+    public int getClassId() {
+        return UsernamePasswordCredentials.CLASS_ID;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return UsernamePasswordCredentialsFactory.FACTORY_ID;
+    }
+}

--- a/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/UsernamePasswordCredentialsFactory.java
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/java/com/company/security/UsernamePasswordCredentialsFactory.java
@@ -1,0 +1,17 @@
+package com.company.security;
+
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+
+public class UsernamePasswordCredentialsFactory implements PortableFactory {
+
+    public static final int FACTORY_ID = 1;
+
+    @Override
+    public Portable create(int id) {
+        if(UsernamePasswordCredentials.CLASS_ID == id){
+            return new UsernamePasswordCredentials();
+        }
+        return null;
+    }
+}

--- a/code_samples/jaas_sample/hazelcast-member/src/main/resources/hazelcast.xml
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/resources/hazelcast.xml
@@ -21,18 +21,6 @@
            http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
 
     <license-key>YOUR-LICENSE-KEY</license-key>
-    
-    <network>
-        <join>
-            <multicast enabled="false">
-                <multicast-group>224.2.2.3</multicast-group>
-                <multicast-port>54327</multicast-port>
-            </multicast>
-            <tcp-ip enabled="true">
-                <interface>127.0.0.1</interface>
-            </tcp-ip>
-        </join>
-    </network>
 
     <security enabled="true">
         <client-login-modules>

--- a/code_samples/jaas_sample/hazelcast-member/src/main/resources/hazelcast.xml
+++ b/code_samples/jaas_sample/hazelcast-member/src/main/resources/hazelcast.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+
+    <license-key>YOUR-LICENSE-KEY</license-key>
+    
+    <network>
+        <join>
+            <multicast enabled="false">
+                <multicast-group>224.2.2.3</multicast-group>
+                <multicast-port>54327</multicast-port>
+            </multicast>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+            </tcp-ip>
+        </join>
+    </network>
+
+    <security enabled="true">
+        <client-login-modules>
+            <login-module class-name="com.company.security.ClientLoginModule" usage="REQUIRED"/>
+        </client-login-modules>
+        <client-permissions>
+            <map-permission name="importantReaderMap" principal="readerGroup">
+                <actions>
+                    <action>create</action>
+                    <action>read</action>
+                </actions>
+            </map-permission>
+            <map-permission name="importantAdminMap" principal="adminGroup">
+                <actions>
+                    <action>create</action>
+                    <action>destroy</action>
+                    <action>put</action>
+                    <action>read</action>
+                </actions>
+            </map-permission>
+        </client-permissions>
+    </security>
+
+    <serialization>
+        <portable-factories>
+            <portable-factory factory-id="1">com.company.security.UsernamePasswordCredentialsFactory</portable-factory>
+        </portable-factories>
+    </serialization>
+</hazelcast>

--- a/code_samples/jaas_sample/reader_client.js
+++ b/code_samples/jaas_sample/reader_client.js
@@ -1,0 +1,26 @@
+var Client = require('hazelcast-client').Client;
+var Config = require('hazelcast-client').Config.ClientConfig;
+
+var UsernamePasswordCredentials = require('./user_pass_cred').UsernamePasswordCredentials;
+var UsernamePasswordCredentialsFactory = require('./user_pass_cred_factory').UsernamePasswordCredentialsFactory;
+
+var readerClientConfig = new Config();
+
+readerClientConfig.serializationConfig.portableFactories[1] = new UsernamePasswordCredentialsFactory();
+readerClientConfig.customCredentials = new UsernamePasswordCredentials('reader', 'password2', '127.0.0.1');
+
+Client.newHazelcastClient(readerClientConfig).then(function (readerClient) {
+    console.log('Reader client connected');
+    var readerMap;
+    return readerClient.getMap('importantReaderMap').then(function (map) {
+        console.log('Reader can create a map');
+        readerMap = map;
+        return readerMap.get('someKey');
+    }).then(function (value) {
+        console.log('Reader can read from map: ' + value);
+        return readerMap.put('anotherKey', 'anotherValue'); // Should reject
+    }).catch(function (err) {
+        console.log('Reader cannot put to map. Reason: ' + err);
+        return readerClient.shutdown();
+    });
+});

--- a/code_samples/jaas_sample/user_pass_cred.js
+++ b/code_samples/jaas_sample/user_pass_cred.js
@@ -1,0 +1,27 @@
+function UsernamePasswordCredentials(username, password, endpoint) {
+    this.username = username;
+    this.password = password;
+    this.endpoint = endpoint;
+}
+
+UsernamePasswordCredentials.prototype.readPortable = function (reader) {
+    this.username = reader.readUTF('username');
+    this.endpoint = reader.readUTF('password');
+    this.password = reader.readUTF('endpoint');
+};
+
+UsernamePasswordCredentials.prototype.writePortable = function (writer) {
+    writer.writeUTF('username', this.username);
+    writer.writeUTF('password', this.password);
+    writer.writeUTF('endpoint', this.endpoint);
+};
+
+UsernamePasswordCredentials.prototype.getFactoryId = function () {
+    return 1;
+};
+
+UsernamePasswordCredentials.prototype.getClassId = function () {
+    return 1;
+};
+
+exports.UsernamePasswordCredentials = UsernamePasswordCredentials;

--- a/code_samples/jaas_sample/user_pass_cred_factory.js
+++ b/code_samples/jaas_sample/user_pass_cred_factory.js
@@ -1,0 +1,13 @@
+var UsernamePasswordCredentials = require('./user_pass_cred');
+
+function UsernamePasswordCredentialsFactory() {
+}
+
+UsernamePasswordCredentialsFactory.prototype.create = function (classId) {
+    if(classId === 1){
+        return new UsernamePasswordCredentials();
+    }
+    return null;
+};
+
+exports.UsernamePasswordCredentialsFactory = UsernamePasswordCredentialsFactory;


### PR DESCRIPTION
This pr adds JAAS code samples and README documentation for the Node.js client.

I used `UsernamePasswordCredentials` on the `com.hazelcast.security` package on the code that I put to README to not have too many Java code on the README

On the code samples, I put an example where I implemented the interface from scratch to show how to do it.
