### PR TITLE
Remove safe buffer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "bluebird": "3.5.4",
-    "long": "3.2.0",
-    "safe-buffer": "5.1.2"
+    "long": "3.2.0"
   },
   "devDependencies": {
     "@types/bluebird": "3.5.21",
@@ -26,6 +25,9 @@
     "tslint": "5.7.0",
     "typescript": "2.5.2",
     "winston": "2.3.1"
+  },
+  "engines": {
+    "node": ">=8"
   },
   "scripts": {
     "clean": "rimraf lib typings *.jar *.log",

--- a/src/BitsUtil.ts
+++ b/src/BitsUtil.ts
@@ -15,8 +15,6 @@
  */
 
 /* tslint:disable:no-bitwise */
-import {Buffer} from 'safe-buffer';
-
 export class BitsUtil {
     static BYTE_SIZE_IN_BYTES: number = 1;
     static BOOLEAN_SIZE_IN_BYTES: number = 1;

--- a/src/ClientMessage.ts
+++ b/src/ClientMessage.ts
@@ -15,7 +15,6 @@
  */
 
 /* tslint:disable:no-bitwise */
-import {Buffer} from 'safe-buffer';
 import {BitsUtil} from './BitsUtil';
 import {ClientConnection} from './network/ClientConnection';
 import {FixSizedTypesCodec} from './codec/builtin/FixSizedTypesCodec';

--- a/src/codec/ClientAuthenticationCustomCodec.ts
+++ b/src/codec/ClientAuthenticationCustomCodec.ts
@@ -21,7 +21,6 @@ import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} 
 import {UUID} from '../core/UUID';
 import {CodecUtil} from './builtin/CodecUtil';
 import {StringCodec} from './builtin/StringCodec';
-import {Buffer} from 'safe-buffer';
 import {ByteArrayCodec} from './builtin/ByteArrayCodec';
 import {ListMultiFrameCodec} from './builtin/ListMultiFrameCodec';
 import {Address} from '../Address';

--- a/src/codec/ClientStatisticsCodec.ts
+++ b/src/codec/ClientStatisticsCodec.ts
@@ -20,7 +20,6 @@ import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
 import {ClientMessage, Frame, PARTITION_ID_OFFSET} from '../ClientMessage';
 import * as Long from 'long';
 import {StringCodec} from './builtin/StringCodec';
-import {Buffer} from 'safe-buffer';
 import {ByteArrayCodec} from './builtin/ByteArrayCodec';
 
 // hex: 0x000C00

--- a/src/codec/builtin/ByteArrayCodec.ts
+++ b/src/codec/builtin/ByteArrayCodec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import {ClientMessage, Frame} from '../../ClientMessage';
 
 export class ByteArrayCodec {

--- a/src/codec/builtin/EntryListIntegerIntegerCodec.ts
+++ b/src/codec/builtin/EntryListIntegerIntegerCodec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import {BitsUtil} from '../../BitsUtil';
 import {ClientMessage, Frame} from '../../ClientMessage';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';

--- a/src/codec/builtin/EntryListIntegerLongCodec.ts
+++ b/src/codec/builtin/EntryListIntegerLongCodec.ts
@@ -16,7 +16,6 @@
 
 import {BitsUtil} from '../../BitsUtil';
 import {ClientMessage, Frame} from '../../ClientMessage';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 import * as Long from 'long';
 

--- a/src/codec/builtin/EntryListIntegerUUIDCodec.ts
+++ b/src/codec/builtin/EntryListIntegerUUIDCodec.ts
@@ -16,7 +16,6 @@
 
 import {BitsUtil} from '../../BitsUtil';
 import {ClientMessage, Frame} from '../../ClientMessage';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 import {UUID} from '../../core/UUID';
 

--- a/src/codec/builtin/EntryListLongByteArrayCodec.ts
+++ b/src/codec/builtin/EntryListLongByteArrayCodec.ts
@@ -16,7 +16,6 @@
 
 import {BEGIN_FRAME, ClientMessage, END_FRAME} from '../../ClientMessage';
 import * as Long from 'long';
-import {Buffer} from 'safe-buffer';
 import {ByteArrayCodec} from './ByteArrayCodec';
 import {ListLongCodec} from './ListLongCodec';
 import {ListMultiFrameCodec} from './ListMultiFrameCodec';

--- a/src/codec/builtin/EntryListUUIDLongCodec.ts
+++ b/src/codec/builtin/EntryListUUIDLongCodec.ts
@@ -18,7 +18,6 @@ import {BitsUtil} from '../../BitsUtil';
 import {ClientMessage, Frame} from '../../ClientMessage';
 import {UUID} from '../../core/UUID';
 import * as Long from 'long';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 
 const ENTRY_SIZE_IN_BYTES = BitsUtil.UUID_SIZE_IN_BYTES + BitsUtil.LONG_SIZE_IN_BYTES;

--- a/src/codec/builtin/EntryListUUIDUUIDCodec.ts
+++ b/src/codec/builtin/EntryListUUIDUUIDCodec.ts
@@ -17,7 +17,6 @@
 import {BitsUtil} from '../../BitsUtil';
 import {ClientMessage, Frame} from '../../ClientMessage';
 import {UUID} from '../../core/UUID';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 
 const ENTRY_SIZE_IN_BYTES = BitsUtil.UUID_SIZE_IN_BYTES + BitsUtil.UUID_SIZE_IN_BYTES;

--- a/src/codec/builtin/FixSizedTypesCodec.ts
+++ b/src/codec/builtin/FixSizedTypesCodec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import * as Long from 'long';
 import {BitsUtil} from '../../BitsUtil';
 import {UUID} from '../../core/UUID';

--- a/src/codec/builtin/ListIntegerCodec.ts
+++ b/src/codec/builtin/ListIntegerCodec.ts
@@ -16,7 +16,6 @@
 
 import {ClientMessage, Frame} from '../../ClientMessage';
 import {BitsUtil} from '../../BitsUtil';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 
 export class ListIntegerCodec {

--- a/src/codec/builtin/ListLongCodec.ts
+++ b/src/codec/builtin/ListLongCodec.ts
@@ -17,7 +17,6 @@
 import {ClientMessage, Frame} from '../../ClientMessage';
 import * as Long from 'long';
 import {BitsUtil} from '../../BitsUtil';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 
 export class ListLongCodec {

--- a/src/codec/builtin/ListUUIDCodec.ts
+++ b/src/codec/builtin/ListUUIDCodec.ts
@@ -17,7 +17,6 @@
 import {ClientMessage, Frame} from '../../ClientMessage';
 import {UUID} from '../../core/UUID';
 import {BitsUtil} from '../../BitsUtil';
-import {Buffer} from 'safe-buffer';
 import {FixSizedTypesCodec} from './FixSizedTypesCodec';
 
 export class ListUUIDCodec {

--- a/src/codec/builtin/StringCodec.ts
+++ b/src/codec/builtin/StringCodec.ts
@@ -15,7 +15,6 @@
  */
 
 import {ClientMessage, Frame} from '../../ClientMessage';
-import {Buffer} from 'safe-buffer';
 
 export class StringCodec {
     static encode(clientMessage: ClientMessage, value: string): void {

--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import * as Promise from 'bluebird';
 import * as net from 'net';
 import {EventEmitter} from 'events';

--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import * as Promise from 'bluebird';
 import {EventEmitter} from 'events';
 import HazelcastClient from '../HazelcastClient';

--- a/src/serialization/Data.ts
+++ b/src/serialization/Data.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import * as Long from 'long';
 
 export interface Data {

--- a/src/serialization/HeapData.ts
+++ b/src/serialization/HeapData.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import murmur = require('../invocation/Murmur');
 import {Data} from './Data';
 

--- a/src/serialization/ObjectData.ts
+++ b/src/serialization/ObjectData.ts
@@ -15,7 +15,6 @@
  */
 
 /* tslint:disable:no-bitwise */
-import {Buffer} from 'safe-buffer';
 import * as assert from 'assert';
 import * as Long from 'long';
 import {BitsUtil} from '../BitsUtil';

--- a/src/serialization/SerializationService.ts
+++ b/src/serialization/SerializationService.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {Buffer} from 'safe-buffer';
 import {AggregatorFactory} from '../aggregation/AggregatorFactory';
 import {ClusterDataFactory} from '../ClusterDataFactory';
 import {ClusterDataFactoryHelper} from '../ClusterDataFactoryHelper';

--- a/src/statistics/Statistics.ts
+++ b/src/statistics/Statistics.ts
@@ -24,7 +24,6 @@ import * as os from 'os';
 import {BuildInfo} from '../BuildInfo';
 import {ILogger} from '../logging/ILogger';
 import * as Long from 'long';
-import {Buffer} from 'safe-buffer';
 
 /**
  * This class is the main entry point for collecting and sending the client

--- a/test/connection/ClientMessageReaderTest.js
+++ b/test/connection/ClientMessageReaderTest.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const expect = require('chai').expect;
 
 const ClientMessageReader = require('../../lib/network/ClientConnection').ClientMessageReader;

--- a/test/connection/DirectWriterTest.js
+++ b/test/connection/DirectWriterTest.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const Socket = require('net').Socket;
 const sinon = require('sinon');
 const expect = require('chai').expect;

--- a/test/connection/FragmentedClientMessageHandlerTest.js
+++ b/test/connection/FragmentedClientMessageHandlerTest.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const expect = require('chai').expect;
 const crypto = require('crypto');
 

--- a/test/connection/PipelinedWriterTest.js
+++ b/test/connection/PipelinedWriterTest.js
@@ -16,7 +16,6 @@
 
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const Socket = require('net').Socket;
 const sinon = require('sinon');
 const expect = require('chai').expect;

--- a/test/rest_value/RestValueTest.js
+++ b/test/rest_value/RestValueTest.js
@@ -24,7 +24,6 @@ const fs = require('fs');
 const http = require('http');
 const querystring = require('querystring');
 const DeferredPromise = require('../../lib/Util').DeferredPromise;
-const Buffer = require('safe-buffer').Buffer;
 
 describe('RestValueTest', function () {
 

--- a/test/serialization/APortable.js
+++ b/test/serialization/APortable.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-var Buffer = require('safe-buffer').Buffer;
-
 function APortable(bool, b, c, d, s, f, i, l, str, p, booleans, bytes, chars, doubles, shorts, floats, ints, longs, strings,
                    portables, identifiedDataSerializable, customStreamSerializableObject, customByteArraySerializableObject, data) {
     if (arguments.length === 0) return;

--- a/test/serialization/AnIdentifiedDataSerializable.js
+++ b/test/serialization/AnIdentifiedDataSerializable.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-var Buffer = require('safe-buffer').Buffer;
-
 function AnIdentifiedDataSerializable(bool, b, c, d, s, f, i, l, str, booleans, bytes, chars, doubles, shorts, floats, ints
     , longs, strings, portable, identifiedDataSerializable, customStreamSerializable, customByteArraySerializableObject, data) {
     if (arguments.length === 0) return;

--- a/test/serialization/BinaryCompatibilityTest.js
+++ b/test/serialization/BinaryCompatibilityTest.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-var Buffer = require('safe-buffer').Buffer;
 var fs = require('fs');
 var ObjectDataInput = require('../../lib/serialization/ObjectData').ObjectDataInput;
 var HeapData = require('../../lib/serialization/HeapData').HeapData;

--- a/test/serialization/ObjectDataTest.js
+++ b/test/serialization/ObjectDataTest.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-var Buffer = require('safe-buffer').Buffer;
 var expect = require('chai').expect;
 var Long = require('long');
 var ObjectData = require('../../lib/serialization/ObjectData');

--- a/test/serialization/ReferenceObjects.js
+++ b/test/serialization/ReferenceObjects.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-var Buffer = require('safe-buffer').Buffer;
 var Long = require('long');
 var AnInnerPortable = require('./AnInnerPortable');
 var AnIdentifiedDataSerializable = require('./AnIdentifiedDataSerializable');

--- a/test/unit/protocol/ClientMessageFramingTest.js
+++ b/test/unit/protocol/ClientMessageFramingTest.js
@@ -18,7 +18,6 @@
 
 const cm = require('../../../lib/ClientMessage');
 const expect = require('chai').expect;
-const Buffer = require('safe-buffer').Buffer;
 const Long = require('long');
 const HeapData = require('../../../lib/serialization/HeapData').HeapData;
 const UUID = require('../../../lib/core/UUID').UUID;

--- a/test/unit/protocol/ClientMessageTest.js
+++ b/test/unit/protocol/ClientMessageTest.js
@@ -18,7 +18,6 @@
 
 const cm = require('../../../lib/ClientMessage');
 const expect = require('chai').expect;
-const Buffer = require('safe-buffer').Buffer;
 const Long = require('long');
 const CodecUtil = require('../../../lib/codec/builtin/CodecUtil').CodecUtil;
 


### PR DESCRIPTION
We are going to pick Node.js 8 as the minimum supported version,
which contains polyfill methods implemented by the safe-buffer.
Hence, there is no need for an extra dependency for these.

Protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/321

fixes #519 