### PR TITLE
add aws privatelink feature

### DIFF
--- a/src/discovery/HazelcastCloudDiscovery.ts
+++ b/src/discovery/HazelcastCloudDiscovery.ts
@@ -89,8 +89,10 @@ export class HazelcastCloudDiscovery {
             const privateAddress = value[HazelcastCloudDiscovery.PRIVATE_ADDRESS_PROPERTY];
             const publicAddress = value[HazelcastCloudDiscovery.PUBLIC_ADDRESS_PROPERTY];
 
-            const publicAddr = AddressHelper.createAddressFromString(publicAddress.toString());
-            privateToPublicAddresses.set(new Address(privateAddress, publicAddr.port).toString(), publicAddr);
+            const publicAddr = AddressHelper.createAddressFromString(publicAddress.toString(), -1);
+            // If not explicitly given, create the private address with the public addresses port
+            const privateAddr = AddressHelper.createAddressFromString(privateAddress.toString(), publicAddr.port);
+            privateToPublicAddresses.set(privateAddr.toString(), publicAddr);
         }
 
         return privateToPublicAddresses;

--- a/test/discovery/HazelcastCloudDiscoveryTest.js
+++ b/test/discovery/HazelcastCloudDiscoveryTest.js
@@ -1,0 +1,31 @@
+var Address = require('../../lib/Address');
+var expect = require('chai').expect;
+var HazelcastCloudDiscovery = require('../../lib/discovery/HazelcastCloudDiscovery').HazelcastCloudDiscovery;
+
+describe('HazelcastCloudDiscovery Test', function () {
+    var hazelcastCloudDiscovery = new HazelcastCloudDiscovery();
+
+    it('parseResponse', function () {
+        var response = '[{"private-address":"100.96.5.1","public-address":"10.113.44.139:31115"},' +
+            '{"private-address":"100.96.4.2","public-address":"10.113.44.130:31115"}]';
+
+        var privateToPublicAddresses = hazelcastCloudDiscovery.parseResponse(response);
+        expect(privateToPublicAddresses.size).to.equal(2);
+        expect(new Address('10.113.44.139', 31115)).to.deep.equal(
+            privateToPublicAddresses.get(new Address('100.96.5.1', 31115).toString()));
+        expect(new Address('10.113.44.130', 31115)).to.deep.equal(
+            privateToPublicAddresses.get(new Address('100.96.4.2', 31115).toString()));
+    });
+
+    it('parseResponse_withDifferentPortOnPrivateAddress', function () {
+        var response = '[{"private-address":"100.96.5.1:5701","public-address":"10.113.44.139:31115"},' +
+            '{"private-address":"100.96.4.2:5701","public-address":"10.113.44.130:31115"}]';
+
+        var privateToPublicAddresses = hazelcastCloudDiscovery.parseResponse(response);
+        expect(privateToPublicAddresses.size).to.equal(2);
+        expect(new Address('10.113.44.139', 31115)).to.deep.equal(
+            privateToPublicAddresses.get(new Address('100.96.5.1', 5701).toString()));
+        expect(new Address('10.113.44.130', 31115)).to.deep.equal(
+            privateToPublicAddresses.get(new Address('100.96.4.2', 5701).toString()));
+    });
+});


### PR DESCRIPTION
Implements this PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1952120859/Node.js+Client+AWS+PrivateLink+compatibility