### PR TITLE
Add Buffer type support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -553,18 +553,22 @@ In the following chapters you will learn the description of all options supporte
 
 Serialization is the process of converting an object into a stream of bytes to store the object in the memory, a file or database, or transmit it through the network. Its main purpose is to save the state of an object in order to be able to recreate it when needed. The reverse process is called deserialization. Hazelcast offers you its own native serialization methods. You will see these methods throughout this chapter.
 
-Hazelcast serializes all your objects before sending them to the server. The `boolean`, `number`,`string` and `Long` types are serialized natively and you cannot override this behavior. The following table is the conversion of types for the Java server side.
+Hazelcast serializes all your objects before sending them to the server. Certain types, like `boolean`, `number`, `string`, and `Long`, are serialized natively and you cannot override this behavior. The following table is the conversion of types for the Java server side.
 
-| Node.js | Java                                |
-|---------|-------------------------------------|
-| boolean | Boolean                             |
-| number  | Byte, Short, Integer, Float, Double |
-| string  | String                              |
-| Long    | Long                                |
+| Node.js         | Java                                  |
+|-----------------|---------------------------------------|
+| boolean         | Boolean                               |
+| number          | Byte, Short, Integer, Float, Double   |
+| string          | String                                |
+| Long            | Long                                  |
+| Buffer          | byte[]                                |
+| Object          | com.hazelcast.core.HazelcastJsonValue |
 
