### PR TITLE
Fix ListenerServiceTest

### DIFF
--- a/scripts/dev-test-rc.sh
+++ b/scripts/dev-test-rc.sh
@@ -18,6 +18,15 @@ else
 	ENTERPRISE_REPO=${ENTERPRISE_RELEASE_REPO}
 fi
 
+if [[ ${HZ_TEST_VERSION} == *-SNAPSHOT ]]
+then
+    TEST_REPO=${SNAPSHOT_REPO}
+    ENTRERPRISE_TEST_REPO=${ENTERPRISE_SNAPSHOT_REPO}
+else
+    TEST_REPO=${RELEASE_REPO}
+    ENTRERPRISE_TEST_REPO=${ENTERPRISE_RELEASE_REPO}
+fi
+
 if [ -f "hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar" ]; then
     echo "remote controller already exist, not downloading from maven."
 else
@@ -56,7 +65,7 @@ if [ -n "${HAZELCAST_ENTERPRISE_KEY}" ]; then
         echo "hazelcast-enterprise-tests.jar already exists, not downloading from maven."
     else
         echo "Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
-        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTERPRISE_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
+        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTRERPRISE_TEST_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
         if [ $? -ne 0 ]; then
             echo "Failed to download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
             exit 1
@@ -81,4 +90,3 @@ else
 fi
 
 java -Dhazelcast.enterprise.license.key=${HAZELCAST_ENTERPRISE_KEY} -cp ${CLASSPATH} com.hazelcast.remotecontroller.Main
-

--- a/scripts/dev-test-rc.sh
+++ b/scripts/dev-test-rc.sh
@@ -21,10 +21,10 @@ fi
 if [[ ${HZ_TEST_VERSION} == *-SNAPSHOT ]]
 then
     TEST_REPO=${SNAPSHOT_REPO}
-    ENTRERPRISE_TEST_REPO=${ENTERPRISE_SNAPSHOT_REPO}
+    ENTERPRISE_TEST_REPO=${ENTERPRISE_SNAPSHOT_REPO}
 else
     TEST_REPO=${RELEASE_REPO}
-    ENTRERPRISE_TEST_REPO=${ENTERPRISE_RELEASE_REPO}
+    ENTERPRISE_TEST_REPO=${ENTERPRISE_RELEASE_REPO}
 fi
 
 if [ -f "hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar" ]; then
@@ -65,7 +65,7 @@ if [ -n "${HAZELCAST_ENTERPRISE_KEY}" ]; then
         echo "hazelcast-enterprise-tests.jar already exists, not downloading from maven."
     else
         echo "Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
-        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTRERPRISE_TEST_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
+        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTERPRISE_TEST_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
         if [ $? -ne 0 ]; then
             echo "Failed to download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
             exit 1

--- a/scripts/download-rc.bat
+++ b/scripts/download-rc.bat
@@ -21,10 +21,10 @@ if errorlevel 1 (
 echo %HZ_TEST_VERSION% | findstr /r ".*-SNAPSHOT" >nul 2>&1
 if errorlevel 1 (
 	set TEST_REPO=%RELEASE_REPO%
-    set ENTRERPRISE_TEST_REPO=%ENTERPRISE_RELEASE_REPO%
+    set ENTERPRISE_TEST_REPO=%ENTERPRISE_RELEASE_REPO%
 ) else (
 	set TEST_REPO=%SNAPSHOT_REPO%
-    set ENTRERPRISE_TEST_REPO=%ENTERPRISE_SNAPSHOT_REPO%
+    set ENTERPRISE_TEST_REPO=%ENTERPRISE_SNAPSHOT_REPO%
 )
 
 if exist hazelcast-remote-controller-%HAZELCAST_RC_VERSION%.jar (
@@ -67,7 +67,7 @@ if defined HAZELCAST_ENTERPRISE_KEY (
     	echo hazelcast-enterprise-test.jar already exists, not downloading from maven.
     ) else (
     	echo Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:%HAZELCAST_ENTERPRISE_VERSION%:jar:tests
-    	call mvn -q dependency:get -DrepoUrl=%TEST_REPO% -Dartifact=com.hazelcast:hazelcast-enterprise:%HAZELCAST_TEST_VERSION%:jar:tests -Ddest=hazelcast-enterprise-%HAZELCAST_TEST_VERSION%-tests.jar
+    	call mvn -q dependency:get -DrepoUrl=%ENTERPRISE_TEST_REPO% -Dartifact=com.hazelcast:hazelcast-enterprise:%HAZELCAST_TEST_VERSION%:jar:tests -Ddest=hazelcast-enterprise-%HAZELCAST_TEST_VERSION%-tests.jar
     	if errorlevel 1 (
     		echo Failed download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:%HAZELCAST_TEST_VERSION%:jar:tests
     		exit 1
@@ -95,5 +95,4 @@ start /min "hazelcast-remote-controller" cmd /c "java -Dhazelcast.enterprise.lic
 
 echo wait for Hazelcast to start ...
 ping -n 15 127.0.0.1 > nul
-
 

--- a/scripts/download-rc.sh
+++ b/scripts/download-rc.sh
@@ -69,7 +69,7 @@ if [ -n "${HAZELCAST_ENTERPRISE_KEY}" ]; then
         echo "hazelcast-enterprise-tests.jar already exists, not downloading from maven."
     else
         echo "Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
-        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTERPRISE_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
+        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTRERPRISE_TEST_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
         if [ $? -ne 0 ]; then
             echo "Failed to download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
             exit 1
@@ -96,4 +96,3 @@ fi
 nohup java -Dhazelcast.enterprise.license.key=${HAZELCAST_ENTERPRISE_KEY} -cp ${CLASSPATH}  com.hazelcast.remotecontroller.Main>rc_stdout.log 2>rc_stderr.log &
 
 sleep 10
-

--- a/scripts/download-rc.sh
+++ b/scripts/download-rc.sh
@@ -23,10 +23,10 @@ fi
 if [[ ${HZ_TEST_VERSION} == *-SNAPSHOT ]]
 then
     TEST_REPO=${SNAPSHOT_REPO}
-    ENTRERPRISE_TEST_REPO=${ENTERPRISE_SNAPSHOT_REPO}
+    ENTERPRISE_TEST_REPO=${ENTERPRISE_SNAPSHOT_REPO}
 else
     TEST_REPO=${RELEASE_REPO}
-    ENTRERPRISE_TEST_REPO=${ENTERPRISE_RELEASE_REPO}
+    ENTERPRISE_TEST_REPO=${ENTERPRISE_RELEASE_REPO}
 fi
 
 if [ -f "hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar" ]; then
@@ -69,7 +69,7 @@ if [ -n "${HAZELCAST_ENTERPRISE_KEY}" ]; then
         echo "hazelcast-enterprise-tests.jar already exists, not downloading from maven."
     else
         echo "Downloading: hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
-        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTRERPRISE_TEST_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
+        mvn -q org.apache.maven.plugins:maven-dependency-plugin:2.8:get -DrepoUrl=${ENTERPRISE_TEST_REPO} -Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests -Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar
         if [ $? -ne 0 ]; then
             echo "Failed to download hazelcast enterprise test jar com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests"
             exit 1

--- a/test/ListenerServiceTest.js
+++ b/test/ListenerServiceTest.js
@@ -32,35 +32,37 @@ var Util = require('./Util');
                 return Promise.resolve(cluster.id);
             }).then(function (clusterId) {
                 return RC.startMember(clusterId)
-            }).then(function () {
-                var cfg = new Config.ClientConfig();
-                cfg.networkConfig.smartRouting = isSmartService;
-                return HazelcastClient.newHazelcastClient(cfg);
-            }).then(function (res) {
-                client = res;
             });
         });
 
