### PR TITLE
Add compatibility checks for the rest value tests

### DIFF
--- a/test/rest_value/RestValueTest.js
+++ b/test/rest_value/RestValueTest.js
@@ -24,6 +24,7 @@ const http = require('http');
 const querystring = require('querystring');
 const DeferredPromise = require('../../lib/Util').DeferredPromise;
 const Buffer = require('safe-buffer').Buffer;
+const Util = require('../Util');
 
 describe('RestValueTest', function () {
 
@@ -43,6 +44,10 @@ describe('RestValueTest', function () {
             }).then(c => {
                 client = c;
             });
+    });
+
+    beforeEach(function () {
+        Util.markServerVersionAtLeast(this, client, '3.8');
     });
 
     after(function () {

--- a/test/rest_value/hazelcast_rest.xml
+++ b/test/rest_value/hazelcast_rest.xml
@@ -15,11 +15,9 @@
   -->
 
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.12.xsd"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.6.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
-    <network>
-        <rest-api enabled="true">
-            <endpoint-group name="DATA" enabled="true"/>
-        </rest-api>
-    </network>
+    <properties>
+        <property name="hazelcast.rest.enabled">true</property>
+    </properties>
 </hazelcast>

--- a/test/serialization/DefaultSerializersLiveTest.js
+++ b/test/serialization/DefaultSerializersLiveTest.js
@@ -20,6 +20,7 @@ var RC = require('../RC');
 var expect = require('chai').expect;
 var StringSerializationPolicy = require('../../.').StringSerializationPolicy;
 var RestValue = require('../../lib/core/RestValue').RestValue;
+var Util = require('../Util');
 
 var stringSerializationPolicies = [StringSerializationPolicy.STANDARD, StringSerializationPolicy.LEGACY];
 
@@ -163,6 +164,7 @@ stringSerializationPolicies.forEach(function (stringSerializationPolicy) {
         });
 
         it('rest value', function () {
+            Util.markServerVersionAtLeast(this, client, '3.8');
             // Making sure that the object is properly de-serialized at the server
             var restValue = new RestValue();
             restValue.value = '{\'test\':\'data\'}';


### PR DESCRIPTION
RestValue class was DataSerializable up until 3.8, therefore
it was not supported by the non-Java clients. So, this PR adds
a test check to skip when the server version is less than that.
Also, the rest-api config element is added to xml config on IMDG
version 3.12. To support older versions, it is replaced by the
property based config.