### PR TITLE
Add serverStackTrace property in HazelcastError class

### DIFF
--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -22,45 +22,101 @@ export interface HazelcastErrorConstructor {
 }
 
 /**
- * Base class for all specific errors thrown by Hazelcast client.
+ * Represents a stack trace element of server-side exception.
+ */
+export interface ServerErrorStackElement {
+
+    /**
+     * Class name.
+     */
+    className: string;
+
+    /**
+     * Method name.
+     */
+    methodName: string;
+
+    /**
+     * Name of the file containing the class.
+     */
+    fileName: string;
+
+    /**
+     * Line number from the class.
+     */
+    lineNumber: number;
+
+}
+
+/**
+ * Represents server-side exception.
+ */
+export interface ServerError {
+
+    /**
+     * Error code.
+     */
+    errorCode: number;
+
+    /**
+     * Name of the class responsible for throwing the exception.
+     */
+    className: string;
+
+    /**
+     * Error message.
+     */
+    message: string;
+
+    /**
+     * Server-side stack trace.
+     */
+    stackTraceElements: ServerErrorStackElement[];
+
+}
+
+/**
+ * Base class for all specific exceptions thrown by Hazelcast client.
  */
 export class HazelcastError extends Error {
 
     cause: Error;
     stack: string;
+    serverError?: ServerError;
 
-    constructor(msg: string, cause?: Error) {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
         super(msg);
         this.cause = cause;
+        this.serverError = serverError;
         Error.captureStackTrace(this, HazelcastError);
         Object.setPrototypeOf(this, HazelcastError.prototype);
     }
 }
 
 export class HazelcastSerializationError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, HazelcastSerializationError.prototype);
     }
 }
 
 export class AuthenticationError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, AuthenticationError.prototype);
     }
 }
 
 export class ClientNotActiveError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ClientNotActiveError.prototype);
     }
 }
 
 export class ClientNotAllowedInClusterError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ClientNotAllowedInClusterError.prototype);
     }
 }
@@ -73,232 +129,295 @@ export class ClientOfflineError extends HazelcastError {
 }
 
 export class InvalidConfigurationError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, InvalidConfigurationError.prototype);
     }
 }
 
 export class IllegalStateError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, IllegalStateError.prototype);
     }
 }
 
 export class StaleSequenceError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, StaleSequenceError.prototype);
     }
 }
 
 export class TopicOverloadError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, TopicOverloadError.prototype);
     }
 }
 
 export class IOError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, IOError.prototype);
     }
 }
 
-export class UndefinedErrorCodeError extends HazelcastError {
-    constructor(msg: string, className: string) {
-        super('Class name: ' + className + ' , Message: ' + msg);
-        Object.setPrototypeOf(this, UndefinedErrorCodeError.prototype);
-    }
-}
-
 export class InvocationTimeoutError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, InvocationTimeoutError.prototype);
     }
 }
 
 export class RetryableHazelcastError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, RetryableHazelcastError.prototype);
     }
 }
 
 export class TargetNotMemberError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, TargetNotMemberError.prototype);
     }
 }
 
 export class CallerNotMemberError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, CallerNotMemberError.prototype);
     }
 }
 
 export class CancellationError extends IllegalStateError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, CancellationError.prototype);
     }
 }
 
 export class ClassCastError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ClassCastError.prototype);
     }
 }
 
 export class ClassNotFoundError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ClassNotFoundError.prototype);
     }
 }
 
 export class ConcurrentModificationError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ConcurrentModificationError.prototype);
     }
 }
 
 export class ConfigMismatchError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ConfigMismatchError.prototype);
     }
 }
 
 export class DistributedObjectDestroyedError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, DistributedObjectDestroyedError.prototype);
     }
 }
 
 export class HazelcastInstanceNotActiveError extends IllegalStateError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, HazelcastInstanceNotActiveError.prototype);
     }
 }
 
 export class MemberLeftError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, MemberLeftError.prototype);
     }
 }
 
 export class PartitionMigratingError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, PartitionMigratingError.prototype);
     }
 }
 
 export class QueryError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, QueryError.prototype);
     }
 }
 
 export class TransactionError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, TransactionError.prototype);
     }
 }
 
 export class TransactionNotActiveError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, TransactionNotActiveError.prototype);
     }
 }
 
 export class TransactionTimedOutError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, TransactionTimedOutError.prototype);
     }
 }
 
 export class SplitBrainProtectionError extends TransactionError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, SplitBrainProtectionError.prototype);
     }
 }
 
 export class RetryableIOError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, RetryableIOError.prototype);
     }
 }
 
 export class TargetDisconnectedError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, TargetDisconnectedError.prototype);
     }
 }
 
 export class UnsupportedOperationError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, UnsupportedOperationError.prototype);
     }
 }
 
 export class ConsistencyLostError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ConsistencyLostError.prototype);
     }
 }
 
 export class NoDataMemberInClusterError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, NoDataMemberInClusterError.prototype);
     }
 }
 
 export class StaleTaskIdError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, StaleTaskIdError.prototype);
     }
 }
 
 export class NodeIdOutOfRangeError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, NodeIdOutOfRangeError.prototype);
     }
 }
 
 export class ReachedMaxSizeError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, ReachedMaxSizeError.prototype);
     }
 }
 
 export class IndeterminateOperationStateError extends HazelcastError {
-    constructor(msg: string, cause?: Error) {
-        super(msg, cause);
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
         Object.setPrototypeOf(this, IndeterminateOperationStateError.prototype);
+    }
+}
+
+export class ArrayIndexOutOfBoundsError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, ArrayIndexOutOfBoundsError.prototype);
+    }
+}
+
+export class ArrayStoreError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, ArrayStoreError.prototype);
+    }
+}
+
+export class IllegalArgumentError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, IllegalArgumentError.prototype);
+    }
+}
+
+export class IndexOutOfBoundsError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, IndexOutOfBoundsError.prototype);
+    }
+}
+
+export class InterruptedError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, InterruptedError.prototype);
+    }
+}
+
+export class InvalidAddressError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, InvalidAddressError.prototype);
+    }
+}
+
+export class NegativeArraySizeError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, NegativeArraySizeError.prototype);
+    }
+}
+
+export class NoSuchElementError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, NoSuchElementError.prototype);
+    }
+}
+
+export class NullPointerError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+        super(msg, cause, serverError);
+        Object.setPrototypeOf(this, NullPointerError.prototype);
+    }
+}
+
+export class UndefinedErrorCodeError extends HazelcastError {
+    constructor(msg: string, className: string, serverError?: ServerError) {
+        super('Class name: ' + className + ' , Message: ' + msg, null, serverError);
+        Object.setPrototypeOf(this, UndefinedErrorCodeError.prototype);
     }
 }

