### PR TITLE
[CP Subsystem] Add AtomicLong support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1462,6 +1462,8 @@ Hazelcast IMDG 4.0 introduces CP concurrency primitives with respect to the [CAP
 
 Before using Atomic Long, Lock, and Semaphore, CP Subsystem has to be enabled on cluster-side. Refer to [CP Subsystem](https://docs.hazelcast.org/docs/latest/manual/html-single/#cp-subsystem) documentation for more information.
 
+> **NOTE: If you call the `DistributedObject.destroy()` method on a CP data structure, that data structure is terminated on the underlying CP group and cannot be reinitialized until the CP group is force-destroyed on the cluster side. For this reason, please make sure that you are completely done with a CP data structure before destroying its proxy.**
+
 ### 7.4.11.1. Using Atomic Long
 
 Hazelcast `IAtomicLong` is the distributed implementation of atomic 64-bit integer counter. It offers various atomic operations such as `get`, `set`, `getAndSet`, `compareAndSet` and `incrementAndGet`. This data structure is a part of CP Subsystem.
@@ -1480,6 +1482,8 @@ await atomicLong.addAndGet(42);
 const result = atomicLong.compareAndSet(42, 0);
 console.log('CAS operation result:', result);
 ```
+
+`IAtomicLong` implementation does not offer exactly-once / effectively-once execution semantics. It goes with at-least-once execution semantics by default and can cause an API call to be committed multiple times in case of CP member failures. It can be tuned to offer at-most-once execution semantics. Please see [`fail-on-indeterminate-operation-state`](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#cp-subsystem-configuration) server-side setting.
 
 ### 7.4.11.2. Using Lock and Semaphore
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1464,7 +1464,7 @@ Before using Atomic Long, Lock, and Semaphore, CP Subsystem has to be enabled on
 
 > **NOTE: If you call the `DistributedObject.destroy()` method on a CP data structure, that data structure is terminated on the underlying CP group and cannot be reinitialized until the CP group is force-destroyed on the cluster side. For this reason, please make sure that you are completely done with a CP data structure before destroying its proxy.**
 
-### 7.4.11.1. Using Atomic Long
+#### 7.4.11.1. Using Atomic Long
 
 Hazelcast `IAtomicLong` is the distributed implementation of atomic 64-bit integer counter. It offers various atomic operations such as `get`, `set`, `getAndSet`, `compareAndSet` and `incrementAndGet`. This data structure is a part of CP Subsystem.
 
@@ -1485,7 +1485,7 @@ console.log('CAS operation result:', result);
 
 `IAtomicLong` implementation does not offer exactly-once / effectively-once execution semantics. It goes with at-least-once execution semantics by default and can cause an API call to be committed multiple times in case of CP member failures. It can be tuned to offer at-most-once execution semantics. Please see [`fail-on-indeterminate-operation-state`](https://docs.hazelcast.org/docs/latest/manual/html-single/index.html#cp-subsystem-configuration) server-side setting.
 
-### 7.4.11.2. Using Lock and Semaphore
+#### 7.4.11.2. Using Lock and Semaphore
 
 These new implementations are accessed using the [CP Subsystem](https://docs.hazelcast.org/docs/latest/manual/html-single/#cp-subsystem) which cannot be used with the Node.js client yet. We plan to implement these data structures in the upcoming 4.0 release of Hazelcast Node.js client. In the meantime, since there is no way to access old non-CP primitives using IMDG 4.x, we removed their implementations, code samples and documentations. They will be back once we implement them.
 

--- a/code_samples/atomic_long.js
+++ b/code_samples/atomic_long.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { Client } = require('hazelcast-client');
+
+(async () => {
+    try {
+        const client = await Client.newHazelcastClient();
+
+        const viewCounter = await client.getAtomicLong('views');
+        const value = await viewCounter.get();
+        console.log('Value:', value);
+        const newValue = await viewCounter.addAndGet(42);
+        console.log('New value:', newValue);
+
+        client.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/code_samples/org-website/AtomicLongSample.js
+++ b/code_samples/org-website/AtomicLongSample.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { Client } = require('hazelcast-client');
+
+(async () => {
+    try {
+        // Start the Hazelcast Client and connect to an already running
+        // Hazelcast Cluster on 127.0.0.1
+        // Note: CP Subsystem has to be enabled on the cluster
+        const hz = await Client.newHazelcastClient();
+        // Get the AtomicLong counter from Cluster
+        const counter = await hz.getAtomicLong('counter');
+        // Add and get the counter
+        const value = await counter.addAndGet(3);
+        console.log('Counter value is', value);
+        // Shutdown this Hazelcast client
+        hz.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -49,7 +49,7 @@ import {
     IAtomicLong
 } from './proxy';
 import {ProxyManager, NAMESPACE_SEPARATOR} from './proxy/ProxyManager';
-import {ClientRaftProxyFactory} from './proxy/cpsubsystem/ClientRaftProxyFactory';
+import {CPProxyManager} from './proxy/cpsubsystem/CPProxyManager';
 import {LockReferenceIdGenerator} from './proxy/LockReferenceIdGenerator';
 import {SerializationService, SerializationServiceV1} from './serialization/SerializationService';
 import {AddressProvider} from './connection/AddressProvider';
@@ -101,7 +101,7 @@ export class HazelcastClient {
     /** @internal */
     private readonly proxyManager: ProxyManager;
     /** @internal */
-    private readonly cpProxyFactory: ClientRaftProxyFactory;
+    private readonly cpProxyManager: CPProxyManager;
     /** @internal */
     private readonly nearCacheManager: NearCacheManager;
     /** @internal */
@@ -133,7 +133,7 @@ export class HazelcastClient {
         this.addressProvider = this.createAddressProvider();
         this.connectionManager = new ClientConnectionManager(this);
         this.invocationService = new InvocationService(this);
-        this.cpProxyFactory = new ClientRaftProxyFactory(this);
+        this.cpProxyManager = new CPProxyManager(this);
         this.proxyManager = new ProxyManager(this);
         this.clusterService = new ClusterService(this);
         this.lifecycleService = new LifecycleServiceImpl(this);
@@ -315,7 +315,7 @@ export class HazelcastClient {
      * @returns {Promise<PNCounter>}
      */
     getAtomicLong(name: string): Promise<IAtomicLong> {
-        return this.cpProxyFactory.getOrCreateProxy(name, ClientRaftProxyFactory.ATOMIC_LONG_SERVICE) as Promise<IAtomicLong>;
+        return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.ATOMIC_LONG_SERVICE) as Promise<IAtomicLong>;
     }
 
     /**

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -45,9 +45,11 @@ import {
     MultiMap,
     ReplicatedMap,
     Ringbuffer,
-    PNCounter
+    PNCounter,
+    IAtomicLong
 } from './proxy';
 import {ProxyManager, NAMESPACE_SEPARATOR} from './proxy/ProxyManager';
+import {ClientRaftProxyFactory} from './proxy/cpsubsystem/ClientRaftProxyFactory';
 import {LockReferenceIdGenerator} from './proxy/LockReferenceIdGenerator';
 import {SerializationService, SerializationServiceV1} from './serialization/SerializationService';
 import {AddressProvider} from './connection/AddressProvider';
@@ -98,6 +100,8 @@ export class HazelcastClient {
     private readonly lifecycleService: LifecycleServiceImpl;
     /** @internal */
     private readonly proxyManager: ProxyManager;
+    /** @internal */
+    private readonly cpProxyFactory: ClientRaftProxyFactory;
     /** @internal */
     private readonly nearCacheManager: NearCacheManager;
     /** @internal */
@@ -295,6 +299,22 @@ export class HazelcastClient {
      */
     getPNCounter(name: string): Promise<PNCounter> {
         return this.proxyManager.getOrCreateProxy(name, ProxyManager.PNCOUNTER_SERVICE) as Promise<PNCounter>;
+    }
+
+    /**
+     * Returns the distributed AtomicLong instance with given name.
+     * The instance is created on CP Subsystem.
+     *
+     * If no group name is given within the `name` argument, then the
+     * AtomicLong instance will be created on the DEFAULT CP group.
+     * If a group name is given, like `.getAtomicLong('myLong@group1')`,
+     * the given group will be initialized first, if not initialized
+     * already, and then the instance will be created on this group.
+     * @param name
+     * @returns {Promise<PNCounter>}
+     */
+    getAtomicLong(name: string): Promise<IAtomicLong> {
+        return this.cpProxyFactory.getOrCreateProxy(name, ProxyManager.PNCOUNTER_SERVICE) as Promise<IAtomicLong>;
     }
 
     /**

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -133,6 +133,7 @@ export class HazelcastClient {
         this.addressProvider = this.createAddressProvider();
         this.connectionManager = new ClientConnectionManager(this);
         this.invocationService = new InvocationService(this);
+        this.cpProxyFactory = new ClientRaftProxyFactory(this);
         this.proxyManager = new ProxyManager(this);
         this.clusterService = new ClusterService(this);
         this.lifecycleService = new LifecycleServiceImpl(this);
@@ -314,7 +315,7 @@ export class HazelcastClient {
      * @returns {Promise<PNCounter>}
      */
     getAtomicLong(name: string): Promise<IAtomicLong> {
-        return this.cpProxyFactory.getOrCreateProxy(name, ProxyManager.PNCOUNTER_SERVICE) as Promise<IAtomicLong>;
+        return this.cpProxyFactory.getOrCreateProxy(name, ClientRaftProxyFactory.ATOMIC_LONG_SERVICE) as Promise<IAtomicLong>;
     }
 
     /**

--- a/src/codec/AtomicLongAddAndGetCodec.ts
+++ b/src/codec/AtomicLongAddAndGetCodec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x090300
+const REQUEST_MESSAGE_TYPE = 590592;
+// hex: 0x090301
+// RESPONSE_MESSAGE_TYPE = 590593
+
+const REQUEST_DELTA_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_DELTA_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongAddAndGetResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class AtomicLongAddAndGetCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, delta: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(false);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_DELTA_OFFSET, delta);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongAddAndGetResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as AtomicLongAddAndGetResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/AtomicLongAlterCodec.ts
+++ b/src/codec/AtomicLongAlterCodec.ts
@@ -41,7 +41,7 @@ export interface AtomicLongAlterResponseParams {
 
 /** @internal */
 export class AtomicLongAlterCodec {
-    static encodeRequest(groupId: RaftGroupId, name: string, function: Data, returnValueType: number): ClientMessage {
+    static encodeRequest(groupId: RaftGroupId, name: string, _function: Data, returnValueType: number): ClientMessage {
         const clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
 
@@ -53,7 +53,7 @@ export class AtomicLongAlterCodec {
 
         RaftGroupIdCodec.encode(clientMessage, groupId);
         StringCodec.encode(clientMessage, name);
-        DataCodec.encode(clientMessage, function);
+        DataCodec.encode(clientMessage, _function);
         return clientMessage;
     }
 

--- a/src/codec/AtomicLongAlterCodec.ts
+++ b/src/codec/AtomicLongAlterCodec.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+import {Data} from '../serialization/Data';
+import {DataCodec} from './builtin/DataCodec';
+import * as Long from 'long';
+
+// hex: 0x090200
+const REQUEST_MESSAGE_TYPE = 590336;
+// hex: 0x090201
+// RESPONSE_MESSAGE_TYPE = 590337
+
+const REQUEST_RETURN_VALUE_TYPE_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_RETURN_VALUE_TYPE_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongAlterResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class AtomicLongAlterCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, function: Data, returnValueType: number): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(false);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeInt(initialFrame.content, REQUEST_RETURN_VALUE_TYPE_OFFSET, returnValueType);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        DataCodec.encode(clientMessage, function);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongAlterResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as AtomicLongAlterResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/AtomicLongApplyCodec.ts
+++ b/src/codec/AtomicLongApplyCodec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {ClientMessage, Frame, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+import {Data} from '../serialization/Data';
+import {DataCodec} from './builtin/DataCodec';
+import {CodecUtil} from './builtin/CodecUtil';
+
+// hex: 0x090100
+const REQUEST_MESSAGE_TYPE = 590080;
+// hex: 0x090101
+// RESPONSE_MESSAGE_TYPE = 590081
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongApplyResponseParams {
+    response: Data;
+}
+
+/** @internal */
+export class AtomicLongApplyCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, function: Data): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(false);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        DataCodec.encode(clientMessage, function);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongApplyResponseParams {
+        // empty initial frame
+        clientMessage.nextFrame();
+
+        const response = {} as AtomicLongApplyResponseParams;
+        response.response = CodecUtil.decodeNullable(clientMessage, DataCodec.decode);
+
+        return response;
+    }
+}

--- a/src/codec/AtomicLongApplyCodec.ts
+++ b/src/codec/AtomicLongApplyCodec.ts
@@ -38,7 +38,7 @@ export interface AtomicLongApplyResponseParams {
 
 /** @internal */
 export class AtomicLongApplyCodec {
-    static encodeRequest(groupId: RaftGroupId, name: string, function: Data): ClientMessage {
+    static encodeRequest(groupId: RaftGroupId, name: string, _function: Data): ClientMessage {
         const clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable(false);
 
@@ -49,7 +49,7 @@ export class AtomicLongApplyCodec {
 
         RaftGroupIdCodec.encode(clientMessage, groupId);
         StringCodec.encode(clientMessage, name);
-        DataCodec.encode(clientMessage, function);
+        DataCodec.encode(clientMessage, _function);
         return clientMessage;
     }
 

--- a/src/codec/AtomicLongCompareAndSetCodec.ts
+++ b/src/codec/AtomicLongCompareAndSetCodec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x090400
+const REQUEST_MESSAGE_TYPE = 590848;
+// hex: 0x090401
+// RESPONSE_MESSAGE_TYPE = 590849
+
+const REQUEST_EXPECTED_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_UPDATED_OFFSET = REQUEST_EXPECTED_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_UPDATED_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongCompareAndSetResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class AtomicLongCompareAndSetCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, expected: Long, updated: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(false);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_EXPECTED_OFFSET, expected);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_UPDATED_OFFSET, updated);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongCompareAndSetResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as AtomicLongCompareAndSetResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/AtomicLongGetAndAddCodec.ts
+++ b/src/codec/AtomicLongGetAndAddCodec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x090600
+const REQUEST_MESSAGE_TYPE = 591360;
+// hex: 0x090601
+// RESPONSE_MESSAGE_TYPE = 591361
+
+const REQUEST_DELTA_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_DELTA_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongGetAndAddResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class AtomicLongGetAndAddCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, delta: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(false);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_DELTA_OFFSET, delta);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongGetAndAddResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as AtomicLongGetAndAddResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/AtomicLongGetAndSetCodec.ts
+++ b/src/codec/AtomicLongGetAndSetCodec.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x090700
+const REQUEST_MESSAGE_TYPE = 591616;
+// hex: 0x090701
+// RESPONSE_MESSAGE_TYPE = 591617
+
+const REQUEST_NEW_VALUE_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_NEW_VALUE_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongGetAndSetResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class AtomicLongGetAndSetCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, newValue: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(false);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_NEW_VALUE_OFFSET, newValue);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongGetAndSetResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as AtomicLongGetAndSetResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/AtomicLongGetCodec.ts
+++ b/src/codec/AtomicLongGetCodec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+import * as Long from 'long';
+
+// hex: 0x090500
+const REQUEST_MESSAGE_TYPE = 591104;
+// hex: 0x090501
+// RESPONSE_MESSAGE_TYPE = 591105
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface AtomicLongGetResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class AtomicLongGetCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): AtomicLongGetResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as AtomicLongGetResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/CPGroupCreateCPGroupCodec.ts
+++ b/src/codec/CPGroupCreateCPGroupCodec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {ClientMessage, Frame, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {StringCodec} from './builtin/StringCodec';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+
+// hex: 0x1E0100
+const REQUEST_MESSAGE_TYPE = 1966336;
+// hex: 0x1E0101
+// RESPONSE_MESSAGE_TYPE = 1966337
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+
+/** @internal */
+export interface CPGroupCreateCPGroupResponseParams {
+    groupId: RaftGroupId;
+}
+
+/** @internal */
+export class CPGroupCreateCPGroupCodec {
+    static encodeRequest(proxyName: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        StringCodec.encode(clientMessage, proxyName);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): CPGroupCreateCPGroupResponseParams {
+        // empty initial frame
+        clientMessage.nextFrame();
+
+        const response = {} as CPGroupCreateCPGroupResponseParams;
+        response.groupId = RaftGroupIdCodec.decode(clientMessage);
+
+        return response;
+    }
+}

--- a/src/codec/CPGroupDestroyCPObjectCodec.ts
+++ b/src/codec/CPGroupDestroyCPObjectCodec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {ClientMessage, Frame, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x1E0200
+const REQUEST_MESSAGE_TYPE = 1966592;
+// hex: 0x1E0201
+// RESPONSE_MESSAGE_TYPE = 1966593
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+
+/** @internal */
+export class CPGroupDestroyCPObjectCodec {
+    static encodeRequest(groupId: RaftGroupId, serviceName: string, objectName: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, serviceName);
+        StringCodec.encode(clientMessage, objectName);
+        return clientMessage;
+    }
+}

--- a/src/codec/CPSessionCloseSessionCodec.ts
+++ b/src/codec/CPSessionCloseSessionCodec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+
+// hex: 0x1F0200
+const REQUEST_MESSAGE_TYPE = 2032128;
+// hex: 0x1F0201
+// RESPONSE_MESSAGE_TYPE = 2032129
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface CPSessionCloseSessionResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class CPSessionCloseSessionCodec {
+    static encodeRequest(groupId: RaftGroupId, sessionId: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): CPSessionCloseSessionResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as CPSessionCloseSessionResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/CPSessionCreateSessionCodec.ts
+++ b/src/codec/CPSessionCreateSessionCodec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+import * as Long from 'long';
+
+// hex: 0x1F0100
+const REQUEST_MESSAGE_TYPE = 2031872;
+// hex: 0x1F0101
+// RESPONSE_MESSAGE_TYPE = 2031873
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_SESSION_ID_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+const RESPONSE_TTL_MILLIS_OFFSET = RESPONSE_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_HEARTBEAT_MILLIS_OFFSET = RESPONSE_TTL_MILLIS_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+
+/** @internal */
+export interface CPSessionCreateSessionResponseParams {
+    sessionId: Long;
+    ttlMillis: Long;
+    heartbeatMillis: Long;
+}
+
+/** @internal */
+export class CPSessionCreateSessionCodec {
+    static encodeRequest(groupId: RaftGroupId, endpointName: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, endpointName);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): CPSessionCreateSessionResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as CPSessionCreateSessionResponseParams;
+        response.sessionId = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_SESSION_ID_OFFSET);
+        response.ttlMillis = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_TTL_MILLIS_OFFSET);
+        response.heartbeatMillis = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_HEARTBEAT_MILLIS_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/CPSessionGenerateThreadIdCodec.ts
+++ b/src/codec/CPSessionGenerateThreadIdCodec.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import * as Long from 'long';
+
+// hex: 0x1F0400
+const REQUEST_MESSAGE_TYPE = 2032640;
+// hex: 0x1F0401
+// RESPONSE_MESSAGE_TYPE = 2032641
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface CPSessionGenerateThreadIdResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class CPSessionGenerateThreadIdCodec {
+    static encodeRequest(groupId: RaftGroupId): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): CPSessionGenerateThreadIdResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as CPSessionGenerateThreadIdResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/CPSessionHeartbeatSessionCodec.ts
+++ b/src/codec/CPSessionHeartbeatSessionCodec.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+
+// hex: 0x1F0300
+const REQUEST_MESSAGE_TYPE = 2032384;
+// hex: 0x1F0301
+// RESPONSE_MESSAGE_TYPE = 2032385
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+
+/** @internal */
+export class CPSessionHeartbeatSessionCodec {
+    static encodeRequest(groupId: RaftGroupId, sessionId: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        return clientMessage;
+    }
+}

--- a/src/codec/FencedLockGetLockOwnershipCodec.ts
+++ b/src/codec/FencedLockGetLockOwnershipCodec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+import * as Long from 'long';
+
+// hex: 0x070400
+const REQUEST_MESSAGE_TYPE = 459776;
+// hex: 0x070401
+// RESPONSE_MESSAGE_TYPE = 459777
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_FENCE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+const RESPONSE_LOCK_COUNT_OFFSET = RESPONSE_FENCE_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_SESSION_ID_OFFSET = RESPONSE_LOCK_COUNT_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_THREAD_ID_OFFSET = RESPONSE_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+
+/** @internal */
+export interface FencedLockGetLockOwnershipResponseParams {
+    fence: Long;
+    lockCount: number;
+    sessionId: Long;
+    threadId: Long;
+}
+
+/** @internal */
+export class FencedLockGetLockOwnershipCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): FencedLockGetLockOwnershipResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as FencedLockGetLockOwnershipResponseParams;
+        response.fence = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_FENCE_OFFSET);
+        response.lockCount = FixSizedTypesCodec.decodeInt(initialFrame.content, RESPONSE_LOCK_COUNT_OFFSET);
+        response.sessionId = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_SESSION_ID_OFFSET);
+        response.threadId = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_THREAD_ID_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/FencedLockLockCodec.ts
+++ b/src/codec/FencedLockLockCodec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x070100
+const REQUEST_MESSAGE_TYPE = 459008;
+// hex: 0x070101
+// RESPONSE_MESSAGE_TYPE = 459009
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface FencedLockLockResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class FencedLockLockCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): FencedLockLockResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as FencedLockLockResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/FencedLockTryLockCodec.ts
+++ b/src/codec/FencedLockTryLockCodec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x070200
+const REQUEST_MESSAGE_TYPE = 459264;
+// hex: 0x070201
+// RESPONSE_MESSAGE_TYPE = 459265
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_TIMEOUT_MS_OFFSET = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_TIMEOUT_MS_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface FencedLockTryLockResponseParams {
+    response: Long;
+}
+
+/** @internal */
+export class FencedLockTryLockCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID, timeoutMs: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_TIMEOUT_MS_OFFSET, timeoutMs);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): FencedLockTryLockResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as FencedLockTryLockResponseParams;
+        response.response = FixSizedTypesCodec.decodeLong(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/FencedLockUnlockCodec.ts
+++ b/src/codec/FencedLockUnlockCodec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x070300
+const REQUEST_MESSAGE_TYPE = 459520;
+// hex: 0x070301
+// RESPONSE_MESSAGE_TYPE = 459521
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface FencedLockUnlockResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class FencedLockUnlockCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): FencedLockUnlockResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as FencedLockUnlockResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreAcquireCodec.ts
+++ b/src/codec/SemaphoreAcquireCodec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0200
+const REQUEST_MESSAGE_TYPE = 786944;
+// hex: 0x0C0201
+// RESPONSE_MESSAGE_TYPE = 786945
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_PERMITS_OFFSET = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const REQUEST_TIMEOUT_MS_OFFSET = REQUEST_PERMITS_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_TIMEOUT_MS_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreAcquireResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class SemaphoreAcquireCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID, permits: number, timeoutMs: Long): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        FixSizedTypesCodec.encodeInt(initialFrame.content, REQUEST_PERMITS_OFFSET, permits);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_TIMEOUT_MS_OFFSET, timeoutMs);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreAcquireResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreAcquireResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreAvailablePermitsCodec.ts
+++ b/src/codec/SemaphoreAvailablePermitsCodec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0600
+const REQUEST_MESSAGE_TYPE = 787968;
+// hex: 0x0C0601
+// RESPONSE_MESSAGE_TYPE = 787969
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreAvailablePermitsResponseParams {
+    response: number;
+}
+
+/** @internal */
+export class SemaphoreAvailablePermitsCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreAvailablePermitsResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreAvailablePermitsResponseParams;
+        response.response = FixSizedTypesCodec.decodeInt(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreChangeCodec.ts
+++ b/src/codec/SemaphoreChangeCodec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0500
+const REQUEST_MESSAGE_TYPE = 787712;
+// hex: 0x0C0501
+// RESPONSE_MESSAGE_TYPE = 787713
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_PERMITS_OFFSET = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_PERMITS_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreChangeResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class SemaphoreChangeCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID, permits: number): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        FixSizedTypesCodec.encodeInt(initialFrame.content, REQUEST_PERMITS_OFFSET, permits);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreChangeResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreChangeResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreDrainCodec.ts
+++ b/src/codec/SemaphoreDrainCodec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0400
+const REQUEST_MESSAGE_TYPE = 787456;
+// hex: 0x0C0401
+// RESPONSE_MESSAGE_TYPE = 787457
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreDrainResponseParams {
+    response: number;
+}
+
+/** @internal */
+export class SemaphoreDrainCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreDrainResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreDrainResponseParams;
+        response.response = FixSizedTypesCodec.decodeInt(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreGetSemaphoreTypeCodec.ts
+++ b/src/codec/SemaphoreGetSemaphoreTypeCodec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0700
+const REQUEST_MESSAGE_TYPE = 788224;
+// hex: 0x0C0701
+// RESPONSE_MESSAGE_TYPE = 788225
+
+const REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreGetSemaphoreTypeResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class SemaphoreGetSemaphoreTypeCodec {
+    static encodeRequest(proxyName: string): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        StringCodec.encode(clientMessage, proxyName);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreGetSemaphoreTypeResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreGetSemaphoreTypeResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreInitCodec.ts
+++ b/src/codec/SemaphoreInitCodec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0100
+const REQUEST_MESSAGE_TYPE = 786688;
+// hex: 0x0C0101
+// RESPONSE_MESSAGE_TYPE = 786689
+
+const REQUEST_PERMITS_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_PERMITS_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreInitResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class SemaphoreInitCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, permits: number): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeInt(initialFrame.content, REQUEST_PERMITS_OFFSET, permits);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreInitResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreInitResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/SemaphoreReleaseCodec.ts
+++ b/src/codec/SemaphoreReleaseCodec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {BitsUtil} from '../util/BitsUtil';
+import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';
+import {ClientMessage, Frame, RESPONSE_BACKUP_ACKS_OFFSET, PARTITION_ID_OFFSET} from '../protocol/ClientMessage';
+import * as Long from 'long';
+import {UUID} from '../core/UUID';
+import {RaftGroupId} from '../proxy/cpsubsystem/RaftGroupId';
+import {RaftGroupIdCodec} from './custom/RaftGroupIdCodec';
+import {StringCodec} from './builtin/StringCodec';
+
+// hex: 0x0C0300
+const REQUEST_MESSAGE_TYPE = 787200;
+// hex: 0x0C0301
+// RESPONSE_MESSAGE_TYPE = 787201
+
+const REQUEST_SESSION_ID_OFFSET = PARTITION_ID_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const REQUEST_THREAD_ID_OFFSET = REQUEST_SESSION_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_INVOCATION_UID_OFFSET = REQUEST_THREAD_ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const REQUEST_PERMITS_OFFSET = REQUEST_INVOCATION_UID_OFFSET + BitsUtil.UUID_SIZE_IN_BYTES;
+const REQUEST_INITIAL_FRAME_SIZE = REQUEST_PERMITS_OFFSET + BitsUtil.INT_SIZE_IN_BYTES;
+const RESPONSE_RESPONSE_OFFSET = RESPONSE_BACKUP_ACKS_OFFSET + BitsUtil.BYTE_SIZE_IN_BYTES;
+
+/** @internal */
+export interface SemaphoreReleaseResponseParams {
+    response: boolean;
+}
+
+/** @internal */
+export class SemaphoreReleaseCodec {
+    static encodeRequest(groupId: RaftGroupId, name: string, sessionId: Long, threadId: Long, invocationUid: UUID, permits: number): ClientMessage {
+        const clientMessage = ClientMessage.createForEncode();
+        clientMessage.setRetryable(true);
+
+        const initialFrame = Frame.createInitialFrame(REQUEST_INITIAL_FRAME_SIZE);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_SESSION_ID_OFFSET, sessionId);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, REQUEST_THREAD_ID_OFFSET, threadId);
+        FixSizedTypesCodec.encodeUUID(initialFrame.content, REQUEST_INVOCATION_UID_OFFSET, invocationUid);
+        FixSizedTypesCodec.encodeInt(initialFrame.content, REQUEST_PERMITS_OFFSET, permits);
+        clientMessage.addFrame(initialFrame);
+        clientMessage.setMessageType(REQUEST_MESSAGE_TYPE);
+        clientMessage.setPartitionId(-1);
+
+        RaftGroupIdCodec.encode(clientMessage, groupId);
+        StringCodec.encode(clientMessage, name);
+        return clientMessage;
+    }
+
+    static decodeResponse(clientMessage: ClientMessage): SemaphoreReleaseResponseParams {
+        const initialFrame = clientMessage.nextFrame();
+
+        const response = {} as SemaphoreReleaseResponseParams;
+        response.response = FixSizedTypesCodec.decodeBoolean(initialFrame.content, RESPONSE_RESPONSE_OFFSET);
+
+        return response;
+    }
+}

--- a/src/codec/custom/RaftGroupIdCodec.ts
+++ b/src/codec/custom/RaftGroupIdCodec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable max-len */
+import {FixSizedTypesCodec} from '../builtin/FixSizedTypesCodec';
+import {BitsUtil} from '../../util/BitsUtil';
+import {ClientMessage, BEGIN_FRAME, END_FRAME, Frame, DEFAULT_FLAGS} from '../../protocol/ClientMessage';
+import {CodecUtil} from '../builtin/CodecUtil';
+import {RaftGroupId} from '../../proxy/cpsubsystem/RaftGroupId';
+import {StringCodec} from '../builtin/StringCodec';
+
+const SEED_OFFSET = 0;
+const ID_OFFSET = SEED_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+const INITIAL_FRAME_SIZE = ID_OFFSET + BitsUtil.LONG_SIZE_IN_BYTES;
+
+/** @internal */
+export class RaftGroupIdCodec {
+    static encode(clientMessage: ClientMessage, raftGroupId: RaftGroupId): void {
+        clientMessage.addFrame(BEGIN_FRAME.copy());
+
+        const initialFrame = Frame.createInitialFrame(INITIAL_FRAME_SIZE, DEFAULT_FLAGS);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, SEED_OFFSET, raftGroupId.seed);
+        FixSizedTypesCodec.encodeLong(initialFrame.content, ID_OFFSET, raftGroupId.id);
+        clientMessage.addFrame(initialFrame);
+
+        StringCodec.encode(clientMessage, raftGroupId.name);
+
+        clientMessage.addFrame(END_FRAME.copy());
+    }
+
+    static decode(clientMessage: ClientMessage): RaftGroupId {
+        // begin frame
+        clientMessage.nextFrame();
+
+        const initialFrame = clientMessage.nextFrame();
+        const seed = FixSizedTypesCodec.decodeLong(initialFrame.content, SEED_OFFSET);
+        const id = FixSizedTypesCodec.decodeLong(initialFrame.content, ID_OFFSET);
+
+        const name = StringCodec.decode(clientMessage);
+
+        CodecUtil.fastForwardToEndFrame(clientMessage);
+
+        return new RaftGroupId(name, seed, id);
+    }
+}

--- a/src/proxy/BaseProxy.ts
+++ b/src/proxy/BaseProxy.ts
@@ -26,7 +26,7 @@ import {UUID} from '../core/UUID';
  * Common super class for any proxy.
  * @internal
  */
-export class BaseProxy {
+export abstract class BaseProxy {
 
     protected client: HazelcastClient;
     protected readonly name: string;

--- a/src/proxy/BaseProxy.ts
+++ b/src/proxy/BaseProxy.ts
@@ -42,40 +42,20 @@ export class BaseProxy {
         return this.name;
     }
 
-    /**
-     * Returns name of the proxy.
-     * @returns
-     */
     getName(): string {
         return this.name;
     }
 
-    /**
-     * Returns name of the service which this proxy belongs to.
-     * Refer to service field of {@link ProxyManager} for service names.
-     * @returns
-     */
     getServiceName(): string {
         return this.serviceName;
     }
 
-    /**
-     * Deletes the proxy object and frees allocated resources on cluster.
-     * @returns
-     */
     destroy(): Promise<void> {
         return this.client.getProxyManager().destroyProxy(this.name, this.serviceName).then(() => {
             return this.postDestroy();
         });
     }
 
-    /**
-     * Destroys this client proxy instance locally without issuing distributed
-     * object destroy request to the cluster as the destroy method does.
-     * <p>
-     * The local destruction operation still may perform some communication
-     * with the cluster; for example, to unregister remote event subscriptions.
-     */
     destroyLocally(): Promise<void> {
         return this.postDestroy();
     }

--- a/src/proxy/FlakeIdGenerator.ts
+++ b/src/proxy/FlakeIdGenerator.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import * as Promise from 'bluebird';
+import * as Long from 'long';
+import {DistributedObject} from '../core/DistributedObject';
+
 /**
  * A cluster-wide unique ID generator. Generated IDs are `Long` primitive values
  * and are k-ordered (roughly ordered). IDs are in the range from `0` to `Long.MAX_VALUE`.
@@ -36,10 +40,6 @@
  * nodeId will be assigned from zero again. Uniqueness after the restart will be preserved thanks to
  * the timestamp component.
  */
-import * as Promise from 'bluebird';
-import * as Long from 'long';
-import {DistributedObject} from '../core/DistributedObject';
-
 export interface FlakeIdGenerator extends DistributedObject {
 
     /**

--- a/src/proxy/IAtomicLong.ts
+++ b/src/proxy/IAtomicLong.ts
@@ -31,8 +31,7 @@ import {DistributedObject} from '../core';
  * execution semantics. It goes with at-least-once execution semantics
  * by default and can cause an API call to be committed multiple times
  * in case of CP member failures. It can be tuned to offer at-most-once
- * execution semantics. Please see
- * `CPSubsystemConfig#setFailOnIndeterminateOperationState(boolean)`
+ * execution semantics. Please see `fail-on-indeterminate-operation-state`
  * server-side setting.
  */
 export interface IAtomicLong extends DistributedObject {

--- a/src/proxy/IAtomicLong.ts
+++ b/src/proxy/IAtomicLong.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Promise from 'bluebird';
+import * as Long from 'long';
+import {DistributedObject} from '../core';
+
+/**
+ * IAtomicLong is a redundant and highly available distributed counter
+ * for 64-bit integers (`long` type in java).
+ *
+ * It works on top of the Raft consensus algorithm. It offers linearizability
+ * during crash failures and network partitions. It is CP with respect to
+ * the CAP principle. If a network partition occurs, it remains available
+ * on at most one side of the partition.
+ *
+ * IAtomicLong implementation does not offer exactly-once / effectively-once
+ * execution semantics. It goes with at-least-once execution semantics
+ * by default and can cause an API call to be committed multiple times
+ * in case of CP member failures. It can be tuned to offer at-most-once
+ * execution semantics. Please see
+ * `CPSubsystemConfig#setFailOnIndeterminateOperationState(boolean)`
+ * server-side setting.
+ */
+export interface IAtomicLong extends DistributedObject {
+
+    /**
+     * Atomically adds the given value to the current value.
+     *
+     * @param delta the value to add to the current value
+     * @returns the updated value, the given value added to the current value
+     */
+    addAndGet(delta: Long | number): Promise<Long>;
+
+    /**
+     * Atomically sets the value to the given updated value
+     * only if the current value equals the expected value.
+     *
+     * @param expect the expected value
+     * @param update the new value
+     * @returns `true` if successful; or `false` if the actual value
+     * was not equal to the expected value.
+     */
+    compareAndSet(expect: Long | number, update: Long | number): Promise<boolean>;
+
+    /**
+     * Atomically decrements the current value by one.
+     *
+     * @returns the updated value, the current value decremented by one
+     */
+    decrementAndGet(): Promise<Long>;
+
+    /**
+     * Gets the current value.
+     *
+     * @returns the current value
+     */
+    get(): Promise<Long>;
+
+    /**
+     * Atomically adds the given value to the current value.
+     *
+     * @param delta the value to add to the current value
+     * @returns the old value before the add
+     */
+    getAndAdd(delta: Long | number): Promise<Long>;
+
+    /**
+     * Atomically sets the given value and returns the old value.
+     *
+     * @param newValue the new value
+     * @returns the old value
+     */
+    getAndSet(newValue: Long | number): Promise<Long>;
+
+    /**
+     * Atomically increments the current value by one.
+     *
+     * @returns the updated value, the current value incremented by one
+     */
+    incrementAndGet(): Promise<Long>;
+
+    /**
+     * Atomically increments the current value by one.
+     *
+     * @returns the old value
+     */
+    getAndIncrement(): Promise<Long>;
+
+    /**
+     * Atomically sets the given value.
+     *
+     * @param newValue the new value
+     */
+    set(newValue: Long | number): Promise<void>;
+}

--- a/src/proxy/IList.ts
+++ b/src/proxy/IList.ts
@@ -19,6 +19,9 @@ import {ItemListener} from './ItemListener';
 import {ReadOnlyLazyList} from '../core/ReadOnlyLazyList';
 import {DistributedObject} from '../core/DistributedObject';
 
+/**
+ * Concurrent and distributed list.
+ */
 export interface IList<E> extends DistributedObject {
 
     /**

--- a/src/proxy/IMap.ts
+++ b/src/proxy/IMap.ts
@@ -27,6 +27,9 @@ import {IdentifiedDataSerializable} from '../serialization/Serializable';
 import {Portable} from '../serialization/Portable';
 import {IndexConfig} from '../config/IndexConfig';
 
+/**
+ * Concurrent, distributed, observable and queryable map.
+ */
 export interface IMap<K, V> extends DistributedObject {
 
     /**

--- a/src/proxy/IQueue.ts
+++ b/src/proxy/IQueue.ts
@@ -18,6 +18,9 @@ import * as Promise from 'bluebird';
 import {ItemListener} from './ItemListener';
 import {DistributedObject} from '../core';
 
+/**
+ * Concurrent, distributed, observable queue.
+ */
 export interface IQueue<E> extends DistributedObject {
     /**
      * Adds given item to the end of the queue. Operation is successful only

--- a/src/proxy/ISet.ts
+++ b/src/proxy/ISet.ts
@@ -18,6 +18,9 @@ import * as Promise from 'bluebird';
 import {ItemListener} from './ItemListener';
 import {DistributedObject} from '../core';
 
+/**
+ * Concurrent and distributed set.
+ */
 export interface ISet<E> extends DistributedObject {
     /**
      * Adds the specified element to this set if not already present.

--- a/src/proxy/ITopic.ts
+++ b/src/proxy/ITopic.ts
@@ -18,6 +18,15 @@ import * as Promise from 'bluebird';
 import {DistributedObject} from '../core';
 import {MessageListener} from './MessageListener';
 
+/**
+ * Hazelcast provides distribution mechanism for publishing messages that are
+ * delivered to multiple subscribers, which is also known as a publish/subscribe
+ * (pub/sub) messaging model. Publish and subscriptions are cluster-wide.
+ *
+ * This interface stand for reliable topic, i.e. it uses a Ringbuffer to store
+ * events. The events in the Ringbuffer are replicated, so they won't get
+ * lost when a node goes down.
+ */
 export interface ITopic<E> extends DistributedObject {
 
     /**

--- a/src/proxy/ListProxy.ts
+++ b/src/proxy/ListProxy.ts
@@ -76,13 +76,11 @@ export class ListProxy<E> extends PartitionSpecificProxy implements IList<E> {
     }
 
     addAt(index: number, element: E): Promise<void> {
-        return this.encodeInvoke(ListAddWithIndexCodec, index, this.toData(element))
-            .then(() => undefined);
+        return this.encodeInvoke(ListAddWithIndexCodec, index, this.toData(element)).then();
     }
 
     clear(): Promise<void> {
-        return this.encodeInvoke(ListClearCodec)
-            .then(() => undefined);
+        return this.encodeInvoke(ListClearCodec).then();
     }
 
     contains(entry: E): Promise<boolean> {

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -292,8 +292,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     clear(): Promise<void> {
-        return this.encodeInvokeOnRandomTarget(MapClearCodec)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(MapClearCodec).then();
     }
 
     isEmpty(): Promise<boolean> {
@@ -346,20 +345,17 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     evictAll(): Promise<void> {
-        return this.encodeInvokeOnRandomTarget(MapEvictAllCodec)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(MapEvictAllCodec).then();
     }
 
     flush(): Promise<void> {
-        return this.encodeInvokeOnRandomTarget(MapFlushCodec)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(MapFlushCodec).then();
     }
 
     lock(key: K, ttl = -1): Promise<void> {
         assertNotNull(key);
         const keyData = this.toData(key);
-        return this.encodeInvokeOnKey(MapLockCodec, keyData, keyData, 0, ttl, 0)
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MapLockCodec, keyData, keyData, 0, ttl, 0).then();
     }
 
     isLocked(key: K): Promise<boolean> {
@@ -375,15 +371,13 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     unlock(key: K): Promise<void> {
         assertNotNull(key);
         const keyData = this.toData(key);
-        return this.encodeInvokeOnKey(MapUnlockCodec, keyData, keyData, 0, 0)
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MapUnlockCodec, keyData, keyData, 0, 0).then();
     }
 
     forceUnlock(key: K): Promise<void> {
         assertNotNull(key);
         const keyData = this.toData(key);
-        return this.encodeInvokeOnKey(MapForceUnlockCodec, keyData, keyData, 0)
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MapForceUnlockCodec, keyData, keyData, 0).then();
     }
 
     keySet(): Promise<K[]> {
@@ -396,13 +390,11 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
 
     loadAll(keys: K[] = null, replaceExistingValues = true): Promise<void> {
         if (keys == null) {
-            return this.encodeInvokeOnRandomTarget(MapLoadAllCodec, replaceExistingValues)
-                .then(() => undefined);
+            return this.encodeInvokeOnRandomTarget(MapLoadAllCodec, replaceExistingValues).then();
         } else {
             const toData = this.toData.bind(this);
             const keysData: Data[] = keys.map<Data>(toData);
-            return this.encodeInvokeOnRandomTarget(MapLoadGivenKeysCodec, keysData, replaceExistingValues)
-                .then(() => undefined);
+            return this.encodeInvokeOnRandomTarget(MapLoadGivenKeysCodec, keysData, replaceExistingValues).then();
         }
     }
 
@@ -477,8 +469,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     addIndex(indexConfig: IndexConfig): Promise<void> {
         assertNotNull(indexConfig);
         const normalizedConfig = IndexUtil.validateAndNormalize(this.name, indexConfig);
-        return this.encodeInvokeOnRandomTarget(MapAddIndexCodec, normalizedConfig)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(MapAddIndexCodec, normalizedConfig).then();
     }
 
     tryLock(key: K, timeout = 0, lease = -1): Promise<boolean> {
@@ -588,8 +579,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     protected deleteInternal(keyData: Data): Promise<void> {
-        return this.encodeInvokeOnKey(MapDeleteCodec, keyData, keyData, 0)
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MapDeleteCodec, keyData, keyData, 0).then();
     }
 
     protected evictInternal(keyData: Data): Promise<boolean> {
@@ -609,8 +599,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     protected putTransientInternal(keyData: Data, valueData: Data, ttl: number): Promise<void> {
-        return this.encodeInvokeOnKey(MapPutTransientCodec, keyData, keyData, valueData, 0, ttl)
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MapPutTransientCodec, keyData, keyData, valueData, 0, ttl).then();
     }
 
     protected replaceInternal(keyData: Data, newValueData: Data): Promise<V> {
@@ -630,8 +619,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     protected setInternal(keyData: Data, valueData: Data, ttl: number): Promise<void> {
-        return this.encodeInvokeOnKey(MapSetCodec, keyData, keyData, valueData, 0, ttl)
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MapSetCodec, keyData, keyData, valueData, 0, ttl).then();
     }
 
     protected tryPutInternal(keyData: Data, valueData: Data, timeout: number): Promise<boolean> {
@@ -669,8 +657,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
                     .then(() => this.finalizePutAll(partitionsToKeys)),
             );
         }
-        return Promise.all(partitionPromises)
-            .then(() => undefined);
+        return Promise.all(partitionPromises).then();
     }
 
     private addEntryListenerInternal(

--- a/src/proxy/MultiMap.ts
+++ b/src/proxy/MultiMap.ts
@@ -21,6 +21,9 @@ import {
     ReadOnlyLazyList
 } from '../core';
 
+/**
+ * A specialized map whose keys can be associated with multiple values.
+ */
 export interface MultiMap<K, V> extends DistributedObject {
 
     /**

--- a/src/proxy/MultiMapProxy.ts
+++ b/src/proxy/MultiMapProxy.ts
@@ -160,8 +160,7 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
     }
 
     clear(): Promise<void> {
-        return this.encodeInvokeOnRandomTarget(MultiMapClearCodec)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(MultiMapClearCodec).then();
     }
 
     valueCount(key: K): Promise<number> {
@@ -235,7 +234,7 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
     lock(key: K, leaseMillis = -1): Promise<void> {
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(MultiMapLockCodec, keyData, keyData, 1, leaseMillis, this.nextSequence())
-            .then(() => undefined);
+            .then();
     }
 
     isLocked(key: K): Promise<boolean> {
@@ -258,14 +257,12 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
 
     unlock(key: K): Promise<void> {
         const keyData = this.toData(key);
-        return this.encodeInvokeOnKey(MultiMapUnlockCodec, keyData, keyData, 1, this.nextSequence())
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MultiMapUnlockCodec, keyData, keyData, 1, this.nextSequence()).then();
     }
 
     forceUnlock(key: K): Promise<void> {
         const keyData = this.toData(key);
-        return this.encodeInvokeOnKey(MultiMapForceUnlockCodec, keyData, keyData, this.nextSequence())
-            .then(() => undefined);
+        return this.encodeInvokeOnKey(MultiMapForceUnlockCodec, keyData, keyData, this.nextSequence()).then();
     }
 
     putAll(pairs: Array<[K, V[]]>): Promise<void> {
@@ -298,8 +295,7 @@ export class MultiMapProxy<K, V> extends BaseProxy implements MultiMap<K, V> {
            partitionPromises.push(this.encodeInvokeOnPartition(MultiMapPutAllCodec, partitionId, pair));
         });
 
-        return Promise.all(partitionPromises)
-            .then(() => undefined);
+        return Promise.all(partitionPromises).then();
     }
 
     private nextSequence(): Long {

--- a/src/proxy/PNCounter.ts
+++ b/src/proxy/PNCounter.ts
@@ -20,7 +20,7 @@ import {DistributedObject} from '../core/DistributedObject';
 
 /**
  * PN (Positive-Negative) CRDT counter.
- * <p>
+ *
  * The counter supports adding and subtracting values as well as
  * retrieving the current counter value.
  * The counter guarantees that whenever two nodes have received the
@@ -28,11 +28,11 @@ import {DistributedObject} from '../core/DistributedObject';
  * identical, and any conflicting updates are merged automatically.
  * If no new updates are made to the shared state, all nodes that can
  * communicate will eventually have the same data.
- * <p>
+ *
  * The invocation is remote. This may lead to indeterminate state -
  * the update may be applied but the response has not been received.
  * In this case, the caller will be notified with a `TargetDisconnectedError`
- * <p>
+ *
  * The read and write methods provide monotonic read and RYW (read-your-write)
  * guarantees. These guarantees are session guarantees which means that if
  * no replica with the previously observed state is reachable, the session
@@ -47,7 +47,7 @@ import {DistributedObject} from '../core/DistributedObject';
  * case the session can be continued or you can reset the session by calling
  * the `reset()` method. If you have called the `reset()` method,
  * a new session is started with the next invocation to a CRDT replica.
- * <p>
+ *
  * <b>NOTE:</b>
  * The CRDT state is kept entirely on non-lite (data) members. If there
  * aren't any and the methods here are invoked, they will

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -130,9 +130,7 @@ export class ProxyManager {
         const request = ClientCreateProxiesCodec.encodeRequest(proxyEntries);
         request.setPartitionId(-1);
         const invocation = new Invocation(this.client, request);
-        return this.client.getInvocationService()
-            .invokeUrgent(invocation)
-            .then(() => undefined);
+        return this.client.getInvocationService().invokeUrgent(invocation).then();
     }
 
     public getDistributedObjects(): Promise<DistributedObject[]> {
@@ -148,8 +146,7 @@ export class ProxyManager {
         this.proxies.delete(serviceName + NAMESPACE_SEPARATOR + name);
         const clientMessage = ClientDestroyProxyCodec.encodeRequest(name, serviceName);
         clientMessage.setPartitionId(-1);
-        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage)
-            .then(() => undefined);
+        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage).then();
     }
 
     public destroyProxyLocally(namespace: string): Promise<void> {

--- a/src/proxy/QueueProxy.ts
+++ b/src/proxy/QueueProxy.ts
@@ -96,8 +96,7 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
     }
 
     clear(): Promise<void> {
-        return this.encodeInvoke(QueueClearCodec)
-            .then(() => undefined);
+        return this.encodeInvoke(QueueClearCodec).then();
     }
 
     contains(item: E): Promise<boolean> {
@@ -178,8 +177,7 @@ export class QueueProxy<E> extends PartitionSpecificProxy implements IQueue<E> {
 
     put(item: E): Promise<void> {
         const itemData = this.toData(item);
-        return this.encodeInvoke(QueuePutCodec, itemData)
-            .then(() => undefined);
+        return this.encodeInvoke(QueuePutCodec, itemData).then();
     }
 
     remainingCapacity(): Promise<number> {

--- a/src/proxy/ReplicatedMapProxy.ts
+++ b/src/proxy/ReplicatedMapProxy.ts
@@ -71,8 +71,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
     }
 
     clear(): Promise<void> {
-        return this.encodeInvokeOnRandomTarget(ReplicatedMapClearCodec)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(ReplicatedMapClearCodec).then();
     }
 
     get(key: K): Promise<V> {
@@ -146,8 +145,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
             entries.push([keyData, valueData]);
         }
 
-        return this.encodeInvokeOnRandomTarget(ReplicatedMapPutAllCodec, entries)
-            .then(() => undefined);
+        return this.encodeInvokeOnRandomTarget(ReplicatedMapPutAllCodec, entries).then();
     }
 
     keySet(): Promise<K[]> {

--- a/src/proxy/Ringbuffer.ts
+++ b/src/proxy/Ringbuffer.ts
@@ -22,6 +22,12 @@ import {
 } from '../core';
 import {OverflowPolicy} from './OverflowPolicy';
 
+/**
+ * A Ringbuffer is a data structure where the content is stored in a ring-like
+ * structure. A ringbuffer has a fixed capacity so it won't grow beyond
+ * that capacity and endanger the stability of the system. If that capacity
+ * is exceeded, the oldest item in the ringbuffer is overwritten.
+ */
 export interface Ringbuffer<E> extends DistributedObject {
 
     /**

--- a/src/proxy/SetProxy.ts
+++ b/src/proxy/SetProxy.ts
@@ -65,8 +65,7 @@ export class SetProxy<E> extends PartitionSpecificProxy implements ISet<E> {
     }
 
     clear(): Promise<void> {
-        return this.encodeInvoke(SetClearCodec)
-            .then(() => undefined);
+        return this.encodeInvoke(SetClearCodec).then();
     }
 
     contains(entry: E): Promise<boolean> {

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -18,11 +18,9 @@
 import * as Long from 'long';
 import * as Promise from 'bluebird';
 import {HazelcastClient} from '../../HazelcastClient';
-import {BaseProxy} from '../BaseProxy';
+import {BaseCPProxy} from './BaseCPProxy';
 import {IAtomicLong} from '../IAtomicLong';
-import {UnsupportedOperationError} from '../../core';
-import {ClientMessage} from '../../protocol/ClientMessage';
-import {ClientRaftProxyFactory} from './ClientRaftProxyFactory';
+import {CPProxyManager} from './CPProxyManager';
 import {RaftGroupId} from './RaftGroupId';
 import {CPGroupDestroyCPObjectCodec} from '../../codec/CPGroupDestroyCPObjectCodec';
 import {AtomicLongAddAndGetCodec} from '../../codec/AtomicLongAddAndGetCodec';
@@ -32,30 +30,27 @@ import {AtomicLongGetAndAddCodec} from '../../codec/AtomicLongGetAndAddCodec';
 import {AtomicLongGetAndSetCodec} from '../../codec/AtomicLongGetAndSetCodec';
 
 /** @internal */
-export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
+export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
 
     private readonly groupId: RaftGroupId;
     private readonly objectName: string;
 
     constructor(client: HazelcastClient, groupId: RaftGroupId, proxyName: string, objectName: string) {
-        super(client, ClientRaftProxyFactory.ATOMIC_LONG_SERVICE, proxyName);
+        super(client, CPProxyManager.ATOMIC_LONG_SERVICE, proxyName);
         this.groupId = groupId;
         this.objectName = objectName;
     }
 
-    getPartitionKey(): string {
-        throw new UnsupportedOperationError('This operation is not supported by IAtomicLong');
-    }
-
     destroy(): Promise<void> {
-        return this.encodeInvoke(CPGroupDestroyCPObjectCodec, this.groupId, this.serviceName, this.objectName).then();
+        return this.encodeInvokeOnRandomTarget(CPGroupDestroyCPObjectCodec,
+            this.groupId, this.serviceName, this.objectName).then();
     }
 
     addAndGet(delta: Long | number): Promise<Long> {
         if (!Long.isLong(delta)) {
             delta = Long.fromNumber(delta as number);
         }
-        return this.encodeInvoke(AtomicLongAddAndGetCodec, this.groupId, this.objectName, delta)
+        return this.encodeInvokeOnRandomTarget(AtomicLongAddAndGetCodec, this.groupId, this.objectName, delta)
             .then((clientMessage) => {
                 const response = AtomicLongAddAndGetCodec.decodeResponse(clientMessage);
                 return response.response;
@@ -69,7 +64,7 @@ export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
         if (!Long.isLong(update)) {
             update = Long.fromNumber(update as number);
         }
-        return this.encodeInvoke(AtomicLongCompareAndSetCodec, this.groupId, this.objectName, expect, update)
+        return this.encodeInvokeOnRandomTarget(AtomicLongCompareAndSetCodec,this.groupId, this.objectName, expect, update)
             .then((clientMessage) => {
                 const response = AtomicLongCompareAndSetCodec.decodeResponse(clientMessage);
                 return response.response;
@@ -81,7 +76,7 @@ export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
     }
 
     get(): Promise<Long> {
-        return this.encodeInvoke(AtomicLongGetCodec, this.groupId, this.objectName)
+        return this.encodeInvokeOnRandomTarget(AtomicLongGetCodec, this.groupId, this.objectName)
             .then((clientMessage) => {
                 const response = AtomicLongGetCodec.decodeResponse(clientMessage);
                 return response.response;
@@ -92,7 +87,7 @@ export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
         if (!Long.isLong(delta)) {
             delta = Long.fromNumber(delta as number);
         }
-        return this.encodeInvoke(AtomicLongGetAndAddCodec, this.groupId, this.objectName, delta)
+        return this.encodeInvokeOnRandomTarget(AtomicLongGetAndAddCodec, this.groupId, this.objectName, delta)
             .then((clientMessage) => {
                 const response = AtomicLongGetAndAddCodec.decodeResponse(clientMessage);
                 return response.response;
@@ -103,7 +98,7 @@ export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
         if (!Long.isLong(newValue)) {
             newValue = Long.fromNumber(newValue as number);
         }
-        return this.encodeInvoke(AtomicLongGetAndSetCodec, this.groupId, this.objectName, newValue)
+        return this.encodeInvokeOnRandomTarget(AtomicLongGetAndSetCodec, this.groupId, this.objectName, newValue)
             .then((clientMessage) => {
                 const response = AtomicLongGetAndSetCodec.decodeResponse(clientMessage);
                 return response.response;
@@ -120,13 +115,5 @@ export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
 
     set(newValue: Long | number): Promise<void> {
         return this.getAndSet(newValue).then();
-    }
-
-    /**
-     * Invokes request on random target.
-     */
-    private encodeInvoke(codec: any, ...codecArguments: any[]): Promise<ClientMessage> {
-        const clientMessage = codec.encodeRequest(...codecArguments);
-        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage);
     }
 }

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as Long from 'long';
+import * as Promise from 'bluebird';
+import {HazelcastClient} from '../../HazelcastClient';
+import {BaseProxy} from '../BaseProxy';
+import {IAtomicLong} from '../IAtomicLong';
+import {UnsupportedOperationError} from '../../core';
+import {ATOMIC_LONG_SERVICE} from './ClientRaftProxyFactory';
+
+/** @internal */
+export class AtomicLongProxy<E> extends BaseProxy implements IAtomicLong<E> {
+
+    private readonly groupId: string;
+    private readonly objectName: string;
+
+    constructor(client: HazelcastClient, groupId: string, proxyName: string, objectName: string) {
+        super(client, ATOMIC_LONG_SERVICE, proxyName);
+        this.groupId = groupId;
+        this.objectName = objectName;
+    }
+
+    getPartitionKey(): string {
+        throw new UnsupportedOperationError('This operation is not supported by IAtomicLong.');
+    }
+
+    // TODO override
+    destroy(): Promise<void> {
+        return Promise.resolve();
+    }
+
+}

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -64,7 +64,7 @@ export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
         if (!Long.isLong(update)) {
             update = Long.fromNumber(update as number);
         }
-        return this.encodeInvokeOnRandomTarget(AtomicLongCompareAndSetCodec,this.groupId, this.objectName, expect, update)
+        return this.encodeInvokeOnRandomTarget(AtomicLongCompareAndSetCodec, this.groupId, this.objectName, expect, update)
             .then((clientMessage) => {
                 const response = AtomicLongCompareAndSetCodec.decodeResponse(clientMessage);
                 return response.response;

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -21,7 +21,7 @@ import {HazelcastClient} from '../../HazelcastClient';
 import {BaseProxy} from '../BaseProxy';
 import {IAtomicLong} from '../IAtomicLong';
 import {UnsupportedOperationError} from '../../core';
-import {ATOMIC_LONG_SERVICE} from './ClientRaftProxyFactory';
+import {ClientRaftProxyFactory} from './ClientRaftProxyFactory';
 import {RaftGroupId} from './RaftGroupId';
 import {CPGroupDestroyCPObjectCodec} from '../../codec/CPGroupDestroyCPObjectCodec';
 import {AtomicLongAddAndGetCodec} from '../../codec/AtomicLongAddAndGetCodec';
@@ -37,7 +37,7 @@ export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
     private readonly objectName: string;
 
     constructor(client: HazelcastClient, groupId: RaftGroupId, proxyName: string, objectName: string) {
-        super(client, ATOMIC_LONG_SERVICE, proxyName);
+        super(client, ClientRaftProxyFactory.ATOMIC_LONG_SERVICE, proxyName);
         this.groupId = groupId;
         this.objectName = objectName;
     }

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -24,7 +24,7 @@ import {UnsupportedOperationError} from '../../core';
 import {ATOMIC_LONG_SERVICE} from './ClientRaftProxyFactory';
 
 /** @internal */
-export class AtomicLongProxy<E> extends BaseProxy implements IAtomicLong<E> {
+export class AtomicLongProxy extends BaseProxy implements IAtomicLong {
 
     private readonly groupId: string;
     private readonly objectName: string;
@@ -41,6 +41,42 @@ export class AtomicLongProxy<E> extends BaseProxy implements IAtomicLong<E> {
 
     // TODO override
     destroy(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    addAndGet(delta: Long | number): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    compareAndSet(expect: Long | number, update: Long | number): Promise<boolean> {
+        return Promise.resolve(true);
+    }
+
+    decrementAndGet(): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    get(): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    getAndAdd(delta: Long | number): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    getAndSet(newValue: Long | number): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    incrementAndGet(): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    getAndIncrement(): Promise<Long> {
+        return Promise.resolve(new Long(1));
+    }
+
+    set(newValue: Long | number): Promise<void> {
         return Promise.resolve();
     }
 

--- a/src/proxy/cpsubsystem/BaseCPProxy.ts
+++ b/src/proxy/cpsubsystem/BaseCPProxy.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as Promise from 'bluebird';
+import {HazelcastClient} from '../../HazelcastClient';
+import {ClientMessage} from '../../protocol/ClientMessage';
+import {UnsupportedOperationError} from '../../core';
+
+/**
+ * Common super class for any CP Subsystem proxy.
+ * @internal
+ */
+export abstract class BaseCPProxy {
+
+    protected client: HazelcastClient;
+    protected readonly proxyName: string;
+    protected readonly serviceName: string;
+
+    constructor(client: HazelcastClient, serviceName: string, proxyName: string) {
+        this.client = client;
+        this.proxyName = proxyName;
+        this.serviceName = serviceName;
+    }
+
+    getPartitionKey(): string {
+        throw new UnsupportedOperationError('This operation is not supported by CP Subsystem');
+    }
+
+    getName(): string {
+        return this.proxyName;
+    }
+
+    getServiceName(): string {
+        return this.serviceName;
+    }
+
+    /**
+     * Encodes a request from a codec and invokes it on any node.
+     * @param codec
+     * @param codecArguments
+     * @returns response message
+     */
+    protected encodeInvokeOnRandomTarget(codec: any, ...codecArguments: any[]): Promise<ClientMessage> {
+        const clientMessage = codec.encodeRequest(...codecArguments);
+        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage);
+    }
+}

--- a/src/proxy/cpsubsystem/CPProxyManager.ts
+++ b/src/proxy/cpsubsystem/CPProxyManager.ts
@@ -60,7 +60,7 @@ export function getObjectNameForProxy(name: string): string {
 }
 
 /** @internal */
-export class ClientRaftProxyFactory {
+export class CPProxyManager {
 
     public static readonly ATOMIC_LONG_SERVICE = 'hz:raft:atomicLongService';
 
@@ -75,7 +75,7 @@ export class ClientRaftProxyFactory {
         const objectName = getObjectNameForProxy(proxyName);
 
         return this.getGroupId(proxyName).then((groupId) => {
-            if (serviceName === ClientRaftProxyFactory.ATOMIC_LONG_SERVICE) {
+            if (serviceName === CPProxyManager.ATOMIC_LONG_SERVICE) {
                 return new AtomicLongProxy(this.client, groupId, proxyName, objectName);
             }
             throw new IllegalStateError('Unexpected service name: ' + serviceName);

--- a/src/proxy/cpsubsystem/CPProxyManager.ts
+++ b/src/proxy/cpsubsystem/CPProxyManager.ts
@@ -38,7 +38,7 @@ export function withoutDefaultGroupName(name: string): string {
         return name;
     }
 
-    assert(name.slice(i + 1).indexOf('@') === -1, 'Custom group name must be specified at most once');
+    assert(name.indexOf('@', i + 1) === -1, 'Custom group name must be specified at most once');
     const groupName = name.slice(i + 1).trim();
     if (groupName === DEFAULT_GROUP_NAME) {
         return name.slice(0, i);

--- a/src/proxy/cpsubsystem/ClientRaftProxyFactory.ts
+++ b/src/proxy/cpsubsystem/ClientRaftProxyFactory.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as Promise from 'bluebird';
+import {
+    DistributedObject,
+    IllegalStateError
+} from '../../core';
+import {HazelcastClient} from '../../HazelcastClient';
+import {AtomicLongProxy} from './AtomicLongProxy';
+
+/** @internal */
+export const ATOMIC_LONG_SERVICE = 'hz:raft:atomicLongService';
+
+/** @internal */
+export function withoutDefaultGroupName(name: string): string {
+    // TODO
+    return name;
+}
+
+/** @internal */
+export function getGroupNameForProxy(name: string): string {
+    // TODO
+    return name;
+}
+
+/** @internal */
+export class ClientRaftProxyFactory {
+
+    private readonly client: HazelcastClient;
+
+    constructor(client: HazelcastClient) {
+        this.client = client;
+    }
+
+    public getOrCreateProxy(proxyName: string, serviceName: string): Promise<DistributedObject> {
+        proxyName = withoutDefaultGroupName(proxyName);
+        const objectName = getGroupNameForProxy(proxyName);
+
+        return this.getGroupId(proxyName, objectName).then((groupId) => {
+            if (serviceName === ATOMIC_LONG_SERVICE) {
+                return new AtomicLongProxy(this.client, groupId, proxyName, objectName);
+            }
+            throw new IllegalStateError('Unexpected service name: ' + serviceName);
+        });
+    }
+
+    private getGroupId(proxyName: string, objectName: string): Promise<string> {
+        return Promise.resolve('TODO');
+    }
+}

--- a/src/proxy/cpsubsystem/ClientRaftProxyFactory.ts
+++ b/src/proxy/cpsubsystem/ClientRaftProxyFactory.ts
@@ -27,8 +27,6 @@ import {RaftGroupId} from './RaftGroupId';
 import {CPGroupCreateCPGroupCodec} from '../../codec/CPGroupCreateCPGroupCodec';
 import {assertString} from '../../util/Util';
 
-/** @internal */
-export const ATOMIC_LONG_SERVICE = 'hz:raft:atomicLongService';
 const DEFAULT_GROUP_NAME = 'default';
 
 /** @internal */
@@ -64,6 +62,8 @@ export function getObjectNameForProxy(name: string): string {
 /** @internal */
 export class ClientRaftProxyFactory {
 
+    public static readonly ATOMIC_LONG_SERVICE = 'hz:raft:atomicLongService';
+
     private readonly client: HazelcastClient;
 
     constructor(client: HazelcastClient) {
@@ -75,7 +75,7 @@ export class ClientRaftProxyFactory {
         const objectName = getObjectNameForProxy(proxyName);
 
         return this.getGroupId(proxyName).then((groupId) => {
-            if (serviceName === ATOMIC_LONG_SERVICE) {
+            if (serviceName === ClientRaftProxyFactory.ATOMIC_LONG_SERVICE) {
                 return new AtomicLongProxy(this.client, groupId, proxyName, objectName);
             }
             throw new IllegalStateError('Unexpected service name: ' + serviceName);

--- a/src/proxy/cpsubsystem/RaftGroupId.ts
+++ b/src/proxy/cpsubsystem/RaftGroupId.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as Long from 'long';
+
+/** @internal */
+export class RaftGroupId {
+
+    name: string;
+    seed: Long;
+    id: Long;
+
+    constructor(name: string, seed: Long, id: Long) {
+        this.name = name;
+        this.seed = seed;
+        this.id = id;
+    }
+}

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -35,3 +35,4 @@ export * from './ReplicatedMap';
 export * from './Ringbuffer';
 export * from './MessageListener';
 export * from './TopicOverloadPolicy';
+export * from './IAtomicLong';

--- a/src/serialization/portable/PortableContext.ts
+++ b/src/serialization/portable/PortableContext.ts
@@ -27,7 +27,7 @@ import {ClassDefinitionBuilder} from './ClassDefinitionBuilder';
 export class PortableContext {
 
     private version: number;
-    private classDefContext: { [factoyId: number]: ClassDefinitionContext };
+    private classDefContext: { [factoryId: number]: ClassDefinitionContext };
 
     constructor(portableVersion: number) {
         this.version = portableVersion;

--- a/test/cpsubsystem/AtomicLongProxyTest.js
+++ b/test/cpsubsystem/AtomicLongProxyTest.js
@@ -97,14 +97,8 @@ describe('AtomicLongProxyTest', function () {
         expectLong(0, value);
     });
 
-    it('addAndGet: should return added value', async function () {
-        const value = await long.addAndGet(33);
-        expectLong(33, value);
-    });
-
     it('addAndGet: should add', async function () {
-        await long.addAndGet(33);
-        const value = await long.get();
+        const value = await long.addAndGet(33);
         expectLong(33, value);
     });
 

--- a/test/cpsubsystem/AtomicLongProxyTest.js
+++ b/test/cpsubsystem/AtomicLongProxyTest.js
@@ -33,7 +33,7 @@ describe('AtomicLongProxyTest', function () {
     let long;
 
     function expectLong(expected, long) {
-        return expect(long.toString()).to.equal(Long.fromValue(expected).toString());
+        expect(long.toString()).to.equal(Long.fromValue(expected).toString());
     }
 
     before(async function () {
@@ -68,12 +68,25 @@ describe('AtomicLongProxyTest', function () {
         expectLong(0, value2);
     });
 
-    it('destroy: should destroy AtomicLong', async function () {
-        const anotherLong = await client.getAtomicLong('another-long');
+    it('destroy: should destroy AtomicLong and throw on operation', async function () {
+        const anotherLong = await client.getAtomicLong('another-long-1');
+        await anotherLong.destroy();
+        // the next destroy call should be ignored
         await anotherLong.destroy();
 
         try {
             await anotherLong.get();
+        } catch (err) {
+            expect(err).to.be.instanceOf(DistributedObjectDestroyedError);
+        }
+    });
+
+    it('destroy: should destroy AtomicLong and throw on getAtomitLong call', async function () {
+        const anotherLong = await client.getAtomicLong('another-long-2');
+        await anotherLong.destroy();
+
+        try {
+            await client.getAtomicLong('another-long-2');
         } catch (err) {
             expect(err).to.be.instanceOf(DistributedObjectDestroyedError);
         }
@@ -103,7 +116,7 @@ describe('AtomicLongProxyTest', function () {
     it('getAndAdd: should add', async function () {
         await long.getAndAdd(123);
         const value = await long.get();
-        return expectLong(123, value);
+        expectLong(123, value);
     });
 
     it('decrementAndGet: should decrement', async function () {

--- a/test/cpsubsystem/AtomicLongProxyTest.js
+++ b/test/cpsubsystem/AtomicLongProxyTest.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { expect } = require('chai');
+const fs = require('fs');
+const Long = require('long');
+const RC = require('./../RC');
+const { Client } = require('../../');
+
+describe('AtomicLongProxyTest', function () {
+
+    let cluster;
+    let client;
+    let long;
+
+    function expectLong(expected, long) {
+        return expect(long.toString()).to.equal(Long.fromValue(expected).toString());
+    }
+
+    before(async function () {
+        this.timeout(30000);
+        cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_cpsubsystem.xml', 'utf8'))
+        await Promise.all([
+            RC.startMember(cluster.id),
+            RC.startMember(cluster.id),
+            RC.startMember(cluster.id)
+        ]);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
+    });
+
+    beforeEach(async function () {
+        long = await client.getAtomicLong('along');
+    });
+
+    afterEach(async function () {
+        return long.destroy();
+    });
+
+    after(async function () {
+        client.shutdown();
+        return RC.shutdownCluster(cluster.id);
+    });
+
+    it('get: should return 0 initially', async function () {
+        const value = await long.get();
+        expectLong(0, value);
+    });
+
+    it('addAndGet: should return added value', async function () {
+        const value = await long.addAndGet(33);
+        expectLong(33, value);
+    });
+
+    it('addAndGet: should add', async function () {
+        await long.addAndGet(33);
+        const value = await long.get();
+        expectLong(33, value);
+    });
+
+    it('getAndAdd: should return old value', async function () {
+        const value = await long.getAndAdd(123);
+        expectLong(0, value);
+    });
+
+    it('getAndAdd: should add', async function () {
+        await long.getAndAdd(123);
+        const value = await long.get();
+        return expectLong(123, value);
+    });
+
+    it('decrementAndGet: should decrement', async function () {
+        const value = await long.decrementAndGet();
+        expectLong(-1, value);
+    });
+
+    it('compareAndSet: should set the value when condition is met', async function () {
+        await long.set(42);
+        const result = await long.compareAndSet(42, 13);
+        expect(result).to.be.true;
+        const value = await long.get();
+        expectLong(13, value);
+    });
+
+    it('compareAndSet: should have no effect when condition is not met', async function () {
+        await long.set(42);
+        const result = await long.compareAndSet(13, 13);
+        expect(result).to.be.false;
+        const value = await long.get();
+        expectLong(42, value);
+    });
+
+    it('set: should set new value', async function () {
+        await long.set(1001);
+        const value = await long.get();
+        expectLong(1001, value);
+    });
+
+    it('getAndSet: should return old value', async function () {
+        const value = await long.getAndSet(-123);
+        expectLong(0, value);
+    });
+
+    it('getAndSet: should set the value', async function () {
+        await long.getAndSet(-123);
+        const value = await long.get();
+        expectLong(-123, value);
+    });
+
+    it('incrementAndGet: should increment', async function () {
+        const value = await long.incrementAndGet();
+        expectLong(1, value);
+    });
+
+    it('getAndIncrement: should return old value', async function () {
+        const value = await long.getAndIncrement();
+        expectLong(0, value);
+    });
+
+    it('getAndIncrement: should increment the value', async function () {
+        await long.getAndIncrement(2);
+        const value = await long.get();
+        expectLong(2, value);
+    });
+});

--- a/test/cpsubsystem/hazelcast_cpsubsystem.xml
+++ b/test/cpsubsystem/hazelcast_cpsubsystem.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+    <cp-subsystem>
+        <cp-member-count>3</cp-member-count>
+        <group-size>3</group-size>
+    </cp-subsystem>
+</hazelcast>

--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -30,6 +30,8 @@ const { ClientLocalBackupListenerCodec } = require('../../lib/codec/ClientLocalB
  */
 describe('ClientBackupAcksTest', function () {
 
+    this.timeout(15000);
+
     let cluster;
     let client;
 

--- a/test/invocation/InvocationTest.js
+++ b/test/invocation/InvocationTest.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const { Client, IndeterminateOperationStateError } = require('../../');

--- a/test/map/MapStoreTest.js
+++ b/test/map/MapStoreTest.js
@@ -15,15 +15,15 @@
  */
 'use strict';
 
-const expect = require("chai").expect;
+const expect = require('chai').expect;
 const fs = require('fs');
-const HazelcastClient = require("../../lib/index.js").Client;
 const RC = require('./../RC');
-const fillMap = require('../Util').fillMap;
-const promiseWaitMilliseconds = require('../Util').promiseWaitMilliseconds;
+const { Client } = require('../../lib/index.js');
+const { fillMap } = require('../Util');
+const { promiseWaitMilliseconds } = require('../Util');
 const Util = require('../Util');
 
-describe('MapStore', function () {
+describe('MapStoreTest', function () {
 
     let cluster;
     let client;
@@ -37,7 +37,7 @@ describe('MapStore', function () {
                 return RC.startMember(cluster.id);
             })
             .then(function (member) {
-                return HazelcastClient.newHazelcastClient({ clusterName: cluster.id });
+                return Client.newHazelcastClient({ clusterName: cluster.id });
             })
             .then(function (hazelcastClient) {
                 client = hazelcastClient;
@@ -208,21 +208,21 @@ describe('MapStore', function () {
             updated: event => {
                 map.removeEntryListener(listenerId)
                     .then(() => {
-                        if (event.oldValue === "1") {
+                        if (event.oldValue === '1') {
                             done();
                         } else {
-                            done(new Error("Old value for the received event does not match with expected value! " +
-                                "Expected: 1, received: " + event.oldValue));
+                            done(new Error('Old value for the received event does not match with expected value! ' +
+                                'Expected: 1, received: ' + event.oldValue));
                         }
                     });
             },
         }
         map.evictAll()
-            .then(() => map.put("1", "1"))
+            .then(() => map.put('1', '1'))
             .then(() => map.addEntryListener(listener, null, true))
             .then(id => {
                 listenerId = id;
-                return map.putAll([["1", "2"]]);
+                return map.putAll([['1', '2']]);
             });
     });
 
@@ -236,18 +236,18 @@ describe('MapStore', function () {
                         if (event.oldValue == null) {
                             done();
                         } else {
-                            done(new Error("Old value for the received event does not match with expected value! " +
-                                "Expected: null, received: " + event.oldValue));
+                            done(new Error('Old value for the received event does not match with expected value! ' +
+                                'Expected: null, received: ' + event.oldValue));
                         }
                     });
             },
         }
         map.evictAll()
-            .then(() => map.put("1", "1"))
+            .then(() => map.put('1', '1'))
             .then(() => map.addEntryListener(listener, null, true))
             .then(id => {
                 listenerId = id;
-                return map.setAll([["1", "2"]]);
+                return map.setAll([['1', '2']]);
             });
     });
 });

--- a/test/unit/proxy/cpsubsystem/CPProxyManagerTest.js
+++ b/test/unit/proxy/cpsubsystem/CPProxyManagerTest.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
 const { expect } = require('chai');
@@ -21,9 +20,9 @@ const { AssertionError } = require('assert');
 const {
     withoutDefaultGroupName,
     getObjectNameForProxy
-} = require('../../../../lib/proxy/cpsubsystem/ClientRaftProxyFactory');
+} = require('../../../../lib/proxy/cpsubsystem/CPProxyManager');
 
-describe('ClientRaftProxyFactoryTest', function () {
+describe('CPProxyManagerTest', function () {
 
     it('withoutDefaultGroupName: should remove default group from result', function () {
         expect(withoutDefaultGroupName('test@default')).to.be.equal('test');

--- a/test/unit/proxy/cpsubsystem/ClientRaftProxyFactoryTest.js
+++ b/test/unit/proxy/cpsubsystem/ClientRaftProxyFactoryTest.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const { AssertionError } = require('assert');
+const {
+    withoutDefaultGroupName,
+    getObjectNameForProxy
+} = require('../../../../lib/proxy/cpsubsystem/ClientRaftProxyFactory');
+
+describe('ClientRaftProxyFactoryTest', function () {
+
+    it('withoutDefaultGroupName: should remove default group from result', function () {
+        expect(withoutDefaultGroupName('test@default')).to.be.equal('test');
+        expect(withoutDefaultGroupName('test@custom')).to.be.equal('test@custom');
+    });
+
+    it('withoutDefaultGroupName: should throw for non-string', function () {
+        expect(() => withoutDefaultGroupName(42)).to.throw(AssertionError);
+    });
+
+    it('withoutDefaultGroupName: should throw when group is specified multiple times', function () {
+        expect(() => withoutDefaultGroupName('test@default@@default')).to.throw(AssertionError);
+    });
+
+    it('getObjectNameForProxy: should remove group from result', function () {
+        expect(getObjectNameForProxy('test@default')).to.be.equal('test');
+        expect(getObjectNameForProxy('test@custom')).to.be.equal('test');
+    });
+
+    it('getObjectNameForProxy: should throw for non-string', function () {
+        expect(() => getObjectNameForProxy(42)).to.throw(AssertionError);
+    });
+
+    it('getObjectNameForProxy: should throw when object name is empty', function () {
+        expect(() => getObjectNameForProxy('@default')).to.throw(AssertionError);
+        expect(() => getObjectNameForProxy('  @default')).to.throw(AssertionError);
+    });
+
+    it('getObjectNameForProxy: should throw when group name is empty', function () {
+        expect(() => getObjectNameForProxy('test@')).to.throw(AssertionError);
+    });
+});


### PR DESCRIPTION
* Adds `AtomicLong` as the first part of CP Subsystem support
* Includes code samples and documentation
* Also includes minor tsdoc and code style improvements

Corresponding client protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/339

Corresponding PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1457030796/Node.js+Client+CP+Sub+System