### PR TITLE
Update Hazelcast Cloud documentation and code sample

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1384,22 +1384,21 @@ As explained in the [TLS/SSL section](#61-tlsssl), Hazelcast members have key st
 
 ## 5.8. Enabling Hazelcast Cloud Discovery
 
-The purpose of Hazelcast Cloud Discovery is to provide the clients to use IP addresses provided by `hazelcast orchestrator`. To enable Hazelcast Cloud Discovery, specify a token for the `discoveryToken` field and set the `enabled` field to `true`.
-
-The following are example configurations.
+Node.js client can discover and connect to Hazelcast clusters running on [Hazelcast Cloud](https://cloud.hazelcast.com/).
+For this, provide authentication information as `GroupConfig`, enable `CloudConfig` and set your `discoveryToken` as shown below.
 
 **Declarative Configuration:**
 
 ```json
 {
  "group": {
-        "name": "hazel",
-        "password": "cast"
+        "name": "YOUR_CLUSTER_NAME",
+        "password": "YOUR_CLUSTER_PASSWORD"
     },
 
     "network": {
         "hazelcastCloud": {
-            "discoveryToken": "EXAMPLE_TOKEN",
+            "discoveryToken": "YOUR_CLUSTER_DISCOVERY_TOKEN",
             "enabled": true
         }
     }
@@ -1411,14 +1410,15 @@ The following are example configurations.
 
 ```javascript
 var clientConfig = new Config.ClientConfig();
-clientConfig.groupConfig.name = 'hazel';
-clientConfig.groupConfig.password = 'cast';
+clientConfig.groupConfig.name = 'YOUR_CLUSTER_NAME';
+clientConfig.groupConfig.password = 'YOUR_CLUSTER_PASSWORD';
 
 clientConfig.networkConfig.cloudConfig.enabled = true;
-clientConfig.networkConfig.cloudConfig.discoveryToken = 'EXAMPLE_TOKEN';
+clientConfig.networkConfig.cloudConfig.discoveryToken = 'YOUR_CLUSTER_DISCOVERY_TOKEN';
 ```
 
-To be able to connect to the provided IP addresses, you should use secure TLS/SSL connection between the client and members. Therefore, you should set an SSL configuration as described in the previous section.
+If you have enabled encryption for your cluster, you should also enable TLS/SSL configuration to secure communication between your 
+client and cluster members as described in the [TLS/SSL for Hazelcast Node.js Client section](#612-tlsssl-for-hazelcast-nodejs-clients).
 
 # 6. Securing Client Connection
 

--- a/code_samples/hazelcast_cloud_discovery.js
+++ b/code_samples/hazelcast_cloud_discovery.js
@@ -19,25 +19,29 @@ var ClientConfig = require('hazelcast-client').Config.ClientConfig;
 var fs = require('fs');
 var Path = require('path');
 
-
 function createClientConfigWithSSLOpts(key, cert, ca) {
-    var sslOpts = {
-        servername: 'Hazelcast-Inc',
+    var cfg = new ClientConfig();
+
+    // Set up group name and password for authentication
+    cfg.groupConfig.name = 'YOUR_CLUSTER_NAME';
+    cfg.groupConfig.password = 'YOUR_CLUSTER_PASSWORD';
+
+    // Enable Hazelcast Cloud configuration and set the token of your cluster.
+    cfg.networkConfig.cloudConfig.enabled = true;
+    cfg.networkConfig.cloudConfig.discoveryToken = 'YOUR_CLUSTER_DISCOVERY_TOKEN';
+
+    // If you have enabled encryption for your cluster, also configure TLS/SSL for the client.
+    // Otherwise, skip this step.
+    cfg.networkConfig.sslConfig.enabled = true;
+    cfg.networkConfig.sslConfig.sslOptions = {
+        servername: 'hazelcast.cloud',
         rejectUnauthorized: true,
         ca: fs.readFileSync(Path.join(__dirname, ca)),
         key: fs.readFileSync(Path.join(__dirname, key)),
-        cert: fs.readFileSync(Path.join(__dirname, cert))
+        cert: fs.readFileSync(Path.join(__dirname, cert)),
+        passphrase: 'YOUR_KEY_STORE_PASSWORD'
     };
-    var cfg = new ClientConfig();
-    cfg.networkConfig.sslOptions = sslOpts;
-    cfg.networkConfig.connectionAttemptLimit = 1000;
 
-    var token = 'EXAMPLE_TOKEN';
-
-    cfg.networkConfig.cloudConfig.enabled = true;
-    cfg.networkConfig.cloudConfig.discoveryToken = token;
-    cfg.groupConfig.name = 'hazel';
-    cfg.groupConfig.password = 'cast';
     return cfg;
 }
 


### PR DESCRIPTION
We didn't updated Hazelcast Cloud section since we have implemented
it. Right now, Hazelcast Cloud does not use secure communication
by default. One have to enable encryption before starting the cluster
to use secure communication. Also, the code sample we have provided
was not working correctly. 
- `sslConfig` should be enabled first
- `sslOptions` should be under `sslConfig` not `networkConfig`
- `servername` should be `hazelcast.cloud`

This code sample is tested with the Hazelcast Cloud.

I will not send a forward port to master branch since we cannot use 4.0 with cloud yet. I will create an issue to track this. We should update documentation and code sample in the master branch according to changes will be done for the cloud 4.0