--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -395,8 +395,8 @@ export class NullPointerError extends HazelcastError {
 }
 
 export class UndefinedErrorCodeError extends HazelcastError {
-    constructor(msg: string, className: string, serverStackTrace?: ServerErrorStackElement[]) {
-        super('Class name: ' + className + ' , Message: ' + msg, null, serverStackTrace);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, UndefinedErrorCodeError.prototype);
     }
 }

--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -49,74 +49,53 @@ export interface ServerErrorStackElement {
 }
 
 /**
- * Represents server-side exception.
- */
-export interface ServerError {
-
-    /**
-     * Error code.
-     */
-    errorCode: number;
-
-    /**
-     * Name of the class responsible for throwing the exception.
-     */
-    className: string;
-
-    /**
-     * Error message.
-     */
-    message: string;
-
-    /**
-     * Server-side stack trace.
-     */
-    stackTraceElements: ServerErrorStackElement[];
-
-}
-
-/**
  * Base class for all specific exceptions thrown by Hazelcast client.
  */
 export class HazelcastError extends Error {
 
+    /**
+     * Cause of this exception.
+     */
     cause: Error;
-    stack: string;
-    serverError?: ServerError;
 
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
+    /**
+     * Server-side stack trace.
+     */
+    serverStackTrace?: ServerErrorStackElement[];
+
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
         super(msg);
         this.cause = cause;
-        this.serverError = serverError;
+        this.serverStackTrace = serverStackTrace;
         Error.captureStackTrace(this, HazelcastError);
         Object.setPrototypeOf(this, HazelcastError.prototype);
     }
 }
 
 export class HazelcastSerializationError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, HazelcastSerializationError.prototype);
     }
 }
 
 export class AuthenticationError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, AuthenticationError.prototype);
     }
 }
 
 export class ClientNotActiveError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ClientNotActiveError.prototype);
     }
 }
 
 export class ClientNotAllowedInClusterError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ClientNotAllowedInClusterError.prototype);
     }
 }