+        beforeEach(function () {
+            var cfg = new Config.ClientConfig();
+            cfg.networkConfig.smartRouting = isSmartService;
+            return HazelcastClient.newHazelcastClient(cfg).then(function (c) {
+                client = c;
+            });
+        });
+
+        afterEach(function () {
+            return client.shutdown();
+        });
+
         after(function () {
-            client.shutdown();
             return RC.shutdownCluster(cluster.id);
         });
 
         it('listener is invoked when a new object is created', function (done) {
-            var map;
             var listenerId;
             client.addDistributedObjectListener(function (distributedObjectEvent) {
                 expect(distributedObjectEvent.objectName).to.eq('mapToListen');
                 expect(distributedObjectEvent.serviceName).to.eq('hz:impl:mapService');
                 expect(distributedObjectEvent.eventType).to.eq('created');
-                client.removeDistributedObjectListener(listenerId);
-                done();
+                client.removeDistributedObjectListener(listenerId).then(function () {
+                    done();
+                });
             }).then(function (id) {
                 listenerId = id;
-                client.getMap('mapToListen').then(function (mp) {
-                    map = mp;
-                    map.destroy();
-                });
+                client.getMap('mapToListen');
             });
         });
 
@@ -72,8 +74,9 @@ var Util = require('./Util');
                     expect(distributedObjectEvent.objectName).to.eq('mapToRemove');
                     expect(distributedObjectEvent.serviceName).to.eq('hz:impl:mapService');
                     expect(distributedObjectEvent.eventType).to.eq('destroyed');
-                    client.removeDistributedObjectListener(listenerId);
-                    done();
+                    client.removeDistributedObjectListener(listenerId).then(function () {
+                        done();
+                    });
                 } else if (distributedObjectEvent.eventType === 'created' && distributedObjectEvent.objectName === 'mapToRemove') {
                     Util.promiseWaitMilliseconds(1000).then(function () {
                         map.destroy();
@@ -88,11 +91,12 @@ var Util = require('./Util');
         });
 
         it('listener is not invoked when listener was already removed by user', function (done) {
-            this.timeout(3000);
-            client.addDistributedObjectListener(function (distributedObjectEvent) {
-                done('Should not have run!');
+            client.addDistributedObjectListener(function () {
+                done(new Error('Should not have run!'));
             }).then(function (listenerId) {
                 return client.removeDistributedObjectListener(listenerId)
+            }).then(function () {
+                return client.getMap('testMap');
             }).then(function () {
                 setTimeout(done, 1000);
             });


### PR DESCRIPTION
This test fails time to time. I fixed the issue with this test in
master branch. This PR backports the changes done in master to
3.12.x branch.

The problem is the following. In tests, after asserting the
values received from the events, we remove the distributed object
listener and call done(). However, done is called in the next
statment instead of a then block. Because of that, sometimes,
the listeners from the previous test runs stay active in other tests,
and that causes the failures. I believe that we should not use the 
same client for every test. Each of them tests a separate logic. 
Therefore, in this fix I changed the tests so that each of them uses 
a separate client.

Also, updated the scripts with the recent changes from master. There were
small improvments to some internal logic.