### PR TITLE
add missing expired and loaded events

### DIFF
--- a/src/core/EntryListener.ts
+++ b/src/core/EntryListener.ts
@@ -26,6 +26,8 @@ export interface EntryListener<K, V> {
     updated?: EntryEventListener<K, V>;
     merged?: EntryEventListener<K, V>;
     evicted?: EntryEventListener<K, V>;
+    expired?: EntryEventListener<K, V>;
+    loaded?: EntryEventListener<K, V>;
     mapEvicted?: MapEventListener<K, V>;
     mapCleared?: MapEventListener<K, V>;
 

--- a/src/core/EventType.ts
+++ b/src/core/EventType.ts
@@ -25,4 +25,5 @@ export enum EventType {
     MERGED = 1 << 6,
     EXPIRED = 1 << 7,
     INVALIDATION = 1 << 8,
+    LOADED = 1 << 9,
 }

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -611,6 +611,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
                     break;
                 case EventType.LOADED:
                     listener.loaded.apply(null, [entryEvent]);
+                    break;
             }
         };
         let codec: ListenerMessageCodec;

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -559,6 +559,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
             merged: EventType.MERGED,
             removed: EventType.REMOVED,
             updated: EventType.UPDATED,
+            expired: EventType.EXPIRED,
+            loaded: EventType.LOADED,
         };
         for (const funcName in conversionTable) {
             if (listener[funcName]) {
@@ -604,6 +606,11 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
                 case EventType.MERGED:
                     listener.merged.apply(null, [entryEvent]);
                     break;
+                case EventType.EXPIRED:
+                    listener.expired.apply(null, [entryEvent]);
+                    break;
+                case EventType.LOADED:
+                    listener.loaded.apply(null, [entryEvent]);
             }
         };
         let codec: ListenerMessageCodec;

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -703,7 +703,7 @@ describe('MapProxy', function () {
                 });
             });
 
-            it('addEntryListener on key entryRemoved includeValue=yes', function (done) {
+            it('addEntryListener on key entryRemoved includeValue=true', function (done) {
                 var listenerObject = {
                     removed: function (entryEvent) {
                         try {
@@ -724,7 +724,7 @@ describe('MapProxy', function () {
                 });
             });
 
-            it('addEntryListener on key evicted includeValue=yes', function (done) {
+            it('addEntryListener on key evicted includeValue=true', function (done) {
                 var listenerObject = {
                     evicted: function (entryEvent) {
                         try {
@@ -779,6 +779,29 @@ describe('MapProxy', function () {
                 map.addEntryListener(listenerObject).then(function () {
                     map.clear();
                 });
+            });
+
+            it('addEntryListener on map entryExpired includeValue=true', function (done) {
+                var listenerObj = {
+                  expired: function (entryEvent) {
+                      try {
+                          expect(entryEvent.name).to.equal('test');
+                          expect(entryEvent.key).to.equal('expiringKey');
+                          expect(entryEvent.value).to.be.undefined;
+                          expect(entryEvent.oldValue).to.equal('expiringValue');
+                          expect(entryEvent.mergingValue).to.be.undefined;
+                          expect(entryEvent.member).to.not.be.equal(null);
+                          done();
+                      } catch (err) {
+                          done(err);
+                      }
+                  }
+                };
+
+                map.addEntryListener(listenerObj, undefined, true)
+                    .then(function () {
+                        return map.put('expiringKey', 'expiringValue', 1000);
+                    });
             });
 
             it('removeEntryListener with correct id', function () {

--- a/test/map/MapStoreTest.js
+++ b/test/map/MapStoreTest.js
@@ -191,9 +191,9 @@ describe('MapStore', function () {
             .then(function () {
                 return map.put('some-key', 'some-value', 1000)
             }).then(function () {
-                return promiseWaitMilliseconds(1100);
+                return promiseWaitMilliseconds(2000);
             }).then(function () {
-                return map.containsKey('some-key');
+                return map.get('some-key');
             });
     });
 });


### PR DESCRIPTION
This pr adds the missing two events: expired and loaded. The test for the loaded event uses `SampleMapStore` in the `com.hazelcast.client.test` package. It firsts puts a data to map with TTL. After 1 second, data is not available on the map but available on the map store. So, the get method call causes the event to fire by loading the event from the underlying MapStore

fixes #483 