-> **NOTE: A `number` type is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option.**
+> **NOTE: The `Long` type means the type provided by [long.js library](https://github.com/dcodeIO/long.js).**
 
-Arrays of the above types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `long[]` and `string[]` for the Java server side, respectively.
+> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option.**
+
+Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 
 **Serialization Priority**
 

--- a/src/serialization/Data.ts
+++ b/src/serialization/Data.ts
@@ -91,8 +91,6 @@ export interface DataOutput {
 
     writeByteArray(bytes: Buffer): void;
 
-    writeBytes(bytes: string): void;
-
     writeChar(char: string): void;
 
     writeCharArray(chars: string[]): void;
@@ -218,5 +216,7 @@ export interface DataInput {
     reset(): void;
 
     skipBytes(count: number): void;
+
+    available(): number;
 
 }

--- a/src/serialization/Data.ts
+++ b/src/serialization/Data.ts
@@ -89,7 +89,7 @@ export interface DataOutput {
 
     writeByte(byte: number): void;
 
-    writeByteArray(bytes: number[]): void;
+    writeByteArray(bytes: Buffer): void;
 
     writeBytes(bytes: string): void;
 
@@ -176,7 +176,7 @@ export interface DataInput {
 
     readByte(pos?: number): number;
 
-    readByteArray(pos?: number): number[];
+    readByteArray(pos?: number): Buffer;
 
     readChar(pos?: number): string;
 

--- a/src/serialization/ObjectData.ts
+++ b/src/serialization/ObjectData.ts
@@ -349,6 +349,9 @@ export class ObjectDataInput implements DataInput {
         }
         const len = this.readInt();
         if (len === BitsUtil.NULL_ARRAY_LENGTH) {
+            if (pos !== undefined) {
+                this.pos = backupPos;
+            }
             return null;
         }
         const buf = this.buffer.slice(this.pos, this.pos + len);
@@ -526,6 +529,9 @@ export class ObjectDataInput implements DataInput {
         }
         const len = this.readInt();
         if (len === BitsUtil.NULL_ARRAY_LENGTH) {
+            if (pos !== undefined) {
+                this.pos = backupPos;
+            }
             return null;
         }
         const arr: T[] = [];

--- a/src/serialization/Portable.ts
+++ b/src/serialization/Portable.ts
@@ -68,7 +68,7 @@ export interface PortableWriter {
 
     writeNullPortable(fieldName: string, factoryId: number, classId: number): void;
 
-    writeByteArray(fieldName: string, bytes: number[]): void;
+    writeByteArray(fieldName: string, bytes: Buffer): void;
 
     writeBooleanArray(fieldName: string, booleans: boolean[]): void;
 
@@ -121,7 +121,7 @@ export interface PortableReader {
 
     readPortable(fieldName: string): Portable;
 
-    readByteArray(fieldName: string): number[];
+    readByteArray(fieldName: string): Buffer;
 
     readBooleanArray(fieldName: string): boolean[];
 

--- a/src/serialization/SerializationService.ts
+++ b/src/serialization/SerializationService.ts
@@ -320,6 +320,8 @@ export class SerializationServiceV1 implements SerializationService {
         let convertedName: string;
         if (name === 'number') {
             convertedName = this.serializationConfig.defaultNumberType;
+        } else if (name === 'buffer') {
+            convertedName = 'byteArray';
         } else {
             convertedName = name;
         }

--- a/src/serialization/portable/ClassDefinitionWriter.ts
+++ b/src/serialization/portable/ClassDefinitionWriter.ts
@@ -24,6 +24,7 @@ import {HazelcastSerializationError} from '../../core';
 
 /** @internal */
 export class ClassDefinitionWriter implements PortableWriter {
+
     private context: PortableContext;
     private builder: ClassDefinitionBuilder;
 
@@ -88,7 +89,7 @@ export class ClassDefinitionWriter implements PortableWriter {
         this.builder.addPortableField(fieldName, nestedClassDef);
     }
 
-    writeByteArray(fieldName: string, bytes: number[]): void {
+    writeByteArray(fieldName: string, bytes: Buffer): void {
         this.builder.addByteArrayField(fieldName);
     }
 

--- a/src/serialization/portable/DefaultPortableReader.ts
+++ b/src/serialization/portable/DefaultPortableReader.ts
@@ -34,7 +34,9 @@ export class DefaultPortableReader implements PortableReader {
     private finalPos: number;
     private raw = false;
 
-    constructor(serializer: PortableSerializer, input: DataInput, classDefinition: ClassDefinition) {
+    constructor(serializer: PortableSerializer,
+                input: DataInput,
+                classDefinition: ClassDefinition) {
         this.serializer = serializer;
         this.input = input;
         this.classDefinition = classDefinition;
@@ -120,7 +122,7 @@ export class DefaultPortableReader implements PortableReader {
         }
     }
 
-    readByteArray(fieldName: string): number[] {
+    readByteArray(fieldName: string): Buffer {
         const pos = this.positionByField(fieldName, FieldType.BYTE_ARRAY);
         return this.input.readByteArray(pos);
     }

--- a/src/serialization/portable/DefaultPortableWriter.ts
+++ b/src/serialization/portable/DefaultPortableWriter.ts
@@ -24,6 +24,7 @@ import * as Long from 'long';
 
 /** @internal */
 export class DefaultPortableWriter {
+
     private serializer: PortableSerializer;
     private output: PositionalDataOutput;
     private classDefinition: ClassDefinition;
@@ -31,7 +32,9 @@ export class DefaultPortableWriter {
     private offset: number;
     private begin: number;
 
-    constructor(serializer: PortableSerializer, output: PositionalDataOutput, classDefinition: ClassDefinition) {
+    constructor(serializer: PortableSerializer,
+                output: PositionalDataOutput,
+                classDefinition: ClassDefinition) {
         this.serializer = serializer;
         this.output = output;
         this.classDefinition = classDefinition;
@@ -108,7 +111,7 @@ export class DefaultPortableWriter {
         this.output.writeInt(classId);
     }
 
-    writeByteArray(fieldName: string, bytes: number[]): void {
+    writeByteArray(fieldName: string, bytes: Buffer): void {
         this.setPosition(fieldName, FieldType.BYTE_ARRAY);
         this.output.writeByteArray(bytes);
     }

--- a/src/serialization/portable/DefaultPortableWriter.ts
+++ b/src/serialization/portable/DefaultPortableWriter.ts
@@ -188,7 +188,7 @@ export class DefaultPortableWriter {
         const index: number = field.getIndex();
         this.output.pwriteInt(this.offset + index * BitsUtil.INT_SIZE_IN_BYTES, pos);
         this.output.writeShort(fieldName.length);
-        this.output.writeBytes(fieldName);
+        this.output.write(Buffer.from(fieldName));
         this.output.writeByte(fieldType);
         return field;
     }

--- a/src/serialization/portable/MorphingPortableReader.ts
+++ b/src/serialization/portable/MorphingPortableReader.ts
@@ -24,7 +24,10 @@ import * as Long from 'long';
 
 /** @internal */
 export class MorphingPortableReader extends DefaultPortableReader {
-    constructor(portableSerializer: PortableSerializer, input: DataInput, classDefinition: ClassDefinition) {
+
+    constructor(portableSerializer: PortableSerializer,
+                input: DataInput,
+                classDefinition: ClassDefinition) {
         super(portableSerializer, input, classDefinition);
     }
 
@@ -165,7 +168,7 @@ export class MorphingPortableReader extends DefaultPortableReader {
         return this.validateCompatibleAndCall(fieldName, FieldType.BOOLEAN_ARRAY, super.readBooleanArray);
     }
 
-    readByteArray(fieldName: string): number[] {
+    readByteArray(fieldName: string): Buffer {
         return this.validateCompatibleAndCall(fieldName, FieldType.BYTE_ARRAY, super.readByteArray);
     }
 

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -58,6 +58,8 @@ export function getType(obj: any): string {
     assertNotNull(obj);
     if (Long.isLong(obj)) {
         return 'long';
+    } if (Buffer.isBuffer(obj)) {
+        return 'buffer';
     } else {
         const t = typeof obj;
         if (t !== 'object') {

--- a/test/serialization/APortable.js
+++ b/test/serialization/APortable.js
@@ -13,144 +13,146 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+'use strict';
 
-function APortable(bool, b, c, d, s, f, i, l, str, p, booleans, bytes, chars,
-                   doubles, shorts, floats, ints, longs, strings, portables,
-                   identifiedDataSerializable, customStreamSerializableObject,
-                   customByteArraySerializableObject, data) {
-    if (arguments.length === 0) return;
-    this.bool = bool;
-    this.b = b;
-    this.c = c;
-    this.d = d;
-    this.s = s;
-    this.f = f;
-    this.i = i;
-    this.l = l;
-    this.str = str;
-    this.p = p;
+class APortable {
 
-    this.booleans = booleans;
-    this.bytes = bytes;
-    this.chars = chars;
-    this.doubles = doubles;
-    this.shorts = shorts;
-    this.floats = floats;
-    this.ints = ints;
-    this.longs = longs;
-    this.strings = strings;
-    this.portables = portables;
+    constructor(bool, b, c, d, s, f, i, l, str, p, booleans, bytes, chars,
+                doubles, shorts, floats, ints, longs, strings, portables,
+                identifiedDataSerializable, customStreamSerializableObject,
+                customByteArraySerializableObject, data) {
+        if (arguments.length === 0) return;
+        this.bool = bool;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+        this.s = s;
+        this.f = f;
+        this.i = i;
+        this.l = l;
+        this.str = str;
+        this.p = p;
 
-    this.byteSize = bytes.length;
-    this.bytesFully = bytes;
-    this.bytesOffset = bytes.slice(1, 3);
-    this.strChars = str.split('');
-    this.strBytes = Buffer.alloc(this.str.length);
-    for (let i = 0; i < str.length; i++) {
-        this.strBytes[i] = this.strChars[i].charCodeAt(0);
+        this.booleans = booleans;
+        this.bytes = bytes;
+        this.chars = chars;
+        this.doubles = doubles;
+        this.shorts = shorts;
+        this.floats = floats;
+        this.ints = ints;
+        this.longs = longs;
+        this.strings = strings;
+        this.portables = portables;
+
+        this.byteSize = bytes.length;
+        this.bytesFully = bytes;
+        this.bytesOffset = bytes.slice(1, 3);
+        this.strChars = str.split('');
+        this.strBytes = Buffer.alloc(this.str.length);
+        for (let i = 0; i < str.length; i++) {
+            this.strBytes[i] = this.strChars[i].charCodeAt(0);
+        }
+
+        this.identifiedDataSerializableObject = identifiedDataSerializable;
+        this.portableObject = p;
+        this.customStreamSerializableObject = customStreamSerializableObject;
+        this.customByteArraySerializableObject = customByteArraySerializableObject;
+
+        this.data = data;
+
+        this.factoryId = 1;
+        this.classId = 1;
     }
 
-    this.identifiedDataSerializableObject = identifiedDataSerializable;
-    this.portableObject = p;
-    this.customStreamSerializableObject = customStreamSerializableObject;
-    this.customByteArraySerializableObject = customByteArraySerializableObject;
+    readPortable(reader) {
+        this.bool = reader.readBoolean('bool');
+        this.b = reader.readByte('b');
+        this.c = reader.readChar('c');
+        this.d = reader.readDouble('d');
+        this.s = reader.readShort('s');
+        this.f = reader.readFloat('f');
+        this.i = reader.readInt('i');
+        this.l = reader.readLong('l');
+        this.str = reader.readUTF('str');
+        this.p = reader.readPortable('p');
 
-    this.data = data;
+        this.booleans = reader.readBooleanArray('booleans');
+        this.bytes = reader.readByteArray('bs');
+        this.chars = reader.readCharArray('cs');
+        this.doubles = reader.readDoubleArray('ds');
+        this.shorts = reader.readShortArray('ss');
+        this.floats = reader.readFloatArray('fs');
+        this.ints = reader.readIntArray('is');
+        this.longs = reader.readLongArray('ls');
+        this.strings = reader.readUTFArray('strs');
+        this.portables = reader.readPortableArray('ps');
 
-    this.factoryId = 1;
-    this.classId = 1;
+        this.booleansNull = reader.readBooleanArray('booleansNull');
+        this.bytesNull = reader.readByteArray('bsNull');
+        this.charsNull = reader.readCharArray('csNull');
+        this.doublesNull = reader.readDoubleArray('dsNull');
+        this.shortsNull = reader.readShortArray('ssNull');
+        this.floatsNull = reader.readFloatArray('fsNull');
+        this.intsNull = reader.readIntArray('isNull');
+        this.longsNull = reader.readLongArray('lsNull');
+        this.stringsNull = reader.readUTFArray('strsNull');
+
+        const dataInput = reader.getRawDataInput();
+
+        this.bool = dataInput.readBoolean();
+        this.b = dataInput.readByte();
+        this.c = dataInput.readChar();
+        this.d = dataInput.readDouble();
+        this.s = dataInput.readShort();
+        this.f = dataInput.readFloat();
+        this.i = dataInput.readInt();
+        this.l = dataInput.readLong();
+        this.str = dataInput.readUTF();
+
+        this.booleans = dataInput.readBooleanArray();
+        this.bytes = dataInput.readByteArray();
+        this.chars = dataInput.readCharArray();
+        this.doubles = dataInput.readDoubleArray();
+        this.shorts = dataInput.readShortArray();
+        this.floats = dataInput.readFloatArray();
+        this.ints = dataInput.readIntArray();
+        this.longs = dataInput.readLongArray();
+        this.strings = dataInput.readUTFArray();
+
+        this.booleansNull = dataInput.readBooleanArray();
+        this.bytesNull = dataInput.readByteArray();
+        this.charsNull = dataInput.readCharArray();
+        this.doublesNull = dataInput.readDoubleArray();
+        this.shortsNull = dataInput.readShortArray();
+        this.floatsNull = dataInput.readFloatArray();
+        this.intsNull = dataInput.readIntArray();
+        this.longsNull = dataInput.readLongArray();
+        this.stringsNull = dataInput.readUTFArray();
+
+        this.byteSize = dataInput.readByte();
+        this.bytesFully = dataInput.readRaw(this.byteSize);
+        this.bytesOffset = dataInput.readRaw(2);
+        const strSize = dataInput.readInt();
+        this.strChars = Buffer.alloc(strSize);
+        for (let j = 0; j < strSize; j++) {
+            this.strChars[j] = dataInput.readChar();
+        }
+        this.strBytes = dataInput.readRaw(strSize);
+        this.unsignedByte = dataInput.readUnsignedByte();
+        this.unsignedShort = dataInput.readUnsignedShort();
+
+        this.portableObject = dataInput.readObject();
+        this.identifiedDataSerializableObject = dataInput.readObject();
+        this.customByteArraySerializableObject = dataInput.readObject();
+        this.customStreamSerializableObject = dataInput.readObject();
+
+        this.data = dataInput.readData();
+    }
+
+    writeData(writer) {
+        // no-op
+    }
+
 }
-
-APortable.prototype.readPortable = function (reader) {
-    this.bool = reader.readBoolean("bool");
-    this.b = reader.readByte("b");
-    this.c = reader.readChar("c");
-    this.d = reader.readDouble("d");
-    this.s = reader.readShort("s");
-    this.f = reader.readFloat("f");
-    this.i = reader.readInt("i");
-    this.l = reader.readLong("l");
-    this.str = reader.readUTF("str");
-    this.p = reader.readPortable("p");
-
-    this.booleans = reader.readBooleanArray("booleans");
-    this.bytes = reader.readByteArray("bs");
-    this.chars = reader.readCharArray("cs");
-    this.doubles = reader.readDoubleArray("ds");
-    this.shorts = reader.readShortArray("ss");
-    this.floats = reader.readFloatArray("fs");
-    this.ints = reader.readIntArray("is");
-    this.longs = reader.readLongArray("ls");
-    this.strings = reader.readUTFArray("strs");
-    this.portables = reader.readPortableArray("ps");
-
-    this.booleansNull = reader.readBooleanArray("booleansNull");
-    this.bytesNull = reader.readByteArray("bsNull");
-    this.charsNull = reader.readCharArray("csNull");
-    this.doublesNull = reader.readDoubleArray("dsNull");
-    this.shortsNull = reader.readShortArray("ssNull");
-    this.floatsNull = reader.readFloatArray("fsNull");
-    this.intsNull = reader.readIntArray("isNull");
-    this.longsNull = reader.readLongArray("lsNull");
-    this.stringsNull = reader.readUTFArray("strsNull");
-
-    const dataInput = reader.getRawDataInput();
-
-    this.bool = dataInput.readBoolean();
-    this.b = dataInput.readByte();
-    this.c = dataInput.readChar();
-    this.d = dataInput.readDouble();
-    this.s = dataInput.readShort();
-    this.f = dataInput.readFloat();
-    this.i = dataInput.readInt();
-    this.l = dataInput.readLong();
-    this.str = dataInput.readUTF();
-
-    this.booleans = dataInput.readBooleanArray();
-    this.bytes = dataInput.readByteArray();
-    this.chars = dataInput.readCharArray();
-    this.doubles = dataInput.readDoubleArray();
-    this.shorts = dataInput.readShortArray();
-    this.floats = dataInput.readFloatArray();
-    this.ints = dataInput.readIntArray();
-    this.longs = dataInput.readLongArray();
-    this.strings = dataInput.readUTFArray();
-
-    this.booleansNull = dataInput.readBooleanArray();
-    this.bytesNull = dataInput.readByteArray();
-    this.charsNull = dataInput.readCharArray();
-    this.doublesNull = dataInput.readDoubleArray();
-    this.shortsNull = dataInput.readShortArray();
-    this.floatsNull = dataInput.readFloatArray();
-    this.intsNull = dataInput.readIntArray();
-    this.longsNull = dataInput.readLongArray();
-    this.stringsNull = dataInput.readUTFArray();
-
-    this.byteSize = dataInput.readByte();
-    this.bytesFully = Buffer.alloc(this.byteSize);
-    dataInput.readCopy(this.bytesFully, this.byteSize);
-    this.bytesOffset = Buffer.alloc(2);
-    dataInput.readCopy(this.bytesOffset, 2);
-    const strSize = dataInput.readInt();
-    this.strChars = Buffer.alloc(strSize);
-    for (let j = 0; j < strSize; j++) {
-        this.strChars[j] = dataInput.readChar();
-    }
-    this.strBytes = Buffer.alloc(strSize);
-    dataInput.readCopy(this.strBytes, strSize);
-    this.unsignedByte = dataInput.readUnsignedByte();
-    this.unsignedShort = dataInput.readUnsignedShort();
-
-    this.portableObject = dataInput.readObject();
-    this.identifiedDataSerializableObject = dataInput.readObject();
-    this.customByteArraySerializableObject = dataInput.readObject();
-    this.customStreamSerializableObject = dataInput.readObject();
-
-    this.data = dataInput.readData();
-};
-
-APortable.prototype.writeData = function (writer) {
-    // no-op
-};
 
 module.exports = APortable;

--- a/test/serialization/AnIdentifiedDataSerializable.js
+++ b/test/serialization/AnIdentifiedDataSerializable.js
@@ -15,153 +15,154 @@
  */
 'use strict';
 
-function AnIdentifiedDataSerializable(bool, b, c, d, s, f, i, l, str, booleans, bytes, chars,
-                                      doubles, shorts, floats, ints, longs, strings, portable,
-                                      identifiedDataSerializable, customStreamSerializable,
-                                      customByteArraySerializableObject, data) {
-    if (arguments.length === 0) return;
-    this.bool = bool;
-    this.b = b;
-    this.c = c;
-    this.d = d;
-    this.s = s;
-    this.f = f;
-    this.i = i;
-    this.l = l;
-    this.str = str;
+class AnIdentifiedDataSerializable {
 
-    this.booleans = booleans;
-    this.bytes = bytes;
-    this.chars = chars;
-    this.doubles = doubles;
-    this.shorts = shorts;
-    this.floats = floats;
-    this.ints = ints;
-    this.longs = longs;
-    this.strings = strings;
+    constructor(bool, b, c, d, s, f, i, l, str, booleans, bytes, chars,
+                doubles, shorts, floats, ints, longs, strings, portable,
+                identifiedDataSerializable, customStreamSerializable,
+                customByteArraySerializableObject, data) {
+        if (arguments.length === 0) return;
+        this.bool = bool;
+        this.b = b;
+        this.c = c;
+        this.d = d;
+        this.s = s;
+        this.f = f;
+        this.i = i;
+        this.l = l;
+        this.str = str;
 
-    this.byteSize = bytes.length;
-    this.bytesFully = bytes;
-    this.bytesOffset = bytes.slice(1, 3);
-    this.strChars = str.split('');
-    this.strBytes = Buffer.alloc(this.str.length);
-    for (let i = 0; i < str.length; i++) {
-        this.strBytes[i] = this.strChars[i].charCodeAt(0);
+        this.booleans = booleans;
+        this.bytes = bytes;
+        this.chars = chars;
+        this.doubles = doubles;
+        this.shorts = shorts;
+        this.floats = floats;
+        this.ints = ints;
+        this.longs = longs;
+        this.strings = strings;
+
+        this.byteSize = bytes.length;
+        this.bytesFully = bytes;
+        this.bytesOffset = bytes.slice(1, 3);
+        this.strChars = str.split('');
+        this.strBytes = Buffer.alloc(this.str.length);
+        for (let i = 0; i < str.length; i++) {
+            this.strBytes[i] = this.strChars[i].charCodeAt(0);
+        }
+        this.unsignedByte = 137;
+        this.unsignedShort = 32867;
+        this.portableObject = portable;
+        this.identifiedDataSerializableObject = identifiedDataSerializable;
+        this.customStreamSerializableObject = customStreamSerializable;
+        this.customByteArraySerializableObject = customByteArraySerializableObject;
+        this.data = data;
+
+        this.factoryId = 1;
+        this.classId = 1;
     }
-    this.unsignedByte = 137;
-    this.unsignedShort = 32867;
-    this.portableObject = portable;
-    this.identifiedDataSerializableObject = identifiedDataSerializable;
-    this.customStreamSerializableObject = customStreamSerializable;
-    this.customByteArraySerializableObject = customByteArraySerializableObject;
-    this.data = data;
 
-    this.factoryId = 1;
-    this.classId = 1;
+    readData(dataInput) {
+        this.bool = dataInput.readBoolean();
+        this.b = dataInput.readByte();
+        this.c = dataInput.readChar();
+        this.d = dataInput.readDouble();
+        this.s = dataInput.readShort();
+        this.f = dataInput.readFloat();
+        this.i = dataInput.readInt();
+        this.l = dataInput.readLong();
+        this.str = dataInput.readUTF();
+
+        this.booleans = dataInput.readBooleanArray();
+        this.bytes = dataInput.readByteArray();
+        this.chars = dataInput.readCharArray();
+        this.doubles = dataInput.readDoubleArray();
+        this.shorts = dataInput.readShortArray();
+        this.floats = dataInput.readFloatArray();
+        this.ints = dataInput.readIntArray();
+        this.longs = dataInput.readLongArray();
+        this.strings = dataInput.readUTFArray();
+
+        this.booleansNull = dataInput.readBooleanArray();
+        this.bytesNull = dataInput.readByteArray();
+        this.charsNull = dataInput.readCharArray();
+        this.doublesNull = dataInput.readDoubleArray();
+        this.shortsNull = dataInput.readShortArray();
+        this.floatsNull = dataInput.readFloatArray();
+        this.intsNull = dataInput.readIntArray();
+        this.longsNull = dataInput.readLongArray();
+        this.stringsNull = dataInput.readUTFArray();
+
+        this.byteSize = dataInput.readByte();
+        this.bytesFully = dataInput.readRaw(this.byteSize);
+        this.bytesOffset = dataInput.readRaw(2);
+        this.strSize = dataInput.readInt();
+        this.strChars = [];
+        for (let j = 0; j < this.strSize; j++) {
+            this.strChars[j] = dataInput.readChar();
+        }
+        this.strBytes = dataInput.readRaw(this.strSize);
+        this.unsignedByte = dataInput.readUnsignedByte();
+        this.unsignedShort = dataInput.readUnsignedShort();
+
+        this.portableObject = dataInput.readObject();
+        this.identifiedDataSerializableObject = dataInput.readObject();
+        this.customByteArraySerializableObject = dataInput.readObject();
+        this.customStreamSerializableObject = dataInput.readObject();
+
+        this.data = dataInput.readData();
+    }
+
+    writeData(dataOutput) {
+        dataOutput.writeBoolean(this.bool);
+        dataOutput.writeByte(this.b);
+        dataOutput.writeChar(this.c);
+        dataOutput.writeDouble(this.d);
+        dataOutput.writeShort(this.s);
+        dataOutput.writeFloat(this.f);
+        dataOutput.writeInt(this.i);
+        dataOutput.writeLong(this.l);
+        dataOutput.writeUTF(this.str);
+
+        dataOutput.writeBooleanArray(this.booleans);
+        dataOutput.writeByteArray(this.bytes);
+        dataOutput.writeCharArray(this.chars);
+        dataOutput.writeDoubleArray(this.doubles);
+        dataOutput.writeShortArray(this.shorts);
+        dataOutput.writeFloatArray(this.floats);
+        dataOutput.writeIntArray(this.ints);
+        dataOutput.writeLongArray(this.longs);
+        dataOutput.writeUTFArray(this.strings);
+
+        dataOutput.writeBooleanArray(this.booleansNull);
+        dataOutput.writeByteArray(this.bytesNull);
+        dataOutput.writeCharArray(this.charsNull);
+        dataOutput.writeDoubleArray(this.doublesNull);
+        dataOutput.writeShortArray(this.shortsNull);
+        dataOutput.writeFloatArray(this.floatsNull);
+        dataOutput.writeIntArray(this.intsNull);
+        dataOutput.writeLongArray(this.longsNull);
+        dataOutput.writeUTFArray(this.stringsNull);
+
+        const byteSize = this.bytes.length;
+        dataOutput.write(byteSize);
+        dataOutput.write(this.bytes);
+        dataOutput.write(this.bytes[1]);
+        dataOutput.write(this.bytes[2]);
+        dataOutput.writeInt(this.str.length);
+        dataOutput.writeChars(this.str);
+        dataOutput.writeBytes(this.str);
+        dataOutput.writeByte(this.unsignedByte);
+        dataOutput.writeShort(this.unsignedShort);
+
+        dataOutput.writeObject(this.portableObject);
+        dataOutput.writeObject(this.identifiedDataSerializableObject);
+        dataOutput.writeObject(this.customByteArraySerializableObject);
+        dataOutput.writeObject(this.customStreamSerializableObject);
+
+        dataOutput.writeData(this.data);
+    }
+
 }
-
-AnIdentifiedDataSerializable.prototype.readData = function (dataInput) {
-    this.bool = dataInput.readBoolean();
-    this.b = dataInput.readByte();
-    this.c = dataInput.readChar();
-    this.d = dataInput.readDouble();
-    this.s = dataInput.readShort();
-    this.f = dataInput.readFloat();
-    this.i = dataInput.readInt();
-    this.l = dataInput.readLong();
-    this.str = dataInput.readUTF();
-
-    this.booleans = dataInput.readBooleanArray();
-    this.bytes = dataInput.readByteArray();
-    this.chars = dataInput.readCharArray();
-    this.doubles = dataInput.readDoubleArray();
-    this.shorts = dataInput.readShortArray();
-    this.floats = dataInput.readFloatArray();
-    this.ints = dataInput.readIntArray();
-    this.longs = dataInput.readLongArray();
-    this.strings = dataInput.readUTFArray();
-
-    this.booleansNull = dataInput.readBooleanArray();
-    this.bytesNull = dataInput.readByteArray();
-    this.charsNull = dataInput.readCharArray();
-    this.doublesNull = dataInput.readDoubleArray();
-    this.shortsNull = dataInput.readShortArray();
-    this.floatsNull = dataInput.readFloatArray();
-    this.intsNull = dataInput.readIntArray();
-    this.longsNull = dataInput.readLongArray();
-    this.stringsNull = dataInput.readUTFArray();
-
-    this.byteSize = dataInput.readByte();
-    this.bytesFully = Buffer.alloc(this.byteSize);
-    dataInput.readCopy(this.bytesFully, this.byteSize);
-    this.bytesOffset = Buffer.alloc(2);
-    dataInput.readCopy(this.bytesOffset, 2);
-    this.strSize = dataInput.readInt();
-    this.strChars = [];
-    for (let j = 0; j < this.strSize; j++) {
-        this.strChars[j] = dataInput.readChar();
-    }
-    this.strBytes = Buffer.alloc(this.strSize);
-    dataInput.readCopy(this.strBytes, this.strSize);
-    this.unsignedByte = dataInput.readUnsignedByte();
-    this.unsignedShort = dataInput.readUnsignedShort();
-
-    this.portableObject = dataInput.readObject();
-    this.identifiedDataSerializableObject = dataInput.readObject();
-    this.customByteArraySerializableObject = dataInput.readObject();
-    this.customStreamSerializableObject = dataInput.readObject();
-
-    this.data = dataInput.readData();
-};
-
-AnIdentifiedDataSerializable.prototype.writeData = function (dataOutput) {
-    dataOutput.writeBoolean(this.bool);
-    dataOutput.writeByte(this.b);
-    dataOutput.writeChar(this.c);
-    dataOutput.writeDouble(this.d);
-    dataOutput.writeShort(this.s);
-    dataOutput.writeFloat(this.f);
-    dataOutput.writeInt(this.i);
-    dataOutput.writeLong(this.l);
-    dataOutput.writeUTF(this.str);
-
-    dataOutput.writeBooleanArray(this.booleans);
-    dataOutput.writeByteArray(this.bytes);
-    dataOutput.writeCharArray(this.chars);
-    dataOutput.writeDoubleArray(this.doubles);
-    dataOutput.writeShortArray(this.shorts);
-    dataOutput.writeFloatArray(this.floats);
-    dataOutput.writeIntArray(this.ints);
-    dataOutput.writeLongArray(this.longs);
-    dataOutput.writeUTFArray(this.strings);
-
-    dataOutput.writeBooleanArray(this.booleansNull);
-    dataOutput.writeByteArray(this.bytesNull);
-    dataOutput.writeCharArray(this.charsNull);
-    dataOutput.writeDoubleArray(this.doublesNull);
-    dataOutput.writeShortArray(this.shortsNull);
-    dataOutput.writeFloatArray(this.floatsNull);
-    dataOutput.writeIntArray(this.intsNull);
-    dataOutput.writeLongArray(this.longsNull);
-    dataOutput.writeUTFArray(this.stringsNull);
-
-    const byteSize = this.bytes.length;
-    dataOutput.write(byteSize);
-    dataOutput.write(this.bytes);
-    dataOutput.write(this.bytes[1]);
-    dataOutput.write(this.bytes[2]);
-    dataOutput.writeInt(this.str.length);
-    dataOutput.writeChars(this.str);
-    dataOutput.writeBytes(this.str);
-    dataOutput.writeByte(this.unsignedByte);
-    dataOutput.writeShort(this.unsignedShort);
-
-    dataOutput.writeObject(this.portableObject);
-    dataOutput.writeObject(this.identifiedDataSerializableObject);
-    dataOutput.writeObject(this.customByteArraySerializableObject);
-    dataOutput.writeObject(this.customStreamSerializableObject);
-
-    dataOutput.writeData(this.data);
-};
 
 module.exports = AnIdentifiedDataSerializable;

--- a/test/serialization/BinaryCompatibilityTest.js
+++ b/test/serialization/BinaryCompatibilityTest.js
@@ -16,18 +16,18 @@
 'use strict';
 
 const fs = require('fs');
-const ObjectDataInput = require('../../lib/serialization/ObjectData').ObjectDataInput;
-const HeapData = require('../../lib/serialization/HeapData').HeapData;
+const { ObjectDataInput } = require('../../lib/serialization/ObjectData');
+const { HeapData } = require('../../lib/serialization/HeapData');
 const ReferenceObjects = require('./ReferenceObjects');
-const SerializationService = require('../../lib/serialization/SerializationService').SerializationServiceV1;
-const SerializationConfigImpl = require('../../lib/config/SerializationConfig').SerializationConfigImpl;
+const { SerializationServiceV1 } = require('../../lib/serialization/SerializationService');
+const { SerializationConfigImpl } = require('../../lib/config/SerializationConfig');
 
 const AnInnerPortable = require('./AnInnerPortable');
 const AnIdentifiedDataSerializable = require('./AnIdentifiedDataSerializable');
 const APortable = require('./APortable');
-const CustomByteArraySerializable = require('./CustomSerializable').CustomByteArraySerializable;
-const CustomStreamSerializable = require('./CustomSerializable').CustomStreamSerializable;
-const expectAlmostEqual = require('../Util').expectAlmostEqual;
+const { CustomByteArraySerializable } = require('./CustomSerializable');
+const { CustomStreamSerializable } = require('./CustomSerializable');
+const { expectAlmostEqual } = require('../Util');
 
 describe('BinaryCompatibilityTest', function () {
 
@@ -87,32 +87,30 @@ describe('BinaryCompatibilityTest', function () {
         cfg.customSerializers = [
             {
                 id: ReferenceObjects.CUSTOM_BYTE_ARRAY_SERIALIZABLE_ID,
-                write: function (out, object) {
+                write: (out, obj) => {
                     out.writeInt(8);
-                    out.writeInt(object.i);
-                    out.writeFloat(object.f);
+                    out.writeInt(obj.i);
+                    out.writeFloat(obj.f);
                 },
-                read: function (inp) {
-                    const len = inp.readInt();
-                    const buf = Buffer.alloc(len);
-                    inp.readCopy(buf, len);
+                read: (inp) => {
+                    const buf = inp.readByteArray();
                     return new CustomByteArraySerializable(buf.readInt32BE(0), buf.readFloatBE(4));
                 }
             },
             {
                 id: ReferenceObjects.CUSTOM_STREAM_SERIALIZABLE_ID,
-                write: function (out, object) {
-                    out.writeInt(object.int);
-                    out.writeFloat(object.float);
+                write: (out, obj) => {
+                    out.writeInt(obj.int);
+                    out.writeFloat(obj.float);
                 },
-                read: function (inp) {
+                read: (inp) => {
                     return new CustomStreamSerializable(inp.readInt(), inp.readFloat());
                 }
             }
         ];
         cfg.isBigEndian = isBigEndian;
         cfg.defaultNumberType = defaultNumberType;
-        return new SerializationService(cfg)
+        return new SerializationServiceV1(cfg)
     }
 
     before(function () {
@@ -120,13 +118,11 @@ describe('BinaryCompatibilityTest', function () {
             const input = new ObjectDataInput(fs.readFileSync(__dirname + '/' + createFileName(version)), 0, null, true, true);
             while (input.available() > 0) {
                 const utflen = input.readUnsignedShort();
-                const namebuf = Buffer.alloc(utflen);
-                input.readCopy(namebuf, utflen);
+                const namebuf = input.readRaw(utflen);
                 const objectKey = namebuf.toString();
                 const len = input.readInt();
                 if (len !== NULL_LENGTH) {
-                    const otherBuffer = Buffer.alloc(len);
-                    input.readCopy(otherBuffer, len);
+                    const otherBuffer = input.readRaw(len);
                     dataMap[objectKey] = new HeapData(otherBuffer);
                 }
             }
@@ -136,31 +132,29 @@ describe('BinaryCompatibilityTest', function () {
     });
 
     for (const vn in objects) {
-        (function () {
-            const varName = vn;
-            const object = objects[varName];
-            if (objects.hasOwnProperty(varName)) {
-                versions.forEach(function (version) {
-                    isBigEndianValues.forEach(function (isBigEndian) {
-                        it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version, function () {
+        const varName = vn;
+        const object = objects[varName];
+        if (objects.hasOwnProperty(varName)) {
+            versions.forEach(function (version) {
+                isBigEndianValues.forEach(function (isBigEndian) {
+                    it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version, function () {
+                        this.timeout(10000);
+                        const key = createObjectKey(varName, version, isBigEndian);
+                        const service = createSerializationService(isBigEndian, 'integer');
+                        const deserialized = service.toObject(dataMap[key]);
+                        expectAlmostEqual(deserialized, object);
+                    });
+                    if (!ReferenceObjects.skipOnSerialize[varName]) {
+                        it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version + ' serialize deserialize', function () {
                             this.timeout(10000);
-                            const key = createObjectKey(varName, version, isBigEndian);
-                            const service = createSerializationService(isBigEndian, 'integer');
-                            const deserialized = service.toObject(dataMap[key]);
+                            const service = createSerializationService(isBigEndian, stripArticle(varName).toLowerCase());
+                            const data = service.toData(object);
+                            const deserialized = service.toObject(data);
                             expectAlmostEqual(deserialized, object);
                         });
-                        if (!ReferenceObjects.skipOnSerialize[varName]) {
-                            it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version + ' serialize deserialize', function () {
-                                this.timeout(10000);
-                                const service = createSerializationService(isBigEndian, stripArticle(varName).toLowerCase());
-                                const data = service.toData(object);
-                                const deserialized = service.toObject(data);
-                                expectAlmostEqual(deserialized, object);
-                            });
-                        }
-                    });
+                    }
                 });
-            }
-        })();
+            });
+        }
     }
 });

--- a/test/serialization/DefaultSerializersLiveTest.js
+++ b/test/serialization/DefaultSerializersLiveTest.js
@@ -24,7 +24,7 @@ describe('DefaultSerializersLiveTest', function () {
     let cluster, client;
     let map;
 
-    before(function () {
+    before(async function () {
         return RC.createCluster(null, null).then(function (res) {
             cluster = res;
         }).then(function () {
@@ -39,7 +39,7 @@ describe('DefaultSerializersLiveTest', function () {
         });
     });
 
-    after(function () {
+    after(async function () {
         client.shutdown();
         return RC.terminateCluster(cluster.id);
     });
@@ -58,87 +58,74 @@ describe('DefaultSerializersLiveTest', function () {
             'result = ""+foo();'
     }
 
-    it('string', function () {
-        return map.put('testStringKey', 'testStringValue').then(function () {
-            return RC.executeOnController(cluster.id, generateGet('testStringKey'), 1);
-        }).then(function (response) {
-            return expect(response.result.toString()).to.equal('testStringValue');
-        })
+    it('string', async function () {
+        await map.put('testStringKey', 'testStringValue');
+        const response = await RC.executeOnController(cluster.id, generateGet('testStringKey'), 1);
+        expect(response.result.toString()).to.equal('testStringValue');
     });
 
-    it('utf8 sample string test', function () {
-        return map.put('key', 'Iñtërnâtiônàlizætiøn').then(function () {
-            return RC.executeOnController(cluster.id, generateGet('key'), 1);
-        }).then(function (response) {
-            return expect(response.result.toString()).to.equal('Iñtërnâtiônàlizætiøn');
-        });
+    it('utf8 sample string test', async function () {
+        await map.put('key', 'Iñtërnâtiônàlizætiøn');
+        const response = await RC.executeOnController(cluster.id, generateGet('key'), 1);
+        expect(response.result.toString()).to.equal('Iñtërnâtiônàlizætiøn');
     });
 
-    it('number', function () {
-        return map.put('a', 23).then(function () {
-            return RC.executeOnController(cluster.id, generateGet('a'), 1);
-        }).then(function (response) {
-            return expect(Number.parseInt(response.result.toString())).to.equal(23);
-        })
+    it('number', async function () {
+        await map.put('a', 23);
+        const response = await RC.executeOnController(cluster.id, generateGet('a'), 1);
+        expect(Number.parseInt(response.result.toString())).to.equal(23);
     });
 
-    it('array', function () {
-        return map.put('a', ['a', 'v', 'vg']).then(function () {
-            return RC.executeOnController(cluster.id, generateGet('a'), 1);
-        }).then(function (response) {
-            return expect(response.result.toString()).to.equal(['a', 'v', 'vg'].toString());
-        })
+    it('array', async function () {
+        await map.put('a', ['a', 'v', 'vg']);
+        const response = await RC.executeOnController(cluster.id, generateGet('a'), 1);
+        expect(response.result.toString()).to.equal(['a', 'v', 'vg'].toString());
     });
 
-    it('emoji string test on client', function () {
-        return map.put('key', '1⚐中💦2😭‍🙆😔5').then(function () {
-            return map.get('key');
-        }).then(function (response) {
-            return expect(response).to.equal('1⚐中💦2😭‍🙆😔5');
-        });
+    it('buffer on client', async function () {
+        await map.put('foo', Buffer.from('bar'));
+        const response = await map.get('foo');
+        expect(Buffer.isBuffer(response)).to.be.true;
+        expect(response.toString()).to.equal('bar');
     });
 
-    it('utf8 characters test on client', function () {
-        return map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}').then(function () {
-            return map.get('key');
-        }).then(function (response) {
-            return expect(response).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
-        });
+    it('emoji string test on client', async function () {
+        await map.put('key', '1⚐中💦2😭‍🙆😔5');
+        const response = await map.get('key');
+        expect(response).to.equal('1⚐中💦2😭‍🙆😔5');
     });
 
-    it('utf8 characters test on client with surrogates', function () {
-        return map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\uD834\uDF06').then(function () {
-            return map.get('key');
-        }).then(function (response) {
-            return expect(response).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
-        });
+    it('utf8 characters test on client', async function () {
+        await map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
+        const response = await map.get('key');
+        expect(response).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
     });
 
-    it('emoji string test on RC', function () {
-        return map.put('key', '1⚐中💦2😭‍🙆😔5').then(function () {
-            return RC.executeOnController(cluster.id, generateGet('key'), 1);
-        }).then(function (response) {
-            return expect(response.result.toString()).to.equal('1⚐中💦2😭‍🙆😔5');
-        });
+    it('utf8 characters test on client with surrogates', async function () {
+        await map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\uD834\uDF06');
+        const response = await map.get('key');
+        expect(response).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
     });
 
-    it('utf8 characters test on RC', function () {
-        return map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}').then(function () {
-            return RC.executeOnController(cluster.id, generateGet('key'), 1);
-        }).then(function (response) {
-            return expect(response.result.toString()).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
-        });
+    it('emoji string test on RC', async function () {
+        await map.put('key', '1⚐中💦2😭‍🙆😔5');
+        const response = await RC.executeOnController(cluster.id, generateGet('key'), 1);
+        expect(response.result.toString()).to.equal('1⚐中💦2😭‍🙆😔5');
     });
 
-    it('utf8 characters test on RC with surrogates', function () {
-        return map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\uD834\uDF06').then(function () {
-            return RC.executeOnController(cluster.id, generateGet('key'), 1);
-        }).then(function (response) {
-            return expect(response.result.toString()).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
-        });
+    it('utf8 characters test on RC', async function () {
+        await map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
+        const response = await RC.executeOnController(cluster.id, generateGet('key'), 1);
+        expect(response.result.toString()).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
     });
 
-    it('rest value', function () {
+    it('utf8 characters test on RC with surrogates', async function () {
+        await map.put('key', '\u0040\u0041\u01DF\u06A0\u12E0\uD834\uDF06');
+        const response = await RC.executeOnController(cluster.id, generateGet('key'), 1);
+        expect(response.result.toString()).to.equal('\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}');
+    });
+
+    it('rest value', async function () {
         // Make sure that the object is properly de-serialized at the server
         const restValue = new RestValue();
         restValue.value = '{\'test\':\'data\'}';
@@ -152,14 +139,10 @@ describe('DefaultSerializersLiveTest', function () {
             'result = "{\\"contentType\\": \\"" + new String(contentType) + "\\", ' +
             '\\"value\\": \\"" +  new String(value) + "\\"}"\n';
 
-        return map.put('key', restValue)
-            .then(function () {
-                return RC.executeOnController(cluster.id, script, 1);
-            })
-            .then(function (response) {
-                const result = JSON.parse(response.result.toString());
-                expect(result.contentType).to.equal(restValue.contentType);
-                expect(result.value).to.equal(restValue.value);
-            });
+        await map.put('key', restValue);
+        const response = await RC.executeOnController(cluster.id, script, 1);
+        const result = JSON.parse(response.result.toString());
+        expect(result.contentType).to.equal(restValue.contentType);
+        expect(result.value).to.equal(restValue.value);
     });
 });

--- a/test/serialization/DefaultSerializersTest.js
+++ b/test/serialization/DefaultSerializersTest.js
@@ -17,10 +17,10 @@
 
 const expect = require('chai').expect;
 const Long = require('long');
-const SerializationServiceV1 = require('../../lib/serialization/SerializationService').SerializationServiceV1;
-const SerializationConfigImpl = require('../../lib/config/SerializationConfig').SerializationConfigImpl;
-const Predicates = require('../../.').Predicates;
-const RestValue = require('../../lib/core/RestValue').RestValue;
+const { SerializationServiceV1 } = require('../../lib/serialization/SerializationService');
+const { SerializationConfigImpl } = require('../../lib/config/SerializationConfig');
+const { Predicates } = require('../../.');
+const { RestValue } = require('../../lib/core/RestValue');
 
 describe('DefaultSerializersTest', function () {
 
@@ -42,11 +42,13 @@ describe('DefaultSerializersTest', function () {
         '1⚐中💦2😭‍🙆😔5',
         'Iñtërnâtiônàlizætiøn',
         '\u0040\u0041\u01DF\u06A0\u12E0\u{1D306}',
+        Buffer.from('abc'),
         [12, 56, 54, 12],
         [43546.6, 2343.4, 8988, 4],
         [23545798.6],
         null,
         {abc: 'abc', 'five': 5},
+        [{foo: 'bar'}, {bar: 'baz'}],
         Predicates.sql('test'),
         Predicates.and(Predicates.alwaysTrue(), Predicates.alwaysTrue()),
         Predicates.between('this', 0, 1),

--- a/test/serialization/IdentifiedDataSerializableTest.js
+++ b/test/serialization/IdentifiedDataSerializableTest.js
@@ -20,10 +20,11 @@ const { SerializationConfigImpl } = require('../../lib/config/SerializationConfi
 const { SerializationServiceV1 } = require('../../lib/serialization/SerializationService');
 const Util = require('../Util');
 
-describe('IdentifiedDataSerializableTest', function () {
-    const IdentifiedDataClass = function (a_byte, a_boolean, a_character, a_short, an_integer,
-                                          a_long, a_float, a_double, a_string, bytes, booleans,
-                                          chars, shorts, integers, longs, floats, doubles, strings) {
+class IdentifiedDataClass {
+
+    constructor(a_byte, a_boolean, a_character, a_short, an_integer,
+                a_long, a_float, a_double, a_string, bytes, booleans,
+                chars, shorts, integers, longs, floats, doubles, strings) {
         this.a_byte = a_byte;
         this.a_boolean = a_boolean;
         this.a_character = a_character;
@@ -45,9 +46,9 @@ describe('IdentifiedDataSerializableTest', function () {
 
         this.factoryId = 1;
         this.classId = 1;
-    };
+    }
 
-    IdentifiedDataClass.prototype.readData = function (inp) {
+    readData(inp) {
         this.a_byte = inp.readByte();
         this.a_boolean = inp.readBoolean();
         this.a_character = inp.readChar();
@@ -67,9 +68,9 @@ describe('IdentifiedDataSerializableTest', function () {
         this.floats = inp.readFloatArray();
         this.doubles = inp.readDoubleArray();
         this.strings = inp.readUTFArray();
-    };
+    }
 
-    IdentifiedDataClass.prototype.writeData = function (outp) {
+    writeData(outp) {
         outp.writeByte(this.a_byte);
         outp.writeBoolean(this.a_boolean);
         outp.writeChar(this.a_character);
@@ -89,7 +90,11 @@ describe('IdentifiedDataSerializableTest', function () {
         outp.writeFloatArray(this.floats);
         outp.writeDoubleArray(this.doubles);
         outp.writeUTFArray(this.strings);
-    };
+    }
+
+}
+
+describe('IdentifiedDataSerializableTest', function () {
 
     const identifiedFactory = (classId) => {
         if (classId === 1) {
@@ -105,7 +110,7 @@ describe('IdentifiedDataSerializableTest', function () {
         service = new SerializationServiceV1(cfg);
         const dd = new IdentifiedDataClass(
             99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533,
-            'hazelcast', [99, 100, 101], [true, false, false, true],
+            'hazelcast', Buffer.from([0x99, 0x100, 0x101]), [true, false, false, true],
             ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
             [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)],
             [233.2, 65.88, 657.345], [43645.325, 887.56756],

--- a/test/serialization/ObjectDataTest.js
+++ b/test/serialization/ObjectDataTest.js
@@ -22,7 +22,7 @@ const ObjectData = require('../../lib/serialization/ObjectData');
 const ODInp = ObjectData.ObjectDataInput;
 const ODOut = ObjectData.ObjectDataOutput;
 
-describe('ObjectData Test', function () {
+describe('ObjectDataTest', function () {
 
     const out = new ODOut(null, true);
     before(function () {
@@ -31,8 +31,7 @@ describe('ObjectData Test', function () {
         out.writeBoolean(true);
         out.writeBooleanArray([true, false, false, true, true]);
         out.writeByte(255 | 0);
-        out.writeByteArray([0 | 0, 1 | 0, 65535 | 0]);
-        out.writeBytes('bytes');
+        out.writeByteArray(Buffer.from('bytes'));
         out.writeChar('∂');
         out.writeCharArray(['h', 'a', 'z', 'e', 'l']);
         out.writeChars('cast');
@@ -66,14 +65,9 @@ describe('ObjectData Test', function () {
         expect(inp.readBoolean()).to.be.true;
         expect(inp.readBooleanArray()).to.deep.equal([true, false, false, true, true]);
         expect(inp.readByte()).to.equal(255);
-        expect(inp.readByteArray()).to.deep.equal([0, 1, 255]);
-        const readBytes = [];
-        readBytes.push(inp.readByte());
-        readBytes.push(inp.readByte());
-        readBytes.push(inp.readByte());
-        readBytes.push(inp.readByte());
-        readBytes.push(inp.readByte());
-        expect(String.fromCharCode.apply(null, readBytes)).to.equal('bytes');
+        const readBytes = inp.readByteArray();
+        expect(Buffer.isBuffer(readBytes)).to.be.true;
+        expect(readBytes.toString()).to.equal('bytes');
         expect(inp.readChar()).to.equal('∂');
         expect(inp.readCharArray()).to.deep.equal(['h', 'a', 'z', 'e', 'l']);
         expect(inp.readCharArray().join('')).to.equal('cast');

--- a/test/serialization/PortableObjects.js
+++ b/test/serialization/PortableObjects.js
@@ -15,242 +15,269 @@
  */
 'use strict';
 
-function InnerPortable(p1, p2) {
-    this.p1 = p1;
-    this.p2 = p2;
-    this.factoryId = 10;
-    this.classId = 222;
+class InnerPortable {
+
+    constructor(p1, p2) {
+        this.p1 = p1;
+        this.p2 = p2;
+        this.factoryId = 10;
+        this.classId = 222;
+    }
+
+    readPortable(reader) {
+        this.p1 = reader.readUTF('p1');
+        this.p2 = reader.readUTF('p2');
+    }
+
+    writePortable(writer) {
+        writer.writeUTF('p1', this.p1);
+        writer.writeUTF('p2', this.p2);
+    }
+
 }
 
-InnerPortable.prototype.readPortable = function (reader) {
-    this.p1 = reader.readUTF('p1');
-    this.p2 = reader.readUTF('p2');
-};
+class PortableObject {
 
-InnerPortable.prototype.writePortable = function (writer) {
-    writer.writeUTF('p1', this.p1);
-    writer.writeUTF('p2', this.p2);
-};
+    constructor(a_byte, a_boolean, a_character, a_short, an_integer,
+                a_long, a_float, a_double, a_string, a_portable,
+                bytes, booleans, chars, shorts, integers, longs,
+                floats, doubles, strings, portables) {
+        this.a_byte = a_byte;
+        this.a_boolean = a_boolean;
+        this.a_character = a_character;
+        this.a_short = a_short;
+        this.an_integer = an_integer;
+        this.a_long = a_long;
+        this.a_float = a_float;
+        this.a_double = a_double;
+        this.a_string = a_string;
+        this.a_portable = a_portable;
+        this.a_null_portable = null;
+        this.bytes = bytes;
+        this.booleans = booleans;
+        this.chars = chars;
+        this.shorts = shorts;
+        this.integers = integers;
+        this.longs = longs;
+        this.floats = floats;
+        this.doubles = doubles;
+        this.strings = strings;
+        this.portables = portables;
+        this.factoryId = 10;
+        this.classId = 111;
+    }
 
-function PortableObject(
-            a_byte, a_boolean, a_character, a_short, an_integer, a_long, a_float, a_double, a_string, a_portable,
-            bytes, booleans, chars, shorts, integers, longs, floats, doubles, strings, portables
-        ) {
-    this.a_byte = a_byte;
-    this.a_boolean = a_boolean;
-    this.a_character = a_character;
-    this.a_short = a_short;
-    this.an_integer = an_integer;
-    this.a_long = a_long;
-    this.a_float = a_float;
-    this.a_double = a_double;
-    this.a_string = a_string;
-    this.a_portable = a_portable;
-    this.a_null_portable = null;
-    this.bytes = bytes;
-    this.booleans = booleans;
-    this.chars = chars;
-    this.shorts = shorts;
-    this.integers = integers;
-    this.longs = longs;
-    this.floats = floats;
-    this.doubles = doubles;
-    this.strings = strings;
-    this.portables = portables;
-    this.factoryId = 10;
-    this.classId = 111;
+    writePortable(writer) {
+        writer.writeByte('a_byte', this.a_byte);
+        writer.writeBoolean('a_boolean', this.a_boolean);
+        writer.writeChar('a_char', this.a_character);
+        writer.writeShort('a_short', this.a_short);
+        writer.writeInt('an_integer', this.an_integer);
+        writer.writeLong('a_long', this.a_long);
+        writer.writeFloat('a_float', this.a_float);
+        writer.writeDouble('a_double', this.a_double);
+        writer.writeUTF('a_string', this.a_string);
+        writer.writePortable('a_portable', this.a_portable);
+        const tmpInnerObj = new InnerPortable();
+        writer.writeNullPortable('a_null_portable', tmpInnerObj.factoryId, tmpInnerObj.classId);
+
+        writer.writeByteArray('bytes', this.bytes);
+        writer.writeBooleanArray('booleans', this.booleans);
+        writer.writeCharArray('chars', this.chars);
+        writer.writeShortArray('shorts', this.shorts);
+        writer.writeIntArray('integers', this.integers);
+        writer.writeLongArray('longs', this.longs);
+        writer.writeFloatArray('floats', this.floats);
+        writer.writeDoubleArray('doubles', this.doubles);
+        writer.writeUTFArray('strings', this.strings);
+        writer.writePortableArray('portables', this.portables);
+    }
+
+    readPortable(reader) {
+        this.a_byte = reader.readByte('a_byte');
+        this.a_boolean = reader.readBoolean('a_boolean');
+        this.a_character = reader.readChar('a_char');
+        this.a_short = reader.readShort('a_short');
+        this.an_integer = reader.readInt('an_integer');
+        this.a_long = reader.readLong('a_long');
+        this.a_float = reader.readFloat('a_float');
+        this.a_double = reader.readDouble('a_double');
+        this.a_string = reader.readUTF('a_string');
+        this.a_portable = reader.readPortable('a_portable');
+        this.a_null_portable = reader.readPortable('a_null_portable');
+
+        this.bytes = reader.readByteArray('bytes');
+        this.booleans = reader.readBooleanArray('booleans');
+        this.chars = reader.readCharArray('chars');
+        this.shorts = reader.readShortArray('shorts');
+        this.integers = reader.readIntArray('integers');
+        this.longs = reader.readLongArray('longs');
+        this.floats = reader.readFloatArray('floats');
+        this.doubles = reader.readDoubleArray('doubles');
+        this.strings = reader.readUTFArray('strings');
+        this.portables = reader.readPortableArray('portables');
+    }
+
 }
 
-PortableObject.prototype.writePortable = function (writer) {
-    writer.writeByte('a_byte', this.a_byte);
-    writer.writeBoolean('a_boolean', this.a_boolean);
-    writer.writeChar('a_char', this.a_character);
-    writer.writeShort('a_short', this.a_short);
-    writer.writeInt('an_integer', this.an_integer);
-    writer.writeLong('a_long', this.a_long);
-    writer.writeFloat('a_float', this.a_float);
-    writer.writeDouble('a_double', this.a_double);
-    writer.writeUTF('a_string', this.a_string);
-    writer.writePortable('a_portable', this.a_portable);
-    const tmpInnerObj = new InnerPortable();
-    writer.writeNullPortable('a_null_portable', tmpInnerObj.factoryId, tmpInnerObj.classId);
+class PortableObjectV2{
 
-    writer.writeByteArray('bytes', this.bytes);
-    writer.writeBooleanArray('booleans', this.booleans);
-    writer.writeCharArray('chars', this.chars);
-    writer.writeShortArray('shorts', this.shorts);
-    writer.writeIntArray('integers', this.integers);
-    writer.writeLongArray('longs', this.longs);
-    writer.writeFloatArray('floats', this.floats);
-    writer.writeDoubleArray('doubles', this.doubles);
-    writer.writeUTFArray('strings', this.strings);
-    writer.writePortableArray('portables', this.portables);
-};
+    constructor(a_new_prop, a_byte, a_boolean, a_character, a_short, an_integer,
+                a_long, a_float, a_double, a_portable, bytes, booleans, chars,
+                shorts, integers, longs, floats, doubles, strings, portables) {
+        this.a_new_prop = a_new_prop;// this prop is newly added
+        this.a_byte = a_byte;
+        this.a_boolean = a_boolean;
+        this.a_character = a_character;
+        this.a_short = a_short;
+        this.an_integer = an_integer;
+        this.a_long = a_long;
+        this.a_float = a_float; //this is a double in this version
+        this.a_double = a_double;
+        //a_string is removed
+        this.a_portable = a_portable;
+        this.a_null_portable = null;
+        this.bytes = bytes;
+        this.booleans = booleans;
+        this.chars = chars;
+        this.shorts = shorts;
+        this.integers = integers;
+        this.longs = longs;
+        this.floats = floats;
+        this.doubles = doubles;
+        this.strings = strings;
+        this.portables = portables;
 
-PortableObject.prototype.readPortable = function (reader) {
-    this.a_byte = reader.readByte('a_byte');
-    this.a_boolean = reader.readBoolean('a_boolean');
-    this.a_character = reader.readChar('a_char');
-    this.a_short = reader.readShort('a_short');
-    this.an_integer = reader.readInt('an_integer');
-    this.a_long = reader.readLong('a_long');
-    this.a_float = reader.readFloat('a_float');
-    this.a_double = reader.readDouble('a_double');
-    this.a_string = reader.readUTF('a_string');
-    this.a_portable = reader.readPortable('a_portable');
-    this.a_null_portable = reader.readPortable('a_null_portable');
+        this.factoryId = 10;
+        this.classId = 111;
+        this.version = 2;
+    }
 
-    this.bytes = reader.readByteArray('bytes');
-    this.booleans = reader.readBooleanArray('booleans');
-    this.chars = reader.readCharArray('chars');
-    this.shorts = reader.readShortArray('shorts');
-    this.integers = reader.readIntArray('integers');
-    this.longs = reader.readLongArray('longs');
-    this.floats = reader.readFloatArray('floats');
-    this.doubles = reader.readDoubleArray('doubles');
-    this.strings = reader.readUTFArray('strings');
-    this.portables = reader.readPortableArray('portables');
-};
+    writePortable(writer) {
+        writer.writeUTF('a_new_prop', this.a_new_prop);
+        writer.writeByte('a_byte', this.a_byte);
+        writer.writeBoolean('a_boolean', this.a_boolean);
+        writer.writeChar('a_char', this.a_character);
+        writer.writeShort('a_short', this.a_short);
+        writer.writeInt('an_integer', this.an_integer);
+        writer.writeLong('a_long', this.a_long);
+        writer.writeDouble('a_float', this.a_float); //Floats are Double
+        writer.writeDouble('a_double', this.a_double);
+        writer.writePortable('a_portable', this.a_portable);
+        const tmpInnerObj = new InnerPortable();
+        writer.writeNullPortable('a_null_portable', tmpInnerObj.factoryId, tmpInnerObj.classId);
 
-function PortableObjectV2(
-            a_new_prop, a_byte, a_boolean, a_character, a_short, an_integer, a_long, a_float, a_double,
-            a_portable, bytes, booleans, chars, shorts, integers, longs, floats, doubles, strings, portables
-        ) {
-    this.a_new_prop = a_new_prop;// this prop is newly added
-    this.a_byte = a_byte;
-    this.a_boolean = a_boolean;
-    this.a_character = a_character;
-    this.a_short = a_short;
-    this.an_integer = an_integer;
-    this.a_long = a_long;
-    this.a_float = a_float; //this is a double in this version
-    this.a_double = a_double;
-    //a_string is removed
-    this.a_portable = a_portable;
-    this.a_null_portable = null;
-    this.bytes = bytes;
-    this.booleans = booleans;
-    this.chars = chars;
-    this.shorts = shorts;
-    this.integers = integers;
-    this.longs = longs;
-    this.floats = floats;
-    this.doubles = doubles;
-    this.strings = strings;
-    this.portables = portables;
+        writer.writeByteArray('bytes', this.bytes);
+        writer.writeBooleanArray('booleans', this.booleans);
+        writer.writeCharArray('chars', this.chars);
+        writer.writeShortArray('shorts', this.shorts);
+        writer.writeIntArray('integers', this.integers);
+        writer.writeLongArray('longs', this.longs);
+        writer.writeFloatArray('floats', this.floats);
+        writer.writeDoubleArray('doubles', this.doubles);
+        writer.writeUTFArray('strings', this.strings);
+        writer.writePortableArray('portables', this.portables);
+    }
 
-    this.factoryId = 10;
-    this.classId = 111;
-    this.version = 2;
+    readPortable(reader) {
+        this.a_new_prop = reader.readUTF('a_new_prop');
+        this.a_byte = reader.readByte('a_byte');
+        this.a_boolean = reader.readBoolean('a_boolean');
+        this.a_character = reader.readChar('a_char');
+        this.a_short = reader.readShort('a_short');
+        this.an_integer = reader.readInt('an_integer');
+        this.a_long = reader.readLong('a_long');
+        this.a_float = reader.readDouble('a_float'); // Floats are double
+        this.a_double = reader.readDouble('a_double');
+        this.a_portable = reader.readPortable('a_portable');
+        this.a_null_portable = reader.readPortable('a_null_portable');
+
+        this.bytes = reader.readByteArray('bytes');
+        this.booleans = reader.readBooleanArray('booleans');
+        this.chars = reader.readCharArray('chars');
+        this.shorts = reader.readShortArray('shorts');
+        this.integers = reader.readIntArray('integers');
+        this.longs = reader.readLongArray('longs');
+        this.floats = reader.readFloatArray('floats');
+        this.doubles = reader.readDoubleArray('doubles');
+        this.strings = reader.readUTFArray('strings');
+        this.portables = reader.readPortableArray('portables');
+    }
+
 }
 
-PortableObjectV2.prototype.writePortable = function (writer) {
-    writer.writeUTF('a_new_prop', this.a_new_prop);
-    writer.writeByte('a_byte', this.a_byte);
-    writer.writeBoolean('a_boolean', this.a_boolean);
-    writer.writeChar('a_char', this.a_character);
-    writer.writeShort('a_short', this.a_short);
-    writer.writeInt('an_integer', this.an_integer);
-    writer.writeLong('a_long', this.a_long);
-    writer.writeDouble('a_float', this.a_float); //Floats are Double
-    writer.writeDouble('a_double', this.a_double);
-    writer.writePortable('a_portable', this.a_portable);
-    const tmpInnerObj = new InnerPortable();
-    writer.writeNullPortable('a_null_portable', tmpInnerObj.factoryId, tmpInnerObj.classId);
+class SimplePortable {
 
-    writer.writeByteArray('bytes', this.bytes);
-    writer.writeBooleanArray('booleans', this.booleans);
-    writer.writeCharArray('chars', this.chars);
-    writer.writeShortArray('shorts', this.shorts);
-    writer.writeIntArray('integers', this.integers);
-    writer.writeLongArray('longs', this.longs);
-    writer.writeFloatArray('floats', this.floats);
-    writer.writeDoubleArray('doubles', this.doubles);
-    writer.writeUTFArray('strings', this.strings);
-    writer.writePortableArray('portables', this.portables);
-};
+    constructor(str) {
+        this.aString = str;
+        this.factoryId = 10;
+        this.classId = 21;
+    }
 
-PortableObjectV2.prototype.readPortable = function (reader) {
-    this.a_new_prop = reader.readUTF('a_new_prop');
-    this.a_byte = reader.readByte('a_byte');
-    this.a_boolean = reader.readBoolean('a_boolean');
-    this.a_character = reader.readChar('a_char');
-    this.a_short = reader.readShort('a_short');
-    this.an_integer = reader.readInt('an_integer');
-    this.a_long = reader.readLong('a_long');
-    this.a_float = reader.readDouble('a_float'); // Floats are double
-    this.a_double = reader.readDouble('a_double');
-    this.a_portable = reader.readPortable('a_portable');
-    this.a_null_portable = reader.readPortable('a_null_portable');
+    readPortable(reader) {
+        this.aString = reader.readUTF('aString');
+    }
 
-    this.bytes = reader.readByteArray('bytes');
-    this.booleans = reader.readBooleanArray('booleans');
-    this.chars = reader.readCharArray('chars');
-    this.shorts = reader.readShortArray('shorts');
-    this.integers = reader.readIntArray('integers');
-    this.longs = reader.readLongArray('longs');
-    this.floats = reader.readFloatArray('floats');
-    this.doubles = reader.readDoubleArray('doubles');
-    this.strings = reader.readUTFArray('strings');
-    this.portables = reader.readPortableArray('portables');
-};
+    writePortable(writer) {
+        writer.writeUTF('aString', this.aString);
+    }
 
-function SimplePortable(str) {
-    this.aString = str;
-    this.factoryId = 10;
-    this.classId = 21;
 }
 
-SimplePortable.prototype.readPortable = function (reader) {
-    this.aString = reader.readUTF('aString');
-};
+class SimplePortableV3 {
 
-SimplePortable.prototype.writePortable = function (writer) {
-    writer.writeUTF('aString', this.aString);
-};
+    constructor(innerObject) {
+        this.innerObject = innerObject;
+        this.factoryId = 10;
+        this.classId = 21;
+        this.version = 3;
+    }
 
-function SimplePortableV3(innerObject) {
-    this.innerObject = innerObject;
-    this.factoryId = 10;
-    this.classId = 21;
-    this.version = 3;
+    readPortable(reader) {
+        this.innerObject = reader.readPortable('innerObject');
+    }
+
+    writePortable(writer) {
+        writer.writePortable('innerObject', this.innerObject);
+    }
+
 }
 
-SimplePortableV3.prototype.readPortable = function (reader) {
-    this.innerObject = reader.readPortable('innerObject');
-};
+class Parent {
 
-SimplePortableV3.prototype.writePortable = function (writer) {
-    writer.writePortable('innerObject', this.innerObject);
-};
+    constructor(child) {
+        this.child = child;
+        this.factoryId = 1;
+        this.classId = 1;
+    }
 
-function Parent(child) {
-    this.child = child;
-    this.factoryId = 1;
-    this.classId = 1;
+    writePortable(writer) {
+        writer.writePortable('child', this.child);
+    }
+
+    readPortable(reader) {
+        this.child = reader.readPortable('child');
+    }
+
 }
 
-Parent.prototype.writePortable = function (writer) {
-    writer.writePortable('child', this.child);
-};
+class Child {
 
-Parent.prototype.readPortable = function (reader) {
-    this.child = reader.readPortable('child');
-};
+    constructor(name) {
+        this.name = name;
+        this.factoryId = 1;
+        this.classId = 2;
+    }
 
-function Child(name) {
-    this.name = name;
-    this.factoryId = 1;
-    this.classId = 2;
+    writePortable(writer) {
+        writer.writeUTF('name', this.name);
+    }
+
+    readPortable(reader) {
+        this.name = reader.readUTF('name');
+    }
+
 }
-
-Child.prototype.writePortable = function (writer) {
-    writer.writeUTF('name', this.name);
-};
-
-Child.prototype.readPortable = function (reader) {
-    this.name = reader.readUTF('name');
-};
 
 exports.PortableObject = PortableObject;
 exports.PortableObjectV2 = PortableObjectV2;

--- a/test/serialization/PortableSerializationTest.js
+++ b/test/serialization/PortableSerializationTest.js
@@ -15,15 +15,16 @@
  */
 'use strict';
 
-const SerializationConfigImpl = require('../../lib/config/SerializationConfig').SerializationConfigImpl;
-const SerializationServiceV1 = require('../../lib/serialization/SerializationService').SerializationServiceV1;
 const Long = require('long');
 const Util = require('../Util');
-
-const PortableObject = require('./PortableObjects').PortableObject;
-const PortableObjectV2 = require('./PortableObjects').PortableObjectV2;
-const InnerPortable = require('./PortableObjects').InnerPortable;
-const SimplePortableV3 = require('./PortableObjects').SimplePortableV3;
+const { SerializationConfigImpl } = require('../../lib/config/SerializationConfig');
+const { SerializationServiceV1 } = require('../../lib/serialization/SerializationService');
+const {
+    PortableObject,
+    PortableObjectV2,
+    InnerPortable,
+    SimplePortableV3
+} = require('./PortableObjects');
 
 describe('PortableSerializationTest', function () {
 
@@ -44,10 +45,12 @@ describe('PortableSerializationTest', function () {
     it('write-read', function () {
         const service = createSerializationService(PortableObject);
         const emp = new PortableObject(
-            99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533,
-            'hazelcast', new InnerPortable('a', 'b'), [99, 100, 101], [true, false, false, true], ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
-            [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)], [233.2, 65.88, 657.345],
-            [43645.325, 887.56756], ['hazelcast', 'ankara', 'istanbul', 'london', 'palo alto'],
+            99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533, 'hazelcast',
+            new InnerPortable('a', 'b'), Buffer.from([0x99, 0x100, 0x101]), [true, false, false, true],
+            ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
+            [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)],
+            [233.2, 65.88, 657.345], [43645.325, 887.56756],
+            ['hazelcast', 'ankara', 'istanbul', 'london', 'palo alto'],
             [new InnerPortable('elma', 'armut'), new InnerPortable('masa', 'sandalye')]
         );
 
@@ -62,7 +65,7 @@ describe('PortableSerializationTest', function () {
 
         const emp = new PortableObjectV2(
             'a_new_value', 99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533,
-            new InnerPortable('a', 'b'), [99, 100, 101], [true, false, false, true],
+            new InnerPortable('a', 'b'), Buffer.from([0x99, 0x100, 0x101]), [true, false, false, true],
             ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
             [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)],
             [233.2, 65.88, 657.345], [43645.325, 887.56756],
@@ -81,8 +84,8 @@ describe('PortableSerializationTest', function () {
         const newService = createSerializationService(PortableObjectV2);
 
         const empv1 = new PortableObject(
-            99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533,
-            'hazelcast', new InnerPortable('a', 'b'), [99, 100, 101], [true, false, false, true],
+            99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533, 'hazelcast',
+            new InnerPortable('a', 'b'), Buffer.from([0x99, 0x100, 0x101]), [true, false, false, true],
             ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
             [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)],
             [233.2, 65.88, 657.345], [43645.325, 887.56756],
@@ -91,7 +94,7 @@ describe('PortableSerializationTest', function () {
         );
         const empv2 = new PortableObjectV2(
             undefined, 99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533,
-            new InnerPortable('a', 'b'), [99, 100, 101], [true, false, false, true],
+            new InnerPortable('a', 'b'), Buffer.from([0x99, 0x100, 0x101]), [true, false, false, true],
             ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
             [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)],
             [233.2, 65.88, 657.345], [43645.325, 887.56756],
@@ -110,7 +113,7 @@ describe('PortableSerializationTest', function () {
 
         const innerPortableV2 = new PortableObjectV2(
             'propstring', 99, true, 'a', 23, 54375456, Long.fromBits(243534, 43543654), 24.1, 32435.6533,
-            new InnerPortable('a', 'b'), [99, 100, 101], [true, false, false, true],
+            new InnerPortable('a', 'b'), Buffer.from([0x99, 0x100, 0x101]), [true, false, false, true],
             ['a', 'b', 'v'], [12, 545, 23, 6], [325, 6547656, 345],
             [Long.fromNumber(342534654), Long.fromNumber(-3215243654), Long.fromNumber(123123)],
             [233.2, 65.88, 657.345], [43645.325, 887.56756],

--- a/test/serialization/ReferenceObjects.js
+++ b/test/serialization/ReferenceObjects.js
@@ -45,7 +45,7 @@ for (let ci = 65535 - to.aString.length; ci > 0; ci--) {
 }
 
 to.booleans = [true, false, true];
-to.bytes = [112, 4, -1, 4, 112, -35, 43];
+to.bytes = Buffer.from([112, 4, -1, 4, 112, -35, 43]);
 to.chars = ['a', 'b', 'c'];
 to.doubles = [-897543.3678909, 11.1, 22.2, 33.3];
 to.shorts = [-500, 2, 3];


### PR DESCRIPTION
Depends on #570

* Adds native support for node.js' `Buffer` type instead of array of numbers used previously
* Also fixes `null` case handling in `ObjectDataInput#readArray`

Corresponding PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1749254626/Node.js+Client+Native+Binary+Data+Type