### PR TITLE
Add boomerang backups support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -36,6 +36,7 @@
   * [5.4. Setting Connection Timeout](#54-setting-connection-timeout)
   * [5.5. Enabling Client TLS/SSL](#55-enabling-client-tlsssl)
   * [5.6. Enabling Hazelcast Cloud Discovery](#56-enabling-hazelcast-cloud-discovery)
+  * [5.7. Configuring Backup Acknowledgment](#57-configuring-backup-acknowledgment)
 * [6. Client Connection Strategy](#6-client-connection-strategy)
   * [6.1. Configuring Client Connection Retry](#61-configuring-client-connection-retry)
 * [7. Using Node.js Client with Hazelcast IMDG](#7-using-nodejs-client-with-hazelcast-imdg)
@@ -1011,6 +1012,26 @@ const cfg = {
 
 To be able to connect to the provided IP addresses, you should use secure TLS/SSL connection between the client and members. Therefore, you should set an SSL configuration as described in the previous section.
 
+## 5.7. Configuring Backup Acknowledgment
+
+When an operation with sync backup is sent by a client to the Hazelcast member(s), the acknowledgment of the operation's backup is sent to the client by the backup replica member(s). This improves the performance of the client operations.
+
+To disable backup acknowledgement, you should use the `backupAckToClientEnabled` configuration option.
+
+```javascript
+const cfg = {
+    backupAckToClientEnabled: false
+};
+```
+
+Its default value is `true`. This option has no effect for unisocket clients.
+
+You can also fine-tune this feature using entries of the `properties` config option as described below:
+
+- `hazelcast.client.operation.backup.timeout.millis`: Default value is `5000` milliseconds. If an operation has
+backups, this property specifies how long (in milliseconds) the invocation waits for acks from the backup replicas. If acks are not received from some of the backups, there will not be any rollback on the other successful replicas.
+
+- `hazelcast.client.operation.fail.on.indeterminate.state`: Default value is `false`. When it is `true`, if an operation has sync backups and acks are not received from backup replicas in time, or the member which owns primary replica of the target partition leaves the cluster, then the invocation fails. However, even if the invocation fails, there will not be any rollback on other successful replicas.
 
 # 6. Client Connection Strategy
 

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -468,6 +468,7 @@ export class HazelcastClient {
             .then(() => {
                 this.listenerService.start();
                 this.proxyManager.init();
+                this.invocationService.start();
                 this.loadBalancer.initLoadBalancer(this.clusterService, this.config);
                 this.statistics.start();
                 return this.sendStateToCluster();

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -40,8 +40,9 @@ export interface ClientConfig {
     clusterName?: string;
 
     /**
-     * Name of the client instance. By default, set to `hz.client_${CLIENT_ID}`, where
-     * `CLIENT_ID` starts from `0` and it is incremented by `1` for each new client.
+     * Name of the client instance. By default, set to `hz.client_${CLIENT_ID}`,
+     * where `CLIENT_ID` starts from `0` and it is incremented by `1`
+     * for each new client.
      */
     instanceName?: string;
 
@@ -131,9 +132,20 @@ export interface ClientConfig {
     customLogger?: ILogger;
 
     /**
-     * Custom credentials to be used as a part of authentication on the cluster.
+     * Custom credentials to be used as a part of authentication on
+     * the cluster.
      */
     customCredentials?: any;
+
+    /**
+     * Enables client to get backup acknowledgements directly from
+     * the member that backups are applied, which reduces number of hops
+     * and increases performance for smart clients.
+     *
+     * Enabled by default for smart clients. This option has no effect
+     * for unisocket clients.
+     */
+    backupAckToClientEnabled?: boolean;
 
     /**
      * User-defined properties.
@@ -150,6 +162,7 @@ export class ClientConfigImpl implements ClientConfig {
         'hazelcast.client.heartbeat.timeout': 60000,
         'hazelcast.client.invocation.retry.pause.millis': 1000,
         'hazelcast.client.invocation.timeout.millis': 120000,
+        'hazelcast.client.internal.clean.resources.millis': 100,
         'hazelcast.client.cloud.url': 'https://coordinator.hazelcast.cloud',
         'hazelcast.client.statistics.enabled': false,
         'hazelcast.client.statistics.period.seconds': Statistics.PERIOD_SECONDS_DEFAULT_VALUE,
@@ -161,6 +174,8 @@ export class ClientConfigImpl implements ClientConfig {
         'hazelcast.client.autopipelining.threshold.bytes': 8192,
         'hazelcast.client.socket.no.delay': true,
         'hazelcast.client.shuffle.member.list': true,
+        'hazelcast.client.operation.backup.timeout.millis': 5000,
+        'hazelcast.client.operation.fail.on.indeterminate.state': false,
     };
 
     instanceName: string;
@@ -177,6 +192,7 @@ export class ClientConfigImpl implements ClientConfig {
     clusterName = 'dev';
     clientLabels: string[] = [];
     loadBalancer = new LoadBalancerConfigImpl();
+    backupAckToClientEnabled = true;
 
     private configPatternMatcher = new ConfigPatternMatcher();
 

--- a/src/config/ConfigBuilder.ts
+++ b/src/config/ConfigBuilder.ts
@@ -90,6 +90,8 @@ export class ConfigBuilder {
                 this.handleLogger(value);
             } else if (key === 'customCredentials') {
                 this.handleCredentials(value);
+            } else if (key === 'backupAckToClientEnabled') {
+                this.effectiveConfig.backupAckToClientEnabled = tryGetBoolean(value);
             }
         }
     }

--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -295,3 +295,10 @@ export class ReachedMaxSizeError extends HazelcastError {
         Object.setPrototypeOf(this, ReachedMaxSizeError.prototype);
     }
 }
+
+export class IndeterminateOperationStateError extends HazelcastError {
+    constructor(msg: string, cause?: Error) {
+        super(msg, cause);
+        Object.setPrototypeOf(this, IndeterminateOperationStateError.prototype);
+    }
+}

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -374,9 +374,7 @@ export class InvocationService {
      * Removes the handler for all event handlers with a specific correlation id.
      */
     removeEventHandler(correlationId: number): void {
-        if (this.eventHandlers.has(correlationId)) {
-            this.eventHandlers.delete(correlationId);
-        }
+        this.eventHandlers.delete(correlationId);
     }
 
     backupEventHandler(clientMessage: ClientMessage): void {

--- a/src/listener/ListenerMessageCodec.ts
+++ b/src/listener/ListenerMessageCodec.ts
@@ -20,7 +20,11 @@ import {UUID} from '../core/UUID';
 
 /** @internal */
 export interface ListenerMessageCodec {
+
     encodeAddRequest: (localOnly: boolean) => ClientMessage;
+
     decodeAddResponse: (msg: ClientMessage) => UUID;
+
     encodeRemoveRequest: (listenerId: UUID) => ClientMessage;
+
 }

--- a/src/listener/ListenerService.ts
+++ b/src/listener/ListenerService.ts
@@ -118,7 +118,7 @@ export class ListenerService {
 
     registerListener(codec: ListenerMessageCodec, listenerHandlerFn: Function): Promise<string> {
         const activeConnections = this.client.getConnectionManager().getActiveConnections();
-        const userRegistrationKey: string = UuidUtil.generate().toString();
+        const userRegistrationKey = UuidUtil.generate().toString();
         let connectionsOnUserKey: Map<ClientConnection, ClientEventRegistration>;
         const deferred = DeferredPromise<string>();
         const registerRequest = codec.encodeAddRequest(this.isSmart());
@@ -133,7 +133,7 @@ export class ListenerService {
             if (connectionsOnUserKey.has(connection)) {
                 continue;
             }
-            // New correlation id will be set on the invoke call
+            // new correlation id will be set on the invoke call
             const requestCopy = registerRequest.copyWithNewCorrelationId();
             const invocation = new Invocation(this.client, requestCopy);
             invocation.handler = listenerHandlerFn as any;

--- a/src/protocol/ErrorFactory.ts
+++ b/src/protocol/ErrorFactory.ts
@@ -29,6 +29,7 @@ import {
     HazelcastInstanceNotActiveError,
     IllegalStateError,
     InvocationTimeoutError,
+    IndeterminateOperationStateError,
     IOError,
     MemberLeftError,
     NoDataMemberInClusterError,
@@ -64,56 +65,104 @@ export class ClientErrorFactory {
     private codeToErrorConstructor: Map<number, ErrorFactory> = new Map();
 
     constructor() {
-        this.register(ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS, (m, c) => new RangeError(m));
-        this.register(ClientProtocolErrorCodes.ARRAY_STORE, (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.AUTHENTICATION, (m, c) => new AuthenticationError(m, c));
-        this.register(ClientProtocolErrorCodes.CALLER_NOT_MEMBER, (m, c) => new CallerNotMemberError(m, c));
-        this.register(ClientProtocolErrorCodes.CANCELLATION, (m, c) => new CancellationError(m, c));
-        this.register(ClientProtocolErrorCodes.CLASS_CAST, (m, c) => new ClassCastError(m, c));
-        this.register(ClientProtocolErrorCodes.CLASS_NOT_FOUND, (m, c) => new ClassNotFoundError(m, c));
-        this.register(ClientProtocolErrorCodes.CONCURRENT_MODIFICATION, (m, c) => new ConcurrentModificationError(m, c));
-        this.register(ClientProtocolErrorCodes.CONFIG_MISMATCH, (m, c) => new ConfigMismatchError(m, c));
-        this.register(ClientProtocolErrorCodes.DISTRIBUTED_OBJECT_DESTROYED, (m, c) => new DistributedObjectDestroyedError(m, c));
-        this.register(ClientProtocolErrorCodes.EOF, (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.HAZELCAST, (m, c) => new HazelcastError(m, c));
+        this.register(ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS,
+            (m, c) => new RangeError(m));
+        this.register(ClientProtocolErrorCodes.ARRAY_STORE,
+            (m, c) => new TypeError(m));
+        this.register(ClientProtocolErrorCodes.AUTHENTICATION,
+            (m, c) => new AuthenticationError(m, c));
+        this.register(ClientProtocolErrorCodes.CALLER_NOT_MEMBER,
+            (m, c) => new CallerNotMemberError(m, c));
+        this.register(ClientProtocolErrorCodes.CANCELLATION,
+            (m, c) => new CancellationError(m, c));
+        this.register(ClientProtocolErrorCodes.CLASS_CAST,
+            (m, c) => new ClassCastError(m, c));
+        this.register(ClientProtocolErrorCodes.CLASS_NOT_FOUND,
+            (m, c) => new ClassNotFoundError(m, c));
+        this.register(ClientProtocolErrorCodes.CONCURRENT_MODIFICATION,
+            (m, c) => new ConcurrentModificationError(m, c));
+        this.register(ClientProtocolErrorCodes.CONFIG_MISMATCH,
+            (m, c) => new ConfigMismatchError(m, c));
+        this.register(ClientProtocolErrorCodes.DISTRIBUTED_OBJECT_DESTROYED,
+            (m, c) => new DistributedObjectDestroyedError(m, c));
+        this.register(ClientProtocolErrorCodes.EOF,
+            (m, c) => new IOError(m, c));
+        this.register(ClientProtocolErrorCodes.HAZELCAST,
+            (m, c) => new HazelcastError(m, c));
         this.register(ClientProtocolErrorCodes.HAZELCAST_INSTANCE_NOT_ACTIVE,
             (m, c) => new HazelcastInstanceNotActiveError(m, c));
-        this.register(ClientProtocolErrorCodes.HAZELCAST_OVERLOAD, (m, c) => new HazelcastError(m, c));
-        this.register(ClientProtocolErrorCodes.HAZELCAST_SERIALIZATION, (m, c) => new HazelcastSerializationError(m, c));
-        this.register(ClientProtocolErrorCodes.IO, (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.ILLEGAL_ARGUMENT, (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.ILLEGAL_STATE, (m, c) => new IllegalStateError(m, c));
-        this.register(ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS, (m, c) => new RangeError(m));
-        this.register(ClientProtocolErrorCodes.INTERRUPTED, (m, c) => new Error(m));
-        this.register(ClientProtocolErrorCodes.INVALID_ADDRESS, (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.INVALID_CONFIGURATION, (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.MEMBER_LEFT, (m, c) => new MemberLeftError(m, c));
-        this.register(ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE, (m, c) => new RangeError(m));
-        this.register(ClientProtocolErrorCodes.NO_SUCH_ELEMENT, (m, c) => new ReferenceError(m));
-        this.register(ClientProtocolErrorCodes.NOT_SERIALIZABLE, (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.NULL_POINTER, (m, c) => new ReferenceError(m));
-        this.register(ClientProtocolErrorCodes.OPERATION_TIMEOUT, (m, c) => new InvocationTimeoutError(m, c));
-        this.register(ClientProtocolErrorCodes.PARTITION_MIGRATING, (m, c) => new PartitionMigratingError(m, c));
-        this.register(ClientProtocolErrorCodes.QUERY, (m, c) => new QueryError(m, c));
-        this.register(ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED, (m, c) => new QueryError(m, c));
-        this.register(ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION, (m, c) => new SplitBrainProtectionError(m, c));
-        this.register(ClientProtocolErrorCodes.REACHED_MAX_SIZE, (m, c) => new ReachedMaxSizeError(m, c));
-        this.register(ClientProtocolErrorCodes.RETRYABLE_HAZELCAST, (m, c) => new RetryableHazelcastError(m, c));
-        this.register(ClientProtocolErrorCodes.RETRYABLE_IO, (m, c) => new RetryableIOError(m, c));
-        this.register(ClientProtocolErrorCodes.SOCKET, (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.STALE_SEQUENCE, (m, c) => new StaleSequenceError(m, c));
-        this.register(ClientProtocolErrorCodes.TARGET_DISCONNECTED, (m, c) => new TargetDisconnectedError(m, c));
-        this.register(ClientProtocolErrorCodes.TARGET_NOT_MEMBER, (m, c) => new TargetNotMemberError(m, c));
-        this.register(ClientProtocolErrorCodes.TOPIC_OVERLOAD, (m, c) => new TopicOverloadError(m, c));
-        this.register(ClientProtocolErrorCodes.TRANSACTION, (m, c) => new TransactionError(m, c));
-        this.register(ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE, (m, c) => new TransactionNotActiveError(m, c));
-        this.register(ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT, (m, c) => new TransactionTimedOutError(m, c));
-        this.register(ClientProtocolErrorCodes.UNSUPPORTED_OPERATION, (m, c) => new UnsupportedOperationError(m, c));
-        this.register(ClientProtocolErrorCodes.NO_DATA_MEMBER, (m, c) => new NoDataMemberInClusterError(m, c));
-        this.register(ClientProtocolErrorCodes.STALE_TASK_ID, (m, c) => new StaleTaskIdError(m, c));
+        this.register(ClientProtocolErrorCodes.HAZELCAST_OVERLOAD,
+            (m, c) => new HazelcastError(m, c));
+        this.register(ClientProtocolErrorCodes.HAZELCAST_SERIALIZATION,
+            (m, c) => new HazelcastSerializationError(m, c));
+        this.register(ClientProtocolErrorCodes.IO,
+            (m, c) => new IOError(m, c));
+        this.register(ClientProtocolErrorCodes.ILLEGAL_ARGUMENT,
+            (m, c) => new TypeError(m));
+        this.register(ClientProtocolErrorCodes.ILLEGAL_STATE,
+            (m, c) => new IllegalStateError(m, c));
+        this.register(ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS,
+            (m, c) => new RangeError(m));
+        this.register(ClientProtocolErrorCodes.INTERRUPTED,
+            (m, c) => new Error(m));
+        this.register(ClientProtocolErrorCodes.INVALID_ADDRESS,
+            (m, c) => new TypeError(m));
+        this.register(ClientProtocolErrorCodes.INVALID_CONFIGURATION,
+            (m, c) => new TypeError(m));
+        this.register(ClientProtocolErrorCodes.MEMBER_LEFT,
+            (m, c) => new MemberLeftError(m, c));
+        this.register(ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE,
+            (m, c) => new RangeError(m));
+        this.register(ClientProtocolErrorCodes.NO_SUCH_ELEMENT,
+            (m, c) => new ReferenceError(m));
+        this.register(ClientProtocolErrorCodes.NOT_SERIALIZABLE,
+            (m, c) => new IOError(m, c));
+        this.register(ClientProtocolErrorCodes.NULL_POINTER,
+            (m, c) => new ReferenceError(m));
+        this.register(ClientProtocolErrorCodes.OPERATION_TIMEOUT,
+            (m, c) => new InvocationTimeoutError(m, c));
+        this.register(ClientProtocolErrorCodes.PARTITION_MIGRATING,
+            (m, c) => new PartitionMigratingError(m, c));
+        this.register(ClientProtocolErrorCodes.QUERY,
+            (m, c) => new QueryError(m, c));
+        this.register(ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED,
+            (m, c) => new QueryError(m, c));
+        this.register(ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION,
+            (m, c) => new SplitBrainProtectionError(m, c));
+        this.register(ClientProtocolErrorCodes.REACHED_MAX_SIZE,
+            (m, c) => new ReachedMaxSizeError(m, c));
+        this.register(ClientProtocolErrorCodes.RETRYABLE_HAZELCAST,
+            (m, c) => new RetryableHazelcastError(m, c));
+        this.register(ClientProtocolErrorCodes.RETRYABLE_IO,
+            (m, c) => new RetryableIOError(m, c));
+        this.register(ClientProtocolErrorCodes.SOCKET,
+            (m, c) => new IOError(m, c));
+        this.register(ClientProtocolErrorCodes.STALE_SEQUENCE,
+            (m, c) => new StaleSequenceError(m, c));
+        this.register(ClientProtocolErrorCodes.TARGET_DISCONNECTED,
+            (m, c) => new TargetDisconnectedError(m, c));
+        this.register(ClientProtocolErrorCodes.TARGET_NOT_MEMBER,
+            (m, c) => new TargetNotMemberError(m, c));
+        this.register(ClientProtocolErrorCodes.TOPIC_OVERLOAD,
+            (m, c) => new TopicOverloadError(m, c));
+        this.register(ClientProtocolErrorCodes.TRANSACTION,
+            (m, c) => new TransactionError(m, c));
+        this.register(ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE,
+            (m, c) => new TransactionNotActiveError(m, c));
+        this.register(ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT,
+            (m, c) => new TransactionTimedOutError(m, c));
+        this.register(ClientProtocolErrorCodes.UNSUPPORTED_OPERATION,
+            (m, c) => new UnsupportedOperationError(m, c));
+        this.register(ClientProtocolErrorCodes.NO_DATA_MEMBER,
+            (m, c) => new NoDataMemberInClusterError(m, c));
+        this.register(ClientProtocolErrorCodes.STALE_TASK_ID,
+            (m, c) => new StaleTaskIdError(m, c));
         this.register(ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION,
             (m, c) => new NodeIdOutOfRangeError(m, c));
-        this.register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION, (m, c) => new ConsistencyLostError(m, c));
+        this.register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION,
+            (m, c) => new ConsistencyLostError(m, c));
+        this.register(ClientProtocolErrorCodes.INDETERMINATE_OPERATION_STATE,
+            (m, c) => new IndeterminateOperationStateError(m, c));
     }
 
     createErrorFromClientMessage(clientMessage: ClientMessage): Error {
@@ -125,12 +174,11 @@ export class ClientErrorFactory {
         if (errorHolderIdx === errorHolders.length) {
             return null;
         }
-
         const errorHolder = errorHolders[errorHolderIdx];
-        const factoryFunc = this.codeToErrorConstructor.get(errorHolder.errorCode);
+        const factoryFn = this.codeToErrorConstructor.get(errorHolder.errorCode);
         let error: Error;
-        if (factoryFunc != null) {
-            error = factoryFunc(errorHolder.message, this.createError(errorHolders, errorHolderIdx + 1));
+        if (factoryFn != null) {
+            error = factoryFn(errorHolder.message, this.createError(errorHolders, errorHolderIdx + 1));
         } else {
             error = new UndefinedErrorCodeError(errorHolder.message, errorHolder.className);
         }

--- a/src/util/BitsUtil.ts
+++ b/src/util/BitsUtil.ts
@@ -28,25 +28,7 @@ export class BitsUtil {
     static readonly DOUBLE_SIZE_IN_BYTES = 8;
     static readonly UUID_SIZE_IN_BYTES = BitsUtil.BOOLEAN_SIZE_IN_BYTES + 2 * BitsUtil.LONG_SIZE_IN_BYTES;
 
-    static readonly BIG_ENDIAN = 2;
-    static readonly LITTLE_ENDIAN = 1;
-
-    static readonly BEGIN_FLAG = 0x80;
-    static readonly END_FLAG = 0x40;
-    static readonly BEGIN_END_FLAG = BitsUtil.BEGIN_FLAG | BitsUtil.END_FLAG;
-    static readonly LISTENER_FLAG = 0x01;
-
     static readonly NULL_ARRAY_LENGTH = -1;
-
-    static readonly FRAME_LENGTH_FIELD_OFFSET = 0;
-    static readonly VERSION_FIELD_OFFSET = BitsUtil.FRAME_LENGTH_FIELD_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
-    static readonly FLAGS_FIELD_OFFSET = BitsUtil.VERSION_FIELD_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
-    static readonly TYPE_FIELD_OFFSET = BitsUtil.FLAGS_FIELD_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
-    static readonly CORRELATION_ID_FIELD_OFFSET = BitsUtil.TYPE_FIELD_OFFSET + BitsUtil.SHORT_SIZE_IN_BYTES;
-    static readonly PARTITION_ID_FIELD_OFFSET = BitsUtil.CORRELATION_ID_FIELD_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
-    static readonly DATA_OFFSET_FIELD_OFFSET = BitsUtil.PARTITION_ID_FIELD_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
-
-    static readonly HEADER_SIZE = BitsUtil.DATA_OFFSET_FIELD_OFFSET + BitsUtil.SHORT_SIZE_IN_BYTES;
 
     static writeUInt32(buffer: Buffer, pos: number, val: number, isBigEndian: boolean): void {
         if (isBigEndian) {

--- a/test/config/ConfigBuilderTest.js
+++ b/test/config/ConfigBuilderTest.js
@@ -128,6 +128,10 @@ describe('ConfigBuilderTest', function () {
         expect(networkCfg.ssl.sslOptions.servername).to.equal('foo.bar.com');
     });
 
+    it('backupAckToClientEnabled', function () {
+        expect(fullConfig.backupAckToClientEnabled).to.be.false;
+    });
+
     it('properties', function () {
         const properties = fullConfig.properties;
         expect(properties['hazelcast.client.heartbeat.interval']).to.equal(1000);

--- a/test/config/SchemaValidationTest.js
+++ b/test/config/SchemaValidationTest.js
@@ -25,7 +25,7 @@ describe('SchemaValidationTest', function () {
     let schema;
 
     before(function () {
-        schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../config-schema.json'), 'utf8'));
+        schema = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'configurations/config-schema.json'), 'utf8'));
     });
 
     function validateCandidate(candidate) {

--- a/test/config/configurations/config-schema.json
+++ b/test/config/configurations/config-schema.json
@@ -105,6 +105,10 @@
                 }
             }
         },
+        "backupAckToClientEnabled": {
+            "type": "boolean",
+            "default": true
+        },
         "connectionStrategy": {
             "type": "object",
             "properties": {

--- a/test/config/configurations/full.json
+++ b/test/config/configurations/full.json
@@ -42,6 +42,7 @@
             "discoveryToken": "EXAMPLE_TOKEN"
         }
     },
+    "backupAckToClientEnabled": false,
     "connectionStrategy": {
         "asyncStart": true,
         "reconnectMode": "async",

--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { Client, IndeterminateOperationStateError } = require('../../');
+const RC = require('../RC');
+const { ClientLocalBackupListenerCodec } = require('../../lib/codec/ClientLocalBackupListenerCodec');
+
+/**
+ * Tests backup acks to client (a.k.a. boomerang backups).
+ *
+ * Data structures use sync backups with backup count `1` by default,
+ * so there is no need for additional member side configuration.
+ */
+describe('ClientBackupAcksTest', function () {
+
+    let cluster;
+    let client;
+
+    before(async function () {
+        cluster = await RC.createCluster(null, null);
+        await RC.startMember(cluster.id);
+        await RC.startMember(cluster.id);
+    });
+
+    afterEach(async function () {
+        sandbox.restore();
+        return client.shutdown();
+    });
+
+    after(async function () {
+        return RC.terminateCluster(cluster.id);
+    });
+
+    it('should receive backup acks in smart mode', async function () {
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            properties: {
+                'hazelcast.client.operation.fail.on.indeterminate.state': true
+            }
+        });
+        const map = await client.getMap('test-map');
+
+        // it's enough for this operation to succeed
+        await map.set('foo', 'bar');
+    });
+
+    it('should throw when backup acks were lost in smart mode when prop is set', async function () {
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            properties: {
+                'hazelcast.client.operation.backup.timeout.millis': 300,
+                'hazelcast.client.operation.fail.on.indeterminate.state': true
+            }
+        });
+        // replace backup ack handler with a fake to emulate backup acks loss
+        sandbox.replace(ClientLocalBackupListenerCodec, 'handle', sinon.fake());
+        const map = await client.getMap('test-map');
+
+        try {
+            await map.set('foo', 'bar');
+        } catch (err) {
+            expect(err).to.be.instanceof(IndeterminateOperationStateError);
+        }
+    });
+
+    it('should not throw when backup acks were lost in smart mode when prop is not set', async function () {
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            properties: {
+                'hazelcast.client.operation.backup.timeout.millis': 300
+            }
+        });
+        // replace backup ack handler with a fake to emulate backup acks loss
+        sinon.replace(ClientLocalBackupListenerCodec, 'handle', sinon.fake());
+        const map = await client.getMap('test-map');
+
+        // it's enough for this operation to succeed
+        await map.set('foo', 'bar');
+    });
+
+    it('should receive ack in smart mode when acks to client are disabled', async function () {
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            backupAckToClientEnabled: false
+        });
+        const map = await client.getMap('test-map');
+
+        // it's enough for this operation to succeed
+        await map.set('foo', 'bar');
+    });
+
+    it('should receive ack in unisocket mode', async function () {
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            smartRouting: false
+        });
+        const map = await client.getMap('test-map');
+
+        // it's enough for this operation to succeed
+        await map.set('foo', 'bar');
+    });
+});

--- a/test/invocation/InvocationServiceTest.js
+++ b/test/invocation/InvocationServiceTest.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { Client, ClientConfigImpl } = require('../../');
+const { InvocationService } = require('../../lib/invocation/InvocationService');
+const { ListenerService } = require('../../lib/listener/ListenerService');
+const { PartitionServiceImpl } = require('../../lib/PartitionService');
+const { LoggingService } = require('../../lib/logging/LoggingService');
+
+describe('InvocationServiceTest', function () {
+
+    let service;
+
+    function mockClient(config) {
+        const clientStub = sandbox.stub(Client.prototype);
+        clientStub.getConfig.returns(config);
+        const listenerServiceStub = sandbox.stub(ListenerService.prototype);
+        clientStub.getListenerService.returns(listenerServiceStub);
+        const partitionServiceStub = sandbox.stub(PartitionServiceImpl.prototype);
+        clientStub.getPartitionService.returns(partitionServiceStub);
+        const loggingServiceStub = sandbox.stub(LoggingService.prototype);
+        clientStub.getLoggingService.returns(loggingServiceStub);
+        return clientStub;
+    }
+
+    afterEach(function () {
+        sandbox.restore();
+        if (service != null) {
+            service.shutdown();
+        }
+    });
+
+    it('should start clean resource task and register listener when client is smart and acks are enabled', function () {
+        const config = new ClientConfigImpl();
+        const client = mockClient(config);
+
+        service = new InvocationService(client);
+        service.start();
+
+        expect(service.cleanResourcesTask).to.be.not.undefined;
+        expect(client.getListenerService().registerListener.calledOnce).to.be.true;
+    });
+
+    it('should not start clean resource task and register listener when client is unisocket', function () {
+        const config = new ClientConfigImpl();
+        config.network.smartRouting = false;
+        const client = mockClient(config);
+
+        service = new InvocationService(client);
+        service.start();
+
+        expect(service.cleanResourcesTask).to.be.undefined;
+        expect(client.getListenerService().registerListener.notCalled).to.be.true;
+    });
+
+    it('should not start clean resource task and register listener when acks are disabled', function () {
+        const config = new ClientConfigImpl();
+        config.backupAckToClientEnabled = false;
+        const client = mockClient(config);
+
+        service = new InvocationService(client);
+        service.start();
+
+        expect(service.cleanResourcesTask).to.be.undefined;
+        expect(client.getListenerService().registerListener.notCalled).to.be.true;
+    });
+});

--- a/test/invocation/InvocationTest.js
+++ b/test/invocation/InvocationTest.js
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const { Client, IndeterminateOperationStateError } = require('../../');
+const { Invocation, InvocationService } = require('../../lib/invocation/InvocationService');
+const { ClientMessage } = require('../../lib/protocol/ClientMessage');
+
+describe('InvocationTest', function () {
+
+    let clientStub;
+    let serviceStub;
+
+    beforeEach(function () {
+        clientStub = sandbox.stub(Client.prototype);
+        serviceStub = sandbox.stub(InvocationService.prototype);
+        clientStub.getInvocationService.returns(serviceStub);
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('notify: should complete when no expected backups', function () {
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        messageStub.getNumberOfBackupAcks.returns(0);
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.notify(messageStub);
+
+        expect(completeStub.withArgs(messageStub).calledOnce).to.be.true;
+    });
+
+    it('notify: should not complete when expected and no received backups', function () {
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        messageStub.getNumberOfBackupAcks.returns(1);
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.notify(messageStub);
+
+        expect(completeStub.notCalled).to.be.true;
+        expect(invocation.pendingResponseReceivedMillis).to.be.greaterThan(0);
+        expect(invocation.backupsAcksExpected).to.be.equal(1);
+        expect(invocation.pendingResponseMessage).to.be.equal(messageStub);
+    });
+
+    it('notify: should complete when expected and received backups are equal', function () {
+        const invocation = new Invocation(clientStub);
+        invocation.backupsAcksReceived = 1;
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        messageStub.getNumberOfBackupAcks.returns(1);
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.notify(messageStub);
+
+        expect(completeStub.withArgs(messageStub).calledOnce).to.be.true;
+    });
+
+    it('notifyBackupComplete: should not complete when no pending message', function () {
+        const invocation = new Invocation(clientStub);
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.notifyBackupComplete();
+
+        expect(completeStub.notCalled).to.be.true;
+        expect(invocation.backupsAcksReceived).to.be.equal(1);
+    });
+
+    it('notifyBackupComplete: should not complete when not all acks received', function () {
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        invocation.pendingResponseMessage = messageStub;
+        invocation.backupsAcksReceived = 1;
+        invocation.backupsAcksExpected = 3;
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.notifyBackupComplete();
+
+        expect(completeStub.notCalled).to.be.true;
+        expect(invocation.backupsAcksReceived).to.be.equal(2);
+    });
+
+    it('notifyBackupComplete: should complete when all acks received', function () {
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        invocation.pendingResponseMessage = messageStub;
+        invocation.backupsAcksReceived = 1;
+        invocation.backupsAcksExpected = 2;
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.notifyBackupComplete();
+
+        expect(completeStub.withArgs(messageStub).calledOnce).to.be.true;
+        expect(invocation.backupsAcksReceived).to.be.equal(2);
+    });
+
+    it('detectAndHandleBackupTimeout: should not complete when all acks received', function () {
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        invocation.pendingResponseMessage = messageStub;
+        invocation.backupsAcksReceived = 1;
+        invocation.backupsAcksExpected = 1;
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.detectAndHandleBackupTimeout(1);
+
+        expect(completeStub.notCalled).to.be.true;
+    });
+
+    it('detectAndHandleBackupTimeout: should not complete when not all acks received and timeout not reached', function () {
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        invocation.pendingResponseMessage = messageStub;
+        invocation.backupsAcksReceived = 1;
+        invocation.backupsAcksExpected = 1;
+
+        invocation.pendingResponseReceivedMillis = 40;
+        sandbox.useFakeTimers(40); // 40 + 1 > 40
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.detectAndHandleBackupTimeout(1);
+
+        expect(completeStub.notCalled).to.be.true;
+    });
+
+    it('detectAndHandleBackupTimeout: should complete when not all acks received and timeout reached', function () {
+        serviceStub.shouldFailOnIndeterminateState = false;
+
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        invocation.pendingResponseMessage = messageStub;
+        invocation.backupsAcksReceived = 0;
+        invocation.backupsAcksExpected = 1;
+
+        invocation.pendingResponseReceivedMillis = 40;
+        sandbox.useFakeTimers(42); // 40 + 1 < 42
+
+        const completeStub = sandbox.stub(invocation, 'complete');
+        invocation.detectAndHandleBackupTimeout(1);
+
+        expect(completeStub.withArgs(messageStub).calledOnce).to.be.true;
+    });
+
+    it('detectAndHandleBackupTimeout: should complete with error when prop is set', function () {
+        serviceStub.shouldFailOnIndeterminateState = true;
+
+        const invocation = new Invocation(clientStub);
+        const messageStub = sandbox.stub(ClientMessage.prototype);
+        invocation.pendingResponseMessage = messageStub;
+        invocation.request = messageStub;
+        invocation.backupsAcksReceived = 0;
+        invocation.backupsAcksExpected = 1;
+
+        invocation.pendingResponseReceivedMillis = 40;
+        sandbox.useFakeTimers(42); // 40 + 1 < 42
+
+        const completeWithErrorStub = sandbox.stub(invocation, 'completeWithError');
+        invocation.detectAndHandleBackupTimeout(1);
+
+        expect(completeWithErrorStub.calledOnce).to.be.true;
+        expect(completeWithErrorStub.args[0][0]).to.be.instanceof(IndeterminateOperationStateError);
+    });
+});

--- a/test/unit/protocol/ClientMessageTest.js
+++ b/test/unit/protocol/ClientMessageTest.js
@@ -39,7 +39,7 @@ describe('ClientMessageTest', function () {
         const cmDecode = ClientMessage.createForDecode(cmEncode.startFrame);
 
         expect(cmEncode.getMessageType()).to.equal(cmDecode.getMessageType());
-        expect(cmEncode.getHeaderFlags()).to.equal(cmDecode.getHeaderFlags());
+        expect(cmEncode.getStartFrame().flags).to.equal(cmDecode.getStartFrame().flags);
         expect(cmEncode.getCorrelationId()).to.equal(cmDecode.getCorrelationId());
         expect(cmEncode.getPartitionId()).to.equal(cmDecode.getPartitionId());
         expect(cmEncode.getTotalFrameLength()).to.equal(cmDecode.getTotalFrameLength());
@@ -68,7 +68,7 @@ describe('ClientMessageTest', function () {
         expect(originalFrame.flags).to.equal(copyFrame.flags);
 
         expect(originalMessage.getMessageType()).to.equal(copyMessage.getMessageType());
-        expect(originalMessage.getHeaderFlags()).to.equal(copyMessage.getHeaderFlags());
+        expect(originalMessage.getStartFrame().flags).to.equal(copyMessage.getStartFrame().flags);
         expect(originalMessage.getPartitionId()).to.equal(copyMessage.getPartitionId());
         expect(originalMessage.getTotalFrameLength()).to.equal(copyMessage.getTotalFrameLength());
         expect(copyMessage.getCorrelationId()).to.equal(-1);


### PR DESCRIPTION
* Implements support of backup acks to client (a.k.a. boomerang backups)
* Adds related unit tests for `InvocationService` and `Invocation`
* Slightly improves code quality in `InvocationService`, `Invocation` and `ClientMessage`
* Also migrates `ClientLabelTest` to async/await syntax

Corresponding PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1764032832/Node.js+Client+Boomerang+Backups

### Feature Overview

So far clients were waiting for the sync backups to complete on the member. This was causing 4 network hops to complete a client operation with sync backup. Since sync backup configuration is our out-of-box experience, we would like to improve it. Boomerang backup design decreases network hops to 3, thus improving the performance. 

![boomerang-backups](https://user-images.githubusercontent.com/37772591/90883098-d6c45c00-e3b5-11ea-949d-8dc68acd6442.png)
