### PR TITLE
Fixes Client member list state gets broken with hot restart

### DIFF
--- a/src/core/MembershipEvent.ts
+++ b/src/core/MembershipEvent.ts
@@ -24,17 +24,17 @@ export class MembershipEvent {
     /**
      * the removed or added member.
      */
-    private member: Member;
+    public member: Member;
 
     /**
      * the membership event type.
      */
-    private eventType: number;
+    public eventType: number;
 
     /**
      * the members at the moment after this event.
      */
-    private members: Member[];
+    public members: Member[];
 
     constructor(member: Member, eventType: number, members: Member[]) {
         this.member = member;

--- a/src/core/MembershipEvent.ts
+++ b/src/core/MembershipEvent.ts
@@ -34,9 +34,9 @@ export class MembershipEvent {
     /**
      * the members at the moment after this event.
      */
-    public members: Member[];
+    public members: Set<Member>;
 
-    constructor(member: Member, eventType: number, members: Member[]) {
+    constructor(member: Member, eventType: number, members: Set<Member>) {
         this.member = member;
         this.eventType = eventType;
         this.members = members;

--- a/src/proxy/PNCounterProxy.ts
+++ b/src/proxy/PNCounterProxy.ts
@@ -130,11 +130,12 @@ export class PNCounterProxy extends BaseProxy implements PNCounter {
 
     private getReplicaAddresses(excludedAddresses: Address[]): Promise<Address[]> {
         const dataMembers = this.client.getClusterService().getMembers(MemberSelectors.DATA_MEMBER_SELECTOR);
+        const dataMembersIterator = dataMembers.values();
         return this.getMaxConfiguredReplicaCount().then((replicaCount: number) => {
-            const currentCount = Math.min(replicaCount, dataMembers.length);
+            const currentCount = Math.min(replicaCount, dataMembers.size);
             const replicaAddresses: Address[] = [];
             for (let i = 0; i < currentCount; i++) {
-                const memberAddress = dataMembers[i].address;
+                const memberAddress = dataMembersIterator.next().value.address;
                 if (!excludedAddresses.some(memberAddress.equals.bind(memberAddress))) {
                     replicaAddresses.push(memberAddress);
                 }

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -164,13 +164,13 @@ export class ProxyManager {
     private findNextAddress(): Address {
         const members = this.client.getClusterService().getMembers();
         let liteMember: Member = null;
-        for (const member of members) {
+        members.forEach((member) => {
             if (member != null && member.isLiteMember === false) {
                 return member.address;
             } else if (member != null && member.isLiteMember) {
                 liteMember = member;
             }
-        }
+        });
 
         if (liteMember != null) {
             return liteMember.address;

--- a/test/ClientClusterRestartEventTest.js
+++ b/test/ClientClusterRestartEventTest.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var HazelcastClient = require('../.').Client;
+var Controller = require('./RC');
+var expect = require('chai').expect;
+var DeferredPromise = require('../lib/Util').DeferredPromise;
+var MemberAttributeOperationType = require('../.').MemberAttributeOperationType;
+var MemberEvent = require('../lib/invocation/ClusterService').MemberEvent;
+var Config = require('../.').Config;
+
+
+describe('ClientClusterRestartEvenetTest',function () {
+    var cluster;
+    var client;
+    var member;
+
+    beforeEach(function () {
+        return Controller.createCluster(null, null).then(function (res) {
+            cluster = res;
+            return Controller.startMember(cluster.id)
+        }).then(function (res) {
+            member = res;
+            return HazelcastClient.newHazelcastClient();
+        }).then(function (res) {
+            client = res;
+        });
+    });
+
+    afterEach(function () {
+        client.shutdown();
+        return Controller.shutdownCluster(cluster.id);
+    });
+
+
+    it('test single member restart', function () {
+        this.timeout(20000);
+        var listenerCalledResolver = DeferredPromise();
+
+        var membershipListener = {
+            memberAdded: function (membershipEvent) {
+                console.log('Added Event');
+                listenerCalledResolver.resolve(membershipEvent);
+            },
+            memberRemoved: function (membershipEvent) {
+                console.log('Removed Event');
+                listenerCalledResolver.resolve(membershipEvent);
+            },
+            memberAttributeChanged: function (membershipEvent) {
+
+            }
+        };
+        client.clusterService.addMembershipListener(membershipListener);
+
+        return Controller.shutdownMember(cluster.id, member.uuid)
+            .then(function () {
+                return Controller.startMember(cluster.id);
+            }).then(function () {
+                return listenerCalledResolver.promise;
+            }).then(function (membershipEvent) {
+                console.log(membershipEvent);
+                // expect(membershipEvent.eventType).to.equal(MemberEvent.ADDED);
+                // expect(membershipEvent.eventType).to.equal(MemberEvent.REMOVED);
+                // expect(membershipEvent.members).to.equal(client.clusterService.getMembers());
+                // expect(membershipEvent.members.size()).to.equal(1);
+
+            });
+
+    });
+
+});


### PR DESCRIPTION
In hotrestart feature, members will preserve their uuid's, but can
start with different addresses. Client was relying on only uuid,
and when a member restarted, it was assuming nothing has changed.
When it does not change its local membership view in this case, it
is trying to continue with old address which is wrong.

Also for these cases, we were not firing any member
removed,added events. With this fix, for a restarted member
with different address we will wire removed,added events.

Note that, if member comes back with same address and uuid, from
client point of view there is no way to detect the restart. So
no events will be fired in that case.

 Fixes #472 