@@ -129,295 +108,295 @@ export class ClientOfflineError extends HazelcastError {
 }
 
 export class InvalidConfigurationError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, InvalidConfigurationError.prototype);
     }
 }
 
 export class IllegalStateError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, IllegalStateError.prototype);
     }
 }
 
 export class StaleSequenceError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, StaleSequenceError.prototype);
     }
 }
 
 export class TopicOverloadError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, TopicOverloadError.prototype);
     }
 }
 
 export class IOError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, IOError.prototype);
     }
 }
 
 export class InvocationTimeoutError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, InvocationTimeoutError.prototype);
     }
 }
 
 export class RetryableHazelcastError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, RetryableHazelcastError.prototype);
     }
 }
 
 export class TargetNotMemberError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, TargetNotMemberError.prototype);
     }
 }
 
 export class CallerNotMemberError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, CallerNotMemberError.prototype);
     }
 }
 
 export class CancellationError extends IllegalStateError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, CancellationError.prototype);
     }
 }
 
 export class ClassCastError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ClassCastError.prototype);
     }
 }
 
 export class ClassNotFoundError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ClassNotFoundError.prototype);
     }
 }
 
 export class ConcurrentModificationError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ConcurrentModificationError.prototype);
     }
 }
 
 export class ConfigMismatchError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ConfigMismatchError.prototype);
     }
 }
 
 export class DistributedObjectDestroyedError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, DistributedObjectDestroyedError.prototype);
     }
 }
 
 export class HazelcastInstanceNotActiveError extends IllegalStateError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, HazelcastInstanceNotActiveError.prototype);
     }
 }
 
 export class MemberLeftError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, MemberLeftError.prototype);
     }
 }
 
 export class PartitionMigratingError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, PartitionMigratingError.prototype);
     }
 }
 
 export class QueryError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, QueryError.prototype);
     }
 }
 
 export class TransactionError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, TransactionError.prototype);
     }
 }
 
 export class TransactionNotActiveError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, TransactionNotActiveError.prototype);
     }
 }
 
 export class TransactionTimedOutError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, TransactionTimedOutError.prototype);
     }
 }
 
 export class SplitBrainProtectionError extends TransactionError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, SplitBrainProtectionError.prototype);
     }
 }
 
 export class RetryableIOError extends RetryableHazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, RetryableIOError.prototype);
     }
 }
 
 export class TargetDisconnectedError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, TargetDisconnectedError.prototype);
     }
 }
 
 export class UnsupportedOperationError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, UnsupportedOperationError.prototype);
     }
 }
 
 export class ConsistencyLostError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ConsistencyLostError.prototype);
     }
 }
 
 export class NoDataMemberInClusterError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, NoDataMemberInClusterError.prototype);
     }
 }
 
 export class StaleTaskIdError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, StaleTaskIdError.prototype);
     }
 }
 
 export class NodeIdOutOfRangeError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, NodeIdOutOfRangeError.prototype);
     }
 }
 
 export class ReachedMaxSizeError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ReachedMaxSizeError.prototype);
     }
 }
 
 export class IndeterminateOperationStateError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, IndeterminateOperationStateError.prototype);
     }
 }
 
 export class ArrayIndexOutOfBoundsError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ArrayIndexOutOfBoundsError.prototype);
     }
 }
 
 export class ArrayStoreError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, ArrayStoreError.prototype);
     }
 }
 
 export class IllegalArgumentError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, IllegalArgumentError.prototype);
     }
 }
 
 export class IndexOutOfBoundsError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, IndexOutOfBoundsError.prototype);
     }
 }
 
 export class InterruptedError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, InterruptedError.prototype);
     }
 }
 
 export class InvalidAddressError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, InvalidAddressError.prototype);
     }
 }
 
 export class NegativeArraySizeError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, NegativeArraySizeError.prototype);
     }
 }
 
 export class NoSuchElementError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, NoSuchElementError.prototype);
     }
 }
 
 export class NullPointerError extends HazelcastError {
-    constructor(msg: string, cause?: Error, serverError?: ServerError) {
-        super(msg, cause, serverError);
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, NullPointerError.prototype);
     }
 }
 
 export class UndefinedErrorCodeError extends HazelcastError {
-    constructor(msg: string, className: string, serverError?: ServerError) {
-        super('Class name: ' + className + ' , Message: ' + msg, null, serverError);
+    constructor(msg: string, className: string, serverStackTrace?: ServerErrorStackElement[]) {
+        super('Class name: ' + className + ' , Message: ' + msg, null, serverStackTrace);
         Object.setPrototypeOf(this, UndefinedErrorCodeError.prototype);
     }
 }

--- a/src/protocol/ErrorFactory.ts
+++ b/src/protocol/ErrorFactory.ts
@@ -16,6 +16,8 @@
 /** @ignore *//** */
 
 import {
+    ArrayIndexOutOfBoundsError,
+    ArrayStoreError,
     AuthenticationError,
     CallerNotMemberError,
     CancellationError,
@@ -31,9 +33,17 @@ import {
     InvocationTimeoutError,
     IndeterminateOperationStateError,
     IOError,
+    IllegalArgumentError,
+    IndexOutOfBoundsError,
+    InvalidAddressError,
+    InvalidConfigurationError,
+    InterruptedError,
     MemberLeftError,
+    NegativeArraySizeError,
+    NoSuchElementError,
     NoDataMemberInClusterError,
     NodeIdOutOfRangeError,
+    NullPointerError,
     PartitionMigratingError,
     QueryError,
     SplitBrainProtectionError,
@@ -57,7 +67,7 @@ import {ClientMessage} from '../protocol/ClientMessage';
 import {ErrorsCodec} from '../codec/builtin/ErrorsCodec';
 import {ErrorHolder} from './ErrorHolder';
 
-type ErrorFactory = (msg: string, cause: Error) => Error;
+type ErrorFactory = (msg: string, cause: Error, serverError: ErrorHolder) => Error;
 
 /** @internal */
 export class ClientErrorFactory {
@@ -66,103 +76,103 @@ export class ClientErrorFactory {
 
     constructor() {
         this.register(ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS,
-            (m, c) => new RangeError(m));
+            (m, c, e) => new ArrayIndexOutOfBoundsError(m, c, e));
         this.register(ClientProtocolErrorCodes.ARRAY_STORE,
-            (m, c) => new TypeError(m));
+            (m, c, e) => new ArrayStoreError(m, c, e));
         this.register(ClientProtocolErrorCodes.AUTHENTICATION,
-            (m, c) => new AuthenticationError(m, c));
+            (m, c, e) => new AuthenticationError(m, c, e));
         this.register(ClientProtocolErrorCodes.CALLER_NOT_MEMBER,
-            (m, c) => new CallerNotMemberError(m, c));
+            (m, c, e) => new CallerNotMemberError(m, c, e));
         this.register(ClientProtocolErrorCodes.CANCELLATION,
-            (m, c) => new CancellationError(m, c));
+            (m, c, e) => new CancellationError(m, c, e));
         this.register(ClientProtocolErrorCodes.CLASS_CAST,
-            (m, c) => new ClassCastError(m, c));
+            (m, c, e) => new ClassCastError(m, c, e));
         this.register(ClientProtocolErrorCodes.CLASS_NOT_FOUND,
-            (m, c) => new ClassNotFoundError(m, c));
+            (m, c, e) => new ClassNotFoundError(m, c, e));
         this.register(ClientProtocolErrorCodes.CONCURRENT_MODIFICATION,
-            (m, c) => new ConcurrentModificationError(m, c));
+            (m, c, e) => new ConcurrentModificationError(m, c, e));
         this.register(ClientProtocolErrorCodes.CONFIG_MISMATCH,
-            (m, c) => new ConfigMismatchError(m, c));
+            (m, c, e) => new ConfigMismatchError(m, c, e));
         this.register(ClientProtocolErrorCodes.DISTRIBUTED_OBJECT_DESTROYED,
-            (m, c) => new DistributedObjectDestroyedError(m, c));
+            (m, c, e) => new DistributedObjectDestroyedError(m, c, e));
         this.register(ClientProtocolErrorCodes.EOF,
-            (m, c) => new IOError(m, c));
+            (m, c, e) => new IOError(m, c, e));
         this.register(ClientProtocolErrorCodes.HAZELCAST,
-            (m, c) => new HazelcastError(m, c));
+            (m, c, e) => new HazelcastError(m, c, e));
         this.register(ClientProtocolErrorCodes.HAZELCAST_INSTANCE_NOT_ACTIVE,
-            (m, c) => new HazelcastInstanceNotActiveError(m, c));
+            (m, c, e) => new HazelcastInstanceNotActiveError(m, c, e));
         this.register(ClientProtocolErrorCodes.HAZELCAST_OVERLOAD,
-            (m, c) => new HazelcastError(m, c));
+            (m, c, e) => new HazelcastError(m, c, e));
         this.register(ClientProtocolErrorCodes.HAZELCAST_SERIALIZATION,
-            (m, c) => new HazelcastSerializationError(m, c));
-        this.register(ClientProtocolErrorCodes.IO,
-            (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.ILLEGAL_ARGUMENT,
-            (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.ILLEGAL_STATE,
-            (m, c) => new IllegalStateError(m, c));
-        this.register(ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS,
-            (m, c) => new RangeError(m));
-        this.register(ClientProtocolErrorCodes.INTERRUPTED,
-            (m, c) => new Error(m));
-        this.register(ClientProtocolErrorCodes.INVALID_ADDRESS,
-            (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.INVALID_CONFIGURATION,
-            (m, c) => new TypeError(m));
-        this.register(ClientProtocolErrorCodes.MEMBER_LEFT,
-            (m, c) => new MemberLeftError(m, c));
-        this.register(ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE,
-            (m, c) => new RangeError(m));
-        this.register(ClientProtocolErrorCodes.NO_SUCH_ELEMENT,
-            (m, c) => new ReferenceError(m));
-        this.register(ClientProtocolErrorCodes.NOT_SERIALIZABLE,
-            (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.NULL_POINTER,
-            (m, c) => new ReferenceError(m));
-        this.register(ClientProtocolErrorCodes.OPERATION_TIMEOUT,
-            (m, c) => new InvocationTimeoutError(m, c));
-        this.register(ClientProtocolErrorCodes.PARTITION_MIGRATING,
-            (m, c) => new PartitionMigratingError(m, c));
-        this.register(ClientProtocolErrorCodes.QUERY,
-            (m, c) => new QueryError(m, c));
-        this.register(ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED,
-            (m, c) => new QueryError(m, c));
-        this.register(ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION,
-            (m, c) => new SplitBrainProtectionError(m, c));
-        this.register(ClientProtocolErrorCodes.REACHED_MAX_SIZE,
-            (m, c) => new ReachedMaxSizeError(m, c));
-        this.register(ClientProtocolErrorCodes.RETRYABLE_HAZELCAST,
-            (m, c) => new RetryableHazelcastError(m, c));
-        this.register(ClientProtocolErrorCodes.RETRYABLE_IO,
-            (m, c) => new RetryableIOError(m, c));
-        this.register(ClientProtocolErrorCodes.SOCKET,
-            (m, c) => new IOError(m, c));
-        this.register(ClientProtocolErrorCodes.STALE_SEQUENCE,
-            (m, c) => new StaleSequenceError(m, c));
-        this.register(ClientProtocolErrorCodes.TARGET_DISCONNECTED,
-            (m, c) => new TargetDisconnectedError(m, c));
-        this.register(ClientProtocolErrorCodes.TARGET_NOT_MEMBER,
-            (m, c) => new TargetNotMemberError(m, c));
-        this.register(ClientProtocolErrorCodes.TOPIC_OVERLOAD,
-            (m, c) => new TopicOverloadError(m, c));
-        this.register(ClientProtocolErrorCodes.TRANSACTION,
-            (m, c) => new TransactionError(m, c));
-        this.register(ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE,
-            (m, c) => new TransactionNotActiveError(m, c));
-        this.register(ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT,
-            (m, c) => new TransactionTimedOutError(m, c));
-        this.register(ClientProtocolErrorCodes.UNSUPPORTED_OPERATION,
-            (m, c) => new UnsupportedOperationError(m, c));
-        this.register(ClientProtocolErrorCodes.NO_DATA_MEMBER,
-            (m, c) => new NoDataMemberInClusterError(m, c));
-        this.register(ClientProtocolErrorCodes.STALE_TASK_ID,
-            (m, c) => new StaleTaskIdError(m, c));
-        this.register(ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION,
-            (m, c) => new NodeIdOutOfRangeError(m, c));
-        this.register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION,
-            (m, c) => new ConsistencyLostError(m, c));
+            (m, c, e) => new HazelcastSerializationError(m, c, e));
         this.register(ClientProtocolErrorCodes.INDETERMINATE_OPERATION_STATE,
-            (m, c) => new IndeterminateOperationStateError(m, c));
+            (m, c, e) => new IndeterminateOperationStateError(m, c, e));
+        this.register(ClientProtocolErrorCodes.IO,
+            (m, c, e) => new IOError(m, c, e));
+        this.register(ClientProtocolErrorCodes.ILLEGAL_ARGUMENT,
+            (m, c, e) => new IllegalArgumentError(m, c, e));
+        this.register(ClientProtocolErrorCodes.ILLEGAL_STATE,
+            (m, c, e) => new IllegalStateError(m, c, e));
+        this.register(ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS,
+            (m, c, e) => new IndexOutOfBoundsError(m, c, e));
+        this.register(ClientProtocolErrorCodes.INTERRUPTED,
+            (m, c, e) => new InterruptedError(m, c, e));
+        this.register(ClientProtocolErrorCodes.INVALID_ADDRESS,
+            (m, c, e) => new InvalidAddressError(m, c, e));
+        this.register(ClientProtocolErrorCodes.INVALID_CONFIGURATION,
+            (m, c, e) => new InvalidConfigurationError(m, c, e));
+        this.register(ClientProtocolErrorCodes.MEMBER_LEFT,
+            (m, c, e) => new MemberLeftError(m, c, e));
+        this.register(ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE,
+            (m, c, e) => new NegativeArraySizeError(m, c, e));
+        this.register(ClientProtocolErrorCodes.NO_SUCH_ELEMENT,
+            (m, c, e) => new NoSuchElementError(m, c, e));
+        this.register(ClientProtocolErrorCodes.NOT_SERIALIZABLE,
+            (m, c, e) => new IOError(m, c, e));
+        this.register(ClientProtocolErrorCodes.NULL_POINTER,
+            (m, c, e) => new NullPointerError(m, c, e));
+        this.register(ClientProtocolErrorCodes.OPERATION_TIMEOUT,
+            (m, c, e) => new InvocationTimeoutError(m, c, e));
+        this.register(ClientProtocolErrorCodes.PARTITION_MIGRATING,
+            (m, c, e) => new PartitionMigratingError(m, c, e));
+        this.register(ClientProtocolErrorCodes.QUERY,
+            (m, c, e) => new QueryError(m, c, e));
+        this.register(ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED,
+            (m, c, e) => new QueryError(m, c, e));
+        this.register(ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION,
+            (m, c, e) => new SplitBrainProtectionError(m, c, e));
+        this.register(ClientProtocolErrorCodes.REACHED_MAX_SIZE,
+            (m, c, e) => new ReachedMaxSizeError(m, c, e));
+        this.register(ClientProtocolErrorCodes.RETRYABLE_HAZELCAST,
+            (m, c, e) => new RetryableHazelcastError(m, c, e));
+        this.register(ClientProtocolErrorCodes.RETRYABLE_IO,
+            (m, c, e) => new RetryableIOError(m, c, e));
+        this.register(ClientProtocolErrorCodes.SOCKET,
+            (m, c, e) => new IOError(m, c, e));
+        this.register(ClientProtocolErrorCodes.STALE_SEQUENCE,
+            (m, c, e) => new StaleSequenceError(m, c, e));
+        this.register(ClientProtocolErrorCodes.TARGET_DISCONNECTED,
+            (m, c, e) => new TargetDisconnectedError(m, c, e));
+        this.register(ClientProtocolErrorCodes.TARGET_NOT_MEMBER,
+            (m, c, e) => new TargetNotMemberError(m, c, e));
+        this.register(ClientProtocolErrorCodes.TOPIC_OVERLOAD,
+            (m, c, e) => new TopicOverloadError(m, c, e));
+        this.register(ClientProtocolErrorCodes.TRANSACTION,
+            (m, c, e) => new TransactionError(m, c, e));
+        this.register(ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE,
+            (m, c, e) => new TransactionNotActiveError(m, c, e));
+        this.register(ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT,
+            (m, c, e) => new TransactionTimedOutError(m, c, e));
+        this.register(ClientProtocolErrorCodes.UNSUPPORTED_OPERATION,
+            (m, c, e) => new UnsupportedOperationError(m, c, e));
+        this.register(ClientProtocolErrorCodes.NO_DATA_MEMBER,
+            (m, c, e) => new NoDataMemberInClusterError(m, c, e));
+        this.register(ClientProtocolErrorCodes.STALE_TASK_ID,
+            (m, c, e) => new StaleTaskIdError(m, c, e));
+        this.register(ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION,
+            (m, c, e) => new NodeIdOutOfRangeError(m, c, e));
+        this.register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION,
+            (m, c, e) => new ConsistencyLostError(m, c, e));
     }
 
     createErrorFromClientMessage(clientMessage: ClientMessage): Error {
@@ -170,7 +180,7 @@ export class ClientErrorFactory {
         return this.createError(errorHolders, 0);
     }
 
-    createError(errorHolders: ErrorHolder[], errorHolderIdx: number): Error {
+    private createError(errorHolders: ErrorHolder[], errorHolderIdx: number): Error {
         if (errorHolderIdx === errorHolders.length) {
             return null;
         }
@@ -178,7 +188,7 @@ export class ClientErrorFactory {
         const factoryFn = this.codeToErrorConstructor.get(errorHolder.errorCode);
         let error: Error;
         if (factoryFn != null) {
-            error = factoryFn(errorHolder.message, this.createError(errorHolders, errorHolderIdx + 1));
+            error = factoryFn(errorHolder.message, this.createError(errorHolders, errorHolderIdx + 1), errorHolder);
         } else {
             error = new UndefinedErrorCodeError(errorHolder.message, errorHolder.className);
         }

--- a/src/protocol/ErrorFactory.ts
+++ b/src/protocol/ErrorFactory.ts
@@ -66,8 +66,9 @@ import {ClientProtocolErrorCodes} from './ClientProtocolErrorCodes';
 import {ClientMessage} from '../protocol/ClientMessage';
 import {ErrorsCodec} from '../codec/builtin/ErrorsCodec';
 import {ErrorHolder} from './ErrorHolder';
+import {StackTraceElement} from './StackTraceElement';
 
-type ErrorFactory = (msg: string, cause: Error, serverError: ErrorHolder) => Error;
+type ErrorFactory = (msg: string, cause: Error, serverStackTrace: StackTraceElement[]) => Error;
 
 /** @internal */
 export class ClientErrorFactory {
@@ -76,103 +77,103 @@ export class ClientErrorFactory {
 
     constructor() {
         this.register(ClientProtocolErrorCodes.ARRAY_INDEX_OUT_OF_BOUNDS,
-            (m, c, e) => new ArrayIndexOutOfBoundsError(m, c, e));
+            (m, c, s) => new ArrayIndexOutOfBoundsError(m, c, s));
         this.register(ClientProtocolErrorCodes.ARRAY_STORE,
-            (m, c, e) => new ArrayStoreError(m, c, e));
+            (m, c, s) => new ArrayStoreError(m, c, s));
         this.register(ClientProtocolErrorCodes.AUTHENTICATION,
-            (m, c, e) => new AuthenticationError(m, c, e));
+            (m, c, s) => new AuthenticationError(m, c, s));
         this.register(ClientProtocolErrorCodes.CALLER_NOT_MEMBER,
-            (m, c, e) => new CallerNotMemberError(m, c, e));
+            (m, c, s) => new CallerNotMemberError(m, c, s));
         this.register(ClientProtocolErrorCodes.CANCELLATION,
-            (m, c, e) => new CancellationError(m, c, e));
+            (m, c, s) => new CancellationError(m, c, s));
         this.register(ClientProtocolErrorCodes.CLASS_CAST,
-            (m, c, e) => new ClassCastError(m, c, e));
+            (m, c, s) => new ClassCastError(m, c, s));
         this.register(ClientProtocolErrorCodes.CLASS_NOT_FOUND,
-            (m, c, e) => new ClassNotFoundError(m, c, e));
+            (m, c, s) => new ClassNotFoundError(m, c, s));
         this.register(ClientProtocolErrorCodes.CONCURRENT_MODIFICATION,
-            (m, c, e) => new ConcurrentModificationError(m, c, e));
+            (m, c, s) => new ConcurrentModificationError(m, c, s));
         this.register(ClientProtocolErrorCodes.CONFIG_MISMATCH,
-            (m, c, e) => new ConfigMismatchError(m, c, e));
+            (m, c, s) => new ConfigMismatchError(m, c, s));
         this.register(ClientProtocolErrorCodes.DISTRIBUTED_OBJECT_DESTROYED,
-            (m, c, e) => new DistributedObjectDestroyedError(m, c, e));
+            (m, c, s) => new DistributedObjectDestroyedError(m, c, s));
         this.register(ClientProtocolErrorCodes.EOF,
-            (m, c, e) => new IOError(m, c, e));
+            (m, c, s) => new IOError(m, c, s));
         this.register(ClientProtocolErrorCodes.HAZELCAST,
-            (m, c, e) => new HazelcastError(m, c, e));
+            (m, c, s) => new HazelcastError(m, c, s));
         this.register(ClientProtocolErrorCodes.HAZELCAST_INSTANCE_NOT_ACTIVE,
-            (m, c, e) => new HazelcastInstanceNotActiveError(m, c, e));
+            (m, c, s) => new HazelcastInstanceNotActiveError(m, c, s));
         this.register(ClientProtocolErrorCodes.HAZELCAST_OVERLOAD,
-            (m, c, e) => new HazelcastError(m, c, e));
+            (m, c, s) => new HazelcastError(m, c, s));
         this.register(ClientProtocolErrorCodes.HAZELCAST_SERIALIZATION,
-            (m, c, e) => new HazelcastSerializationError(m, c, e));
+            (m, c, s) => new HazelcastSerializationError(m, c, s));
         this.register(ClientProtocolErrorCodes.INDETERMINATE_OPERATION_STATE,
-            (m, c, e) => new IndeterminateOperationStateError(m, c, e));
+            (m, c, s) => new IndeterminateOperationStateError(m, c, s));
         this.register(ClientProtocolErrorCodes.IO,
-            (m, c, e) => new IOError(m, c, e));
+            (m, c, s) => new IOError(m, c, s));
         this.register(ClientProtocolErrorCodes.ILLEGAL_ARGUMENT,
-            (m, c, e) => new IllegalArgumentError(m, c, e));
+            (m, c, s) => new IllegalArgumentError(m, c, s));
         this.register(ClientProtocolErrorCodes.ILLEGAL_STATE,
-            (m, c, e) => new IllegalStateError(m, c, e));
+            (m, c, s) => new IllegalStateError(m, c, s));
         this.register(ClientProtocolErrorCodes.INDEX_OUT_OF_BOUNDS,
-            (m, c, e) => new IndexOutOfBoundsError(m, c, e));
+            (m, c, s) => new IndexOutOfBoundsError(m, c, s));
         this.register(ClientProtocolErrorCodes.INTERRUPTED,
-            (m, c, e) => new InterruptedError(m, c, e));
+            (m, c, s) => new InterruptedError(m, c, s));
         this.register(ClientProtocolErrorCodes.INVALID_ADDRESS,
-            (m, c, e) => new InvalidAddressError(m, c, e));
+            (m, c, s) => new InvalidAddressError(m, c, s));
         this.register(ClientProtocolErrorCodes.INVALID_CONFIGURATION,
-            (m, c, e) => new InvalidConfigurationError(m, c, e));
+            (m, c, s) => new InvalidConfigurationError(m, c, s));
         this.register(ClientProtocolErrorCodes.MEMBER_LEFT,
-            (m, c, e) => new MemberLeftError(m, c, e));
+            (m, c, s) => new MemberLeftError(m, c, s));
         this.register(ClientProtocolErrorCodes.NEGATIVE_ARRAY_SIZE,
-            (m, c, e) => new NegativeArraySizeError(m, c, e));
+            (m, c, s) => new NegativeArraySizeError(m, c, s));
         this.register(ClientProtocolErrorCodes.NO_SUCH_ELEMENT,
-            (m, c, e) => new NoSuchElementError(m, c, e));
+            (m, c, s) => new NoSuchElementError(m, c, s));
         this.register(ClientProtocolErrorCodes.NOT_SERIALIZABLE,
-            (m, c, e) => new IOError(m, c, e));
+            (m, c, s) => new IOError(m, c, s));
         this.register(ClientProtocolErrorCodes.NULL_POINTER,
-            (m, c, e) => new NullPointerError(m, c, e));
+            (m, c, s) => new NullPointerError(m, c, s));
         this.register(ClientProtocolErrorCodes.OPERATION_TIMEOUT,
-            (m, c, e) => new InvocationTimeoutError(m, c, e));
+            (m, c, s) => new InvocationTimeoutError(m, c, s));
         this.register(ClientProtocolErrorCodes.PARTITION_MIGRATING,
-            (m, c, e) => new PartitionMigratingError(m, c, e));
+            (m, c, s) => new PartitionMigratingError(m, c, s));
         this.register(ClientProtocolErrorCodes.QUERY,
-            (m, c, e) => new QueryError(m, c, e));
+            (m, c, s) => new QueryError(m, c, s));
         this.register(ClientProtocolErrorCodes.QUERY_RESULT_SIZE_EXCEEDED,
-            (m, c, e) => new QueryError(m, c, e));
+            (m, c, s) => new QueryError(m, c, s));
         this.register(ClientProtocolErrorCodes.SPLIT_BRAIN_PROTECTION,
-            (m, c, e) => new SplitBrainProtectionError(m, c, e));
+            (m, c, s) => new SplitBrainProtectionError(m, c, s));
         this.register(ClientProtocolErrorCodes.REACHED_MAX_SIZE,
-            (m, c, e) => new ReachedMaxSizeError(m, c, e));
+            (m, c, s) => new ReachedMaxSizeError(m, c, s));
         this.register(ClientProtocolErrorCodes.RETRYABLE_HAZELCAST,
-            (m, c, e) => new RetryableHazelcastError(m, c, e));
+            (m, c, s) => new RetryableHazelcastError(m, c, s));
         this.register(ClientProtocolErrorCodes.RETRYABLE_IO,
-            (m, c, e) => new RetryableIOError(m, c, e));
+            (m, c, s) => new RetryableIOError(m, c, s));
         this.register(ClientProtocolErrorCodes.SOCKET,
-            (m, c, e) => new IOError(m, c, e));
+            (m, c, s) => new IOError(m, c, s));
         this.register(ClientProtocolErrorCodes.STALE_SEQUENCE,
-            (m, c, e) => new StaleSequenceError(m, c, e));
+            (m, c, s) => new StaleSequenceError(m, c, s));
         this.register(ClientProtocolErrorCodes.TARGET_DISCONNECTED,
-            (m, c, e) => new TargetDisconnectedError(m, c, e));
+            (m, c, s) => new TargetDisconnectedError(m, c, s));
         this.register(ClientProtocolErrorCodes.TARGET_NOT_MEMBER,
-            (m, c, e) => new TargetNotMemberError(m, c, e));
+            (m, c, s) => new TargetNotMemberError(m, c, s));
         this.register(ClientProtocolErrorCodes.TOPIC_OVERLOAD,
-            (m, c, e) => new TopicOverloadError(m, c, e));
+            (m, c, s) => new TopicOverloadError(m, c, s));
         this.register(ClientProtocolErrorCodes.TRANSACTION,
-            (m, c, e) => new TransactionError(m, c, e));
+            (m, c, s) => new TransactionError(m, c, s));
         this.register(ClientProtocolErrorCodes.TRANSACTION_NOT_ACTIVE,
-            (m, c, e) => new TransactionNotActiveError(m, c, e));
+            (m, c, s) => new TransactionNotActiveError(m, c, s));
         this.register(ClientProtocolErrorCodes.TRANSACTION_TIMED_OUT,
-            (m, c, e) => new TransactionTimedOutError(m, c, e));
+            (m, c, s) => new TransactionTimedOutError(m, c, s));
         this.register(ClientProtocolErrorCodes.UNSUPPORTED_OPERATION,
-            (m, c, e) => new UnsupportedOperationError(m, c, e));
+            (m, c, s) => new UnsupportedOperationError(m, c, s));
         this.register(ClientProtocolErrorCodes.NO_DATA_MEMBER,
-            (m, c, e) => new NoDataMemberInClusterError(m, c, e));
+            (m, c, s) => new NoDataMemberInClusterError(m, c, s));
         this.register(ClientProtocolErrorCodes.STALE_TASK_ID,
-            (m, c, e) => new StaleTaskIdError(m, c, e));
+            (m, c, s) => new StaleTaskIdError(m, c, s));
         this.register(ClientProtocolErrorCodes.FLAKE_ID_NODE_ID_OUT_OF_RANGE_EXCEPTION,
-            (m, c, e) => new NodeIdOutOfRangeError(m, c, e));
+            (m, c, s) => new NodeIdOutOfRangeError(m, c, s));
         this.register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION,
-            (m, c, e) => new ConsistencyLostError(m, c, e));
+            (m, c, s) => new ConsistencyLostError(m, c, s));
     }
 
     createErrorFromClientMessage(clientMessage: ClientMessage): Error {
@@ -188,7 +189,11 @@ export class ClientErrorFactory {
         const factoryFn = this.codeToErrorConstructor.get(errorHolder.errorCode);
         let error: Error;
         if (factoryFn != null) {
-            error = factoryFn(errorHolder.message, this.createError(errorHolders, errorHolderIdx + 1), errorHolder);
+            error = factoryFn(
+                errorHolder.message,
+                this.createError(errorHolders, errorHolderIdx + 1),
+                errorHolder.stackTraceElements
+            );
         } else {
             error = new UndefinedErrorCodeError(errorHolder.message, errorHolder.className);
         }

--- a/src/protocol/ErrorFactory.ts
+++ b/src/protocol/ErrorFactory.ts
@@ -195,7 +195,12 @@ export class ClientErrorFactory {
                 errorHolder.stackTraceElements
             );
         } else {
-            error = new UndefinedErrorCodeError(errorHolder.message, errorHolder.className);
+            const msg = 'Class name: ' + errorHolder.className + ', Message: ' + errorHolder.message;
+            error = new UndefinedErrorCodeError(
+                msg,
+                this.createError(errorHolders, errorHolderIdx + 1),
+                errorHolder.stackTraceElements
+            );
         }
         return error;
     }

--- a/src/protocol/ErrorHolder.ts
+++ b/src/protocol/ErrorHolder.ts
@@ -16,10 +16,9 @@
 /** @ignore *//** */
 
 import {StackTraceElement} from './StackTraceElement';
-import {ServerError} from '../core';
 
 /** @internal */
-export class ErrorHolder implements ServerError {
+export class ErrorHolder {
 
     errorCode: number;
     className: string;

--- a/src/protocol/ErrorHolder.ts
+++ b/src/protocol/ErrorHolder.ts
@@ -16,9 +16,10 @@
 /** @ignore *//** */
 
 import {StackTraceElement} from './StackTraceElement';
+import {ServerError} from '../core';
 
 /** @internal */
-export class ErrorHolder {
+export class ErrorHolder implements ServerError {
 
     errorCode: number;
     className: string;

--- a/src/protocol/StackTraceElement.ts
+++ b/src/protocol/StackTraceElement.ts
@@ -15,8 +15,11 @@
  */
 /** @ignore *//** */
 
+import {ServerErrorStackElement} from '../core';
+
 /** @internal */
-export class StackTraceElement {
+export class StackTraceElement implements ServerErrorStackElement {
+
     className: string;
     methodName: string;
     fileName: string;

--- a/test/unit/protocol/ClientErrorFactoryTest.js
+++ b/test/unit/protocol/ClientErrorFactoryTest.js
@@ -46,8 +46,8 @@ describe('ClientErrorFactoryTest', function () {
 
         expect(error).to.be.instanceOf(IllegalStateError);
         expect(error.message).to.be.equal('error: foo bar');
-        expect(error.serverError).to.deep.equal(createErrorHolder(code));
         expect(error.cause).to.be.null;
+        expect(error.serverStackTrace).to.deep.equal(createErrorHolder(code).stackTraceElements);
     });
 
     it('createError: should create error with given cause', function () {
@@ -56,12 +56,12 @@ describe('ClientErrorFactoryTest', function () {
 
         expect(error).to.be.instanceOf(IllegalStateError);
         expect(error.message).to.be.equal('error: foo bar');
-        expect(error.serverError).to.deep.equal(createErrorHolder(code));
+        expect(error.serverStackTrace).to.deep.equal(createErrorHolder(code).stackTraceElements);
 
         const cause = error.cause;
         expect(cause).to.be.instanceOf(IllegalStateError);
         expect(cause.message).to.be.equal('error: foo bar');
-        expect(cause.serverError).to.deep.equal(createErrorHolder(code));
+        expect(cause.serverStackTrace).to.deep.equal(createErrorHolder(code).stackTraceElements);
         expect(cause.cause).to.be.null;
     });
 

--- a/test/unit/protocol/ClientErrorFactoryTest.js
+++ b/test/unit/protocol/ClientErrorFactoryTest.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { expect } = require('chai');
+const { IllegalStateError } = require('../../../');
+const { ClientErrorFactory } = require('../../../lib/protocol/ErrorFactory');
+const { ClientProtocolErrorCodes } = require('../../../lib/protocol/ClientProtocolErrorCodes');
+
+describe('ClientErrorFactoryTest', function () {
+
+    const factory = new ClientErrorFactory();
+
+    function createErrorHolder() {
+        return {
+            errorCode: ClientProtocolErrorCodes.ILLEGAL_STATE,
+            className: 'foo.bar.Baz1',
+            message: 'error: foo bar',
+            stackTraceElements: [
+                {
+                    className: 'foo.bar.Baz2',
+                    methodName: 'foobar',
+                    fileName: 'FooBar.java',
+                    lineNumber: 42
+                }
+            ]
+        };
+    }
+
+    it('createError: should create error with no cause', function () {
+        const error = factory.createError([createErrorHolder()], 0);
+
+        expect(error).to.be.instanceOf(IllegalStateError);
+        expect(error.message).to.be.equal('error: foo bar');
+        expect(error.serverError).to.deep.equal(createErrorHolder());
+        expect(error.cause).to.be.null;
+    });
+
+    it('createError: should create error with given cause', function () {
+        const error = factory.createError([createErrorHolder(), createErrorHolder()], 0);
+
+        expect(error).to.be.instanceOf(IllegalStateError);
+        expect(error.message).to.be.equal('error: foo bar');
+        expect(error.serverError).to.deep.equal(createErrorHolder());
+
+        const cause = error.cause;
+        expect(cause).to.be.instanceOf(IllegalStateError);
+        expect(cause.message).to.be.equal('error: foo bar');
+        expect(cause.serverError).to.deep.equal(createErrorHolder());
+        expect(cause.cause).to.be.null;
+    });
+});


### PR DESCRIPTION
Closes #542

* Adds `serverError` property in `HazelcastError` class, so it now contains full information on the server-side error
* Introduces new error classes to be used in `ClientErrorFactory`
* Adds new `ClientErrorFactoryTest`