### PR TITLE
[CP Subsystem] Add FencedLock support

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1526,13 +1526,13 @@ await lock.lock();
 
 Considering this, you should always call the `.lock()` method only once per async call chain and make sure to release the lock as early as possible.
 
-As an alternative approach, you can use the `.tryLock()` method of FencedLock. It tries to acquire the lock in optimistic manner and immediately returns with either a valid fencing token or zero (`Long.fromNumber(0)`). It also accepts an optional `timeout` argument which specifies the timeout in milliseconds to acquire the lock before giving up.
+As an alternative approach, you can use the `.tryLock()` method of FencedLock. It tries to acquire the lock in optimistic manner and immediately returns with either a valid fencing token or `undefined`. It also accepts an optional `timeout` argument which specifies the timeout in milliseconds to acquire the lock before giving up.
 
 ```javascript
 // Try to acquire the lock
 const fence = await lock.tryLock();
 // Check for valid fencing token
-if (fence.greaterThan(0)) {
+if (fence !== undefined) {
     try {
         // Your guarded code goes here
     } finally {

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -367,7 +367,7 @@ const { Client } = require('hazelcast-client');
         // Print some information about this client
         console.log(client.getLocalEndpoint());
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }
@@ -1149,7 +1149,7 @@ As the final step, if you are done with your client, you can shut it down as sho
 
 ```javascript
 ...
-client.shutdown();
+await client.shutdown();
 ```
 
 ## 7.2. Node.js Client Operation Modes
@@ -1460,6 +1460,8 @@ The following are the descriptions of configuration elements and attributes:
 
 Hazelcast IMDG 4.0 introduces CP concurrency primitives with respect to the [CAP principle](http://awoc.wolski.fi/dlib/big-data/Brewer_podc_keynote_2000.pdf), i.e., they always maintain [linearizability](https://aphyr.com/posts/313-strong-consistency-models) and prefer consistency to availability during network partitions and client or server failures.
 
+All data structures within P Subsystem are available through `client.getCPSubsystem()` component of the client.
+
 Before using Atomic Long, Lock, and Semaphore, CP Subsystem has to be enabled on cluster-side. Refer to [CP Subsystem](https://docs.hazelcast.org/docs/latest/manual/html-single/#cp-subsystem) documentation for more information.
 
 > **NOTE: If you call the `DistributedObject.destroy()` method on a CP data structure, that data structure is terminated on the underlying CP group and cannot be reinitialized until the CP group is force-destroyed on the cluster side. For this reason, please make sure that you are completely done with a CP data structure before destroying its proxy.**
@@ -1472,7 +1474,7 @@ An Atomic Long usage example is shown below.
 
 ```javascript
 // Get an AtomicLong called 'my-atomic-long'
-const atomicLong = await client.getAtomicLong('my-atomic-long');
+const atomicLong = await client.getCPSubsystem().getAtomicLong('my-atomic-long');
 // Get current value (returns a Long)
 const value = await atomicLong.get();
 console.log('Value:', value);
@@ -1590,7 +1592,7 @@ const cfg = {
 };
 
 const client = await Client.newHazelcastClient(cfg);
-client.shutdown();
+await client.shutdown();
 ```
 
 **Output:**

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1503,7 +1503,7 @@ try {
     // Your guarded code goes here
 } finally {
     // Make sure to release the lock
-    await lock.unlock();
+    await lock.unlock(fence);
 }
 ```
 
@@ -1521,7 +1521,7 @@ FencedLocks in Hazelcast Node.js client are different from the Java implementati
 const fence = await lock.lock();
 // The following Promise will never be resolved
 // (i.e., it's a dead lock)
-const fence = await lock.lock();
+await lock.lock();
 ```
 
 Considering this, you should always call the `.lock()` method only once per async call chain and make sure to release the lock as early as possible.
@@ -1537,7 +1537,7 @@ if (fence.greaterThan(0)) {
         // Your guarded code goes here
     } finally {
         // Make sure to release the lock
-        await lock.unlock();
+        await lock.unlock(fence);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ const value = await map.get('key');
 console.log(value); // Outputs 'value'
 
 // Shutdown the client
-client.shutdown();
+await client.shutdown();
 ```
 
 > **NOTE: For the sake of brevity we are going to omit boilerplate parts in the above code snippet. Refer to the [Code Samples section](#16-code-samples) to see samples with the complete code.**
@@ -108,7 +108,7 @@ const client = await Client.newHazelcastClient({
 });
 
 console.log('Connected to cluster');
-client.shutdown();
+await client.shutdown();
 ```
 
 Refer to [the documentation](DOCUMENTATION.md) to learn more about supported configuration options.

--- a/benchmark/MapPutRunner.js
+++ b/benchmark/MapPutRunner.js
@@ -13,25 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
-
-const REQ_COUNT = 1000000;
-const BATCH_SIZE = 100;
 
 const Benchmark = require('./SimpleBenchmark');
 const Client = require('../.').Client;
 
-Client.newHazelcastClient()
-    .then((client) => client.getMap('default'))
-    .then((map) => {
+const REQ_COUNT = 1000000;
+const BATCH_SIZE = 100;
+
+(async () => {
+    try {
+        const client = await Client.newHazelcastClient();
+        const map = await client.getMap('default');
+
         const benchmark = new Benchmark({
             nextOp: () => map.put('foo', 'bar'),
             totalOpsCount: REQ_COUNT,
             batchSize: BATCH_SIZE
         });
-        return benchmark.run()
-            .then(() => map.destroy())
-            .then(() => map.client.shutdown());
-    })
-    .then(() => console.log('Benchmark finished'));
+        await benchmark.run();
+        console.log('Benchmark finished');
+
+        await map.destroy();
+        await client.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/benchmark/SimpleBenchmark.js
+++ b/benchmark/SimpleBenchmark.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 'use strict';
 
 class Benchmark {
@@ -39,11 +38,11 @@ class Benchmark {
     run() {
         // initial batch of ops (no-op promises)
         const batch = new Array(this.batchSize).fill(Promise.resolve());
-        const start = new Date();
+        const start = process.hrtime();
         return Promise.all(batch.map(this.chainNext.bind(this)))
             .then(() => {
-                const finish = new Date();
-                const tookSec = (finish - start) / 1000;
+                const time = process.hrtime(start);
+                const tookSec = time[0] + time[1] * 1e-9;
                 console.log(`Took ${tookSec} seconds for ${this.opsCount} requests`);
                 console.log(`Ops/s: ${this.opsCount / tookSec}`);
             });

--- a/code_samples/aggregation.js
+++ b/code_samples/aggregation.js
@@ -40,7 +40,7 @@ const {
         const avgAge = await map.aggregate(Aggregators.numberAvg());
         console.log(`Average age is ${avgAge}`);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/atomic_long.js
+++ b/code_samples/atomic_long.js
@@ -21,13 +21,13 @@ const { Client } = require('hazelcast-client');
     try {
         const client = await Client.newHazelcastClient();
 
-        const viewCounter = await client.getAtomicLong('views');
+        const viewCounter = await client.getCPSubsystem().getAtomicLong('views');
         const value = await viewCounter.get();
         console.log('Value:', value);
         const newValue = await viewCounter.addAndGet(42);
         console.log('New value:', newValue);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/client_statistics.js
+++ b/code_samples/client_statistics.js
@@ -42,7 +42,7 @@ const { Client } = require('hazelcast-client');
         // collection time and keep client running. Then, you should see
         // the statistics in Hazelcast Management Center
         await new Promise((resolve) => setTimeout(resolve, 60000));
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/custom_serializer.js
+++ b/code_samples/custom_serializer.js
@@ -74,7 +74,7 @@ const giveInformation = (timeofday) => {
         const deserialized = await map.get(1);
         giveInformation(deserialized);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/distributed_object_listener.js
+++ b/code_samples/distributed_object_listener.js
@@ -34,7 +34,7 @@ const { Client } = require('hazelcast-client');
         await map.destroy();
 
         await new Promise((resolve) => setTimeout(resolve, 1000));
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/flakeid_generator.js
+++ b/code_samples/flakeid_generator.js
@@ -25,7 +25,7 @@ const { Client } = require('hazelcast-client');
         const id = await flakeIdGenerator.newId();
         console.log('Generated id:', id.toString());
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/global_serializer.js
+++ b/code_samples/global_serializer.js
@@ -56,7 +56,7 @@ selfReferringObject.self = selfReferringObject;
         console.log(obj.self);
         console.log(obj.self.self);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/hazelcast_cloud_discovery.js
+++ b/code_samples/hazelcast_cloud_discovery.js
@@ -45,7 +45,7 @@ const path = require('path');
         const value = await map.get('key');
         console.log(value);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/hazelcast_json_value.js
+++ b/code_samples/hazelcast_json_value.js
@@ -50,7 +50,7 @@ const {
             console.log(employee.toString());
         }
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/identified_data_serializable.js
+++ b/code_samples/identified_data_serializable.js
@@ -58,7 +58,7 @@ class Employee {
         employee = await map.get('key');
         console.log('Employee object:', employee);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/jaas_sample/admin_client.js
+++ b/code_samples/jaas_sample/admin_client.js
@@ -40,7 +40,7 @@ const { usernamePasswordCredentialsFactory } = require('./user_pass_cred_factory
         value = await adminMap.get('anotherKey');
         console.log('Value for the "anotherKey" is', value);
 
-        adminClient.shutdown();
+        await adminClient.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/jaas_sample/reader_client.js
+++ b/code_samples/jaas_sample/reader_client.js
@@ -41,7 +41,7 @@ const { usernamePasswordCredentialsFactory } = require('./user_pass_cred_factory
             console.log('Reader cannot put to map. Reason:', err);
         }
 
-        readerClient.shutdown();
+        await readerClient.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/lifecycle_listener.js
+++ b/code_samples/lifecycle_listener.js
@@ -27,7 +27,7 @@ const { Client } = require('hazelcast-client');
             ]
         });
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/list.js
+++ b/code_samples/list.js
@@ -33,7 +33,7 @@ const { Client } = require('hazelcast-client');
         const removedItem = await list.removeAt(1);
         console.log('Removed', removedItem);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/lock.js
+++ b/code_samples/lock.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { Client } = require('hazelcast-client');
+
+(async () => {
+    try {
+        const client = await Client.newHazelcastClient();
+
+        const lock = await client.getCPSubsystem().getLock('my-lock');
+        let locked = await lock.isLocked();
+        console.log('Locked initially:', locked);
+
+        const fence = await lock.lock();
+        console.log('Fence token:', fence);
+        try {
+            locked = await lock.isLocked();
+            console.log('Locked after lock:', locked);
+
+            // more guarded code goes here
+        } finally {
+            await lock.unlock();
+        }
+
+        locked = await lock.isLocked();
+        console.log('Locked after unlock:', locked);
+
+        await client.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/code_samples/lock.js
+++ b/code_samples/lock.js
@@ -33,7 +33,7 @@ const { Client } = require('hazelcast-client');
 
             // more guarded code goes here
         } finally {
-            await lock.unlock();
+            await lock.unlock(fence);
         }
 
         locked = await lock.isLocked();

--- a/code_samples/logging.js
+++ b/code_samples/logging.js
@@ -63,7 +63,7 @@ const winstonAdapter = {
             customLogger: winstonAdapter
         });
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/map.js
+++ b/code_samples/map.js
@@ -35,7 +35,7 @@ const { Client } = require('hazelcast-client');
         disappearingValue = await map.get('disappearing-key');
         console.log('Disappeared value:', disappearingValue);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/map_entry_listener.js
+++ b/code_samples/map_entry_listener.js
@@ -39,7 +39,7 @@ const { Client } = require('hazelcast-client');
         await map.put(1, 'new-value');
         await map.remove(1);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/near_cache.js
+++ b/code_samples/near_cache.js
@@ -53,7 +53,7 @@ async function do50000Gets(client, mapName) {
         await do50000Gets(client, nearCachedMapName);
         await do50000Gets(client, regularMapName);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/AtomicLongSample.js
+++ b/code_samples/org-website/AtomicLongSample.js
@@ -24,12 +24,12 @@ const { Client } = require('hazelcast-client');
         // Note: CP Subsystem has to be enabled on the cluster
         const hz = await Client.newHazelcastClient();
         // Get the AtomicLong counter from Cluster
-        const counter = await hz.getAtomicLong('counter');
+        const counter = await hz.getCPSubsystem().getAtomicLong('counter');
         // Add and get the counter
         const value = await counter.addAndGet(3);
         console.log('Counter value is', value);
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/CustomSerializerSample.js
+++ b/code_samples/org-website/CustomSerializerSample.js
@@ -58,7 +58,7 @@ class CustomSerializer {
         // CustomSerializer will serialize/deserialize CustomSerializable objects
 
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/EntryProcessorSample.js
+++ b/code_samples/org-website/EntryProcessorSample.js
@@ -59,7 +59,7 @@ function entryProcessorDataSerializableFactory(classId) {
         const value = await map.get('key');
         console.log(value);
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/GlobalSerializerSample.js
+++ b/code_samples/org-website/GlobalSerializerSample.js
@@ -43,7 +43,7 @@ class GlobalSerializer {
         // GlobalSerializer will serialize/deserialize all non-builtin types
 
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/IdentifiedDataSerializableSample.js
+++ b/code_samples/org-website/IdentifiedDataSerializableSample.js
@@ -57,7 +57,7 @@ function sampleDataSerializableFactory(classId) {
         // Employee can be used here
 
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/ListSample.js
+++ b/code_samples/org-website/ListSample.js
@@ -36,7 +36,7 @@ const { Client } = require('hazelcast-client');
         // Clear the list
         await list.clear();
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/LockSample.js
+++ b/code_samples/org-website/LockSample.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { Client } = require('hazelcast-client');
+
+(async () => {
+    try {
+        // Start the Hazelcast Client and connect to an already running
+        // Hazelcast Cluster on 127.0.0.1
+        const hz = await Client.newHazelcastClient();
+        // Get the Distributed Lock from CP Subsystem
+        const lock = await hz.getCPSubsystem().getLock('my-distributed-lock');
+        // Now acquire the lock and execute some guarded code
+        const fence = await lock.lock();
+        console.log('Fence token:', fence);
+        try {
+            // Guarded code goes here
+        } finally {
+            await lock.unlock();
+        }
+        // Shutdown this Hazelcast client
+        await hz.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/code_samples/org-website/LockSample.js
+++ b/code_samples/org-website/LockSample.js
@@ -30,7 +30,7 @@ const { Client } = require('hazelcast-client');
         try {
             // Guarded code goes here
         } finally {
-            await lock.unlock();
+            await lock.unlock(fence);
         }
         // Shutdown this Hazelcast client
         await hz.shutdown();

--- a/code_samples/org-website/MapSample.js
+++ b/code_samples/org-website/MapSample.js
@@ -31,7 +31,7 @@ const { Client } = require('hazelcast-client');
         await map.putIfAbsent('somekey', 'somevalue');
         await map.replace('key', 'value', 'newvalue');
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/MultiMapSample.js
+++ b/code_samples/org-website/MultiMapSample.js
@@ -36,7 +36,7 @@ const { Client } = require('hazelcast-client');
         // remove specific key/value pair
         await multiMap.remove('my-key', 'value2');
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/PortableSerializableSample.js
+++ b/code_samples/org-website/PortableSerializableSample.js
@@ -61,7 +61,7 @@ function portableFactory(classId) {
         // Customer can be used here
 
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/QuerySample.js
+++ b/code_samples/org-website/QuerySample.js
@@ -83,7 +83,7 @@ async function generateUsers(usersMap) {
         console.log(result1.toArray());
         console.log(result2.toArray());
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/QueueSample.js
+++ b/code_samples/org-website/QueueSample.js
@@ -36,7 +36,7 @@ const { Client } = require('hazelcast-client');
         const item = await await queue.take();
         console.log(item);
         // Shutdown this Hazelcast Client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/ReliableTopicSample.js
+++ b/code_samples/org-website/ReliableTopicSample.js
@@ -31,7 +31,7 @@ const { Client } = require('hazelcast-client');
         // Publish a message to the Topic
         await topic.publish('Hello to distributed world');
         // Shutdown this Hazelcast Client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/ReplicatedMapSample.js
+++ b/code_samples/org-website/ReplicatedMapSample.js
@@ -33,7 +33,7 @@ const { Client } = require('hazelcast-client');
         // The value is retrieved from a random member in the cluster
         console.log('Value for key:', value);
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/RingBufferSample.js
+++ b/code_samples/org-website/RingBufferSample.js
@@ -34,7 +34,7 @@ const { Client } = require('hazelcast-client');
         value = await rb.readOne(sequence.add(1));
         console.log('Next value:', value);
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/org-website/SetSample.js
+++ b/code_samples/org-website/SetSample.js
@@ -35,7 +35,7 @@ const { Client } = require('hazelcast-client');
         const items = await set.toArray();
         console.log(items);
         // Shutdown this Hazelcast client
-        hz.shutdown();
+        await hz.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/paging_predicate.js
+++ b/code_samples/paging_predicate.js
@@ -90,7 +90,7 @@ class Comparator {
         values = await map.valuesWithPredicate(predicate);
         console.log('Page 3:', values);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/pn_counter.js
+++ b/code_samples/pn_counter.js
@@ -27,7 +27,7 @@ const { Client } = require('hazelcast-client');
         value = await pnCounter.decrementAndGet();
         console.log('Decremented counter. Current value is', value.toNumber());
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/portable_multiversion_sample.js
+++ b/code_samples/portable_multiversion_sample.js
@@ -212,9 +212,9 @@ function portableFactory3(classId) {
             console.log('Failed due to:', err.message);
         }
 
-        client.shutdown();
-        client2.shutdown();
-        client3.shutdown();
+        await client.shutdown();
+        await client2.shutdown();
+        await client3.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/querying_with_SQL.js
+++ b/code_samples/querying_with_SQL.js
@@ -49,7 +49,7 @@ class Customer {
             console.log(person);
         }
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/queue.js
+++ b/code_samples/queue.js
@@ -32,7 +32,7 @@ const { Client } = require('hazelcast-client');
         item = await queue.poll();
         console.log(`Retrieved item: ${item}`);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/set.js
+++ b/code_samples/set.js
@@ -33,7 +33,7 @@ const { Client } = require('hazelcast-client');
         const size = await set.size();
         console.log('Set size:', size);
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/code_samples/ssl_authentication.js
+++ b/code_samples/ssl_authentication.js
@@ -28,7 +28,7 @@ const { Client } = require('hazelcast-client');
         });
         console.log('The client is authenticated using SSL');
 
-        client.shutdown();
+        await client.shutdown();
     } catch (err) {
         console.error('Error occurred:', err);
     }

--- a/src/CPSubsystem.ts
+++ b/src/CPSubsystem.ts
@@ -34,11 +34,11 @@ import {HazelcastClient} from './HazelcastClient';
  * Data structures in CP Subsystem run in CP groups. Each CP group elects
  * its own Raft leader and runs the Raft consensus algorithm independently.
  *
- * The CP data structure proxies differ from the other Hazelcast data
- * structure proxies in two aspects. First, an internal commit is performed on
- * the METADATA CP group every time you fetch a proxy from this interface.
- * Hence, callers should cache returned proxy objects. Second, if you call
- * `DistributedObject#destroy()` on a CP data structure proxy, that data
+ * The CP data structures differ from the other Hazelcast data structures
+ * in two aspects. First, an internal commit is performed on the METADATA CP
+ * group every time you fetch a proxy from this interface. Hence, callers
+ * should cache returned proxy objects. Second, if you call
+ * `DistributedObject.destroy()` on a CP data structure proxy, that data
  * structure is terminated on the underlying CP group and cannot be
  * reinitialized until the CP group is force-destroyed. For this
  * reason, please make sure that you are completely done with a CP data

--- a/src/CPSubsystem.ts
+++ b/src/CPSubsystem.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Promise from 'bluebird';
+import {IAtomicLong, FencedLock} from './proxy';
+import {CPProxyManager} from './proxy/cpsubsystem/CPProxyManager';
+import {CPSessionManager} from './proxy/cpsubsystem/CPSessionManager';
+import {HazelcastClient} from './HazelcastClient';
+
+/**
+ * CP Subsystem is a component of Hazelcast that builds a strongly consistent
+ * layer for a set of distributed data structures. Its APIs can be used for
+ * implementing distributed coordination use cases, such as leader election,
+ * distributed locking, synchronization, and metadata management.
+ *
+ * Its data structures are CP with respect to the CAP principle, i.e., they
+ * always maintain linearizability and prefer consistency over availability
+ * during network partitions. Besides network partitions, CP Subsystem
+ * withstands server and client failures.
+ *
+ * Data structures in CP Subsystem run in CP groups. Each CP group elects
+ * its own Raft leader and runs the Raft consensus algorithm independently.
+ *
+ * The CP data structure proxies differ from the other Hazelcast data
+ * structure proxies in two aspects. First, an internal commit is performed on
+ * the METADATA CP group every time you fetch a proxy from this interface.
+ * Hence, callers should cache returned proxy objects. Second, if you call
+ * `DistributedObject#destroy()` on a CP data structure proxy, that data
+ * structure is terminated on the underlying CP group and cannot be
+ * reinitialized until the CP group is force-destroyed. For this
+ * reason, please make sure that you are completely done with a CP data
+ * structure before destroying its proxy.
+ */
+export interface CPSubsystem {
+
+    /**
+     * Returns the distributed AtomicLong instance with given name.
+     * The instance is created on CP Subsystem.
+     *
+     * If no group name is given within the `name` argument, then the
+     * AtomicLong instance will be created on the DEFAULT CP group.
+     * If a group name is given, like `.getAtomicLong('myLong@group1')`,
+     * the given group will be initialized first, if not initialized
+     * already, and then the instance will be created on this group.
+     */
+    getAtomicLong(name: string): Promise<IAtomicLong>;
+
+    /**
+     * Returns the distributed FencedLock instance instance with given name.
+     * The instance is created on CP Subsystem.
+     *
+     * If no group name is given within the `name` argument, then the
+     * FencedLock instance will be created on the DEFAULT CP group.
+     * If a group name is given, like `.getLong('myLock@group1')`,
+     * the given group will be initialized first, if not initialized
+     * already, and then the instance will be created on this group.
+     */
+    getLock(name: string): Promise<FencedLock>;
+
+}
+
+/** @internal */
+export class CPSubsystemImpl implements CPSubsystem {
+
+    private readonly cpProxyManager: CPProxyManager;
+    private readonly cpSessionManager: CPSessionManager;
+
+    constructor(client: HazelcastClient) {
+        this.cpProxyManager = new CPProxyManager(client);
+        this.cpSessionManager = new CPSessionManager(client);
+    }
+
+    getAtomicLong(name: string): Promise<IAtomicLong> {
+        return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.ATOMIC_LONG_SERVICE) as Promise<IAtomicLong>;
+    }
+
+    getLock(name: string): Promise<FencedLock> {
+        return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.LOCK_SERVICE) as Promise<FencedLock>;
+    }
+
+    getCPSessionManager(): CPSessionManager {
+        return this.cpSessionManager;
+    }
+
+    shutdown(): Promise<void> {
+        return this.cpSessionManager.shutdown();
+    }
+}

--- a/src/LifecycleService.ts
+++ b/src/LifecycleService.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as Promise from 'bluebird';
 import {EventEmitter} from 'events';
 import {HazelcastClient} from './HazelcastClient';
 import {ILogger} from './logging/ILogger';
@@ -74,11 +75,6 @@ export interface LifecycleService {
      */
     isRunning(): boolean;
 
-    /**
-     * Shuts down the client.
-     */
-    shutdown(): void;
-
 }
 
 /** @internal */
@@ -122,14 +118,14 @@ export class LifecycleServiceImpl extends EventEmitter implements LifecycleServi
         this.emitLifecycleEvent(LifecycleState.STARTED);
     }
 
-    shutdown(): void {
+    shutdown(): Promise<void> {
         if (!this.active) {
             return;
         }
         this.active = false;
 
         this.emitLifecycleEvent(LifecycleState.SHUTTING_DOWN);
-        this.client.doShutdown();
-        this.emitLifecycleEvent(LifecycleState.SHUTDOWN);
+        return this.client.doShutdown()
+            .then(() => this.emitLifecycleEvent(LifecycleState.SHUTDOWN));
     }
 }

--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -394,6 +394,41 @@ export class NullPointerError extends HazelcastError {
     }
 }
 
+export class SessionExpiredError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, SessionExpiredError.prototype);
+    }
+}
+
+export class CPGroupDestroyedError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, CPGroupDestroyedError.prototype);
+    }
+}
+
+export class LockOwnershipLostError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, LockOwnershipLostError.prototype);
+    }
+}
+
+export class IllegalMonitorStateError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, IllegalMonitorStateError.prototype);
+    }
+}
+
+export class WaitKeyCancelledError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, WaitKeyCancelledError.prototype);
+    }
+}
+
 export class UndefinedErrorCodeError extends HazelcastError {
     constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
         super(msg, cause, serverStackTrace);

--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -429,6 +429,34 @@ export class WaitKeyCancelledError extends HazelcastError {
     }
 }
 
+export class LeaderDemotedError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, LeaderDemotedError.prototype);
+    }
+}
+
+export class StaleAppendRequestError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, StaleAppendRequestError.prototype);
+    }
+}
+
+export class CannotReplicateError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, CannotReplicateError.prototype);
+    }
+}
+
+export class NotLeaderError extends HazelcastError {
+    constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
+        super(msg, cause, serverStackTrace);
+        Object.setPrototypeOf(this, NotLeaderError.prototype);
+    }
+}
+
 export class UndefinedErrorCodeError extends HazelcastError {
     constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
         super(msg, cause, serverStackTrace);

--- a/src/core/Member.ts
+++ b/src/core/Member.ts
@@ -87,10 +87,10 @@ export class MemberImpl implements Member {
     }
 
     id(): string {
-        let hashCode = this.address.toString();
+        let id = this.address.toString();
         if (this.uuid) {
-            hashCode += this.uuid.toString();
+            id += this.uuid.toString();
         }
-        return hashCode;
+        return id;
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,3 +29,4 @@ export * from './serialization';
 export {HazelcastClient as Client} from './HazelcastClient';
 export * from './LifecycleService';
 export * from './PartitionService';
+export * from './CPSubsystem';

--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -595,7 +595,7 @@ export class ClientConnectionManager extends EventEmitter {
 
     private shutdownClient(): void {
         try {
-            this.client.getLifecycleService().shutdown();
+            (this.client.getLifecycleService() as LifecycleServiceImpl).shutdown();
         } catch (e) {
             this.logger.error('ConnectionManager', `Error during client shutdown ${e}`);
         }

--- a/src/protocol/ErrorFactory.ts
+++ b/src/protocol/ErrorFactory.ts
@@ -21,6 +21,7 @@ import {
     AuthenticationError,
     CallerNotMemberError,
     CancellationError,
+    CannotReplicateError,
     ClassCastError,
     ClassNotFoundError,
     ConcurrentModificationError,
@@ -40,12 +41,14 @@ import {
     InvalidAddressError,
     InvalidConfigurationError,
     InterruptedError,
+    LeaderDemotedError,
     LockOwnershipLostError,
     MemberLeftError,
     NegativeArraySizeError,
     NoSuchElementError,
     NoDataMemberInClusterError,
     NodeIdOutOfRangeError,
+    NotLeaderError,
     NullPointerError,
     PartitionMigratingError,
     QueryError,
@@ -53,6 +56,7 @@ import {
     SplitBrainProtectionError,
     RetryableHazelcastError,
     RetryableIOError,
+    StaleAppendRequestError,
     StaleSequenceError,
     StaleTaskIdError,
     TargetDisconnectedError,
@@ -189,6 +193,14 @@ export class ClientErrorFactory {
             (m, c, s) => new IllegalMonitorStateError(m, c, s));
         this.register(ClientProtocolErrorCodes.WAIT_KEY_CANCELLED_EXCEPTION,
             (m, c, s) => new WaitKeyCancelledError(m, c, s));
+        this.register(ClientProtocolErrorCodes.CANNOT_REPLICATE_EXCEPTION,
+            (m, c, s) => new CannotReplicateError(m, c, s));
+        this.register(ClientProtocolErrorCodes.LEADER_DEMOTED_EXCEPTION,
+            (m, c, s) => new LeaderDemotedError(m, c, s));
+        this.register(ClientProtocolErrorCodes.STALE_APPEND_REQUEST_EXCEPTION,
+            (m, c, s) => new StaleAppendRequestError(m, c, s));
+        this.register(ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION,
+            (m, c, s) => new NotLeaderError(m, c, s));
     }
 
     createErrorFromClientMessage(clientMessage: ClientMessage): Error {

--- a/src/protocol/ErrorFactory.ts
+++ b/src/protocol/ErrorFactory.ts
@@ -26,6 +26,7 @@ import {
     ConcurrentModificationError,
     ConfigMismatchError,
     ConsistencyLostError,
+    CPGroupDestroyedError,
     DistributedObjectDestroyedError,
     HazelcastError,
     HazelcastInstanceNotActiveError,
@@ -34,10 +35,12 @@ import {
     IndeterminateOperationStateError,
     IOError,
     IllegalArgumentError,
+    IllegalMonitorStateError,
     IndexOutOfBoundsError,
     InvalidAddressError,
     InvalidConfigurationError,
     InterruptedError,
+    LockOwnershipLostError,
     MemberLeftError,
     NegativeArraySizeError,
     NoSuchElementError,
@@ -46,6 +49,7 @@ import {
     NullPointerError,
     PartitionMigratingError,
     QueryError,
+    SessionExpiredError,
     SplitBrainProtectionError,
     RetryableHazelcastError,
     RetryableIOError,
@@ -61,6 +65,7 @@ import {
     UnsupportedOperationError,
     HazelcastSerializationError,
     ReachedMaxSizeError,
+    WaitKeyCancelledError,
 } from '../core';
 import {ClientProtocolErrorCodes} from './ClientProtocolErrorCodes';
 import {ClientMessage} from '../protocol/ClientMessage';
@@ -174,6 +179,16 @@ export class ClientErrorFactory {
             (m, c, s) => new NodeIdOutOfRangeError(m, c, s));
         this.register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION,
             (m, c, s) => new ConsistencyLostError(m, c, s));
+        this.register(ClientProtocolErrorCodes.SESSION_EXPIRED_EXCEPTION,
+            (m, c, s) => new SessionExpiredError(m, c, s));
+        this.register(ClientProtocolErrorCodes.CP_GROUP_DESTROYED_EXCEPTION,
+            (m, c, s) => new CPGroupDestroyedError(m, c, s));
+        this.register(ClientProtocolErrorCodes.LOCK_OWNERSHIP_LOST_EXCEPTION,
+            (m, c, s) => new LockOwnershipLostError(m, c, s));
+        this.register(ClientProtocolErrorCodes.ILLEGAL_MONITOR_STATE,
+            (m, c, s) => new IllegalMonitorStateError(m, c, s));
+        this.register(ClientProtocolErrorCodes.WAIT_KEY_CANCELLED_EXCEPTION,
+            (m, c, s) => new WaitKeyCancelledError(m, c, s));
     }
 
     createErrorFromClientMessage(clientMessage: ClientMessage): Error {

--- a/src/proxy/FencedLock.ts
+++ b/src/proxy/FencedLock.ts
@@ -63,8 +63,7 @@ export interface FencedLock extends DistributedObject {
      * assigned to the current lock acquire.
      *
      * If the lock is already held by another caller, then this method
-     * immediately returns `0` (of `Long` type) that represents a failed
-     * lock attempt.
+     * immediately returns `undefined`, which means a failed lock attempt.
      *
      * @param timeout optional timeout in milliseconds to acquire the lock
      *                before giving up; when it's not specified the operation
@@ -74,7 +73,7 @@ export interface FencedLock extends DistributedObject {
      * @throws LockOwnershipLostError if the underlying CP session was
      *         closed before the client releases the lock
      */
-    tryLock(timeout?: number): Promise<Long>;
+    tryLock(timeout?: number): Promise<Long | undefined>;
 
     /**
      * Releases the lock if the lock is currently held by the client.

--- a/src/proxy/FencedLock.ts
+++ b/src/proxy/FencedLock.ts
@@ -69,7 +69,8 @@ export interface FencedLock extends DistributedObject {
      *                before giving up; when it's not specified the operation
      *                will return immediately after the acquire attempt
      * @returns fencing token (see {@link FencedLock#lock} for more
-     *          information on fencing tokens)
+     *          information on fencing tokens) when lock is acquired;
+     *          or `undefined` when attempt failed
      * @throws LockOwnershipLostError if the underlying CP session was
      *         closed before the client releases the lock
      */

--- a/src/proxy/FencedLock.ts
+++ b/src/proxy/FencedLock.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Promise from 'bluebird';
+import * as Long from 'long';
+import {DistributedObject} from '../core';
+
+/**
+ * A linearizable, distributed, non-reentrant lock.
+ *
+ * FencedLock is CP with respect to the CAP principle. It works on top
+ * of the Raft consensus algorithm. It offers linearizability during crash-stop
+ * failures and network partitions. If a network partition occurs, it remains
+ * available on at most one side of the partition.
+ *
+ * FencedLock works on top of CP sessions. Please refer to CP Session
+ * IMDG documentation section for more information.
+ *
+ * Important note: FencedLock is non-reentrant. Once a caller acquires
+ * the lock, it can not acquire the lock reentrantly. So, the next acquire
+ * attempt made within the same chain of async calls will lead to a dead lock.
+ */
+export interface FencedLock extends DistributedObject {
+
+    /**
+     * Acquires the lock and returns the fencing token assigned to the current
+     * lock acquire.
+     *
+     * If the lock is not available, then the returned Promise is resolved only
+     * when the lock has been acquired.
+     *
+     * Fencing tokens are monotonic 64-bit integers that are incremented each
+     * time the lock switches from the free state to the acquired state.
+     * They are simply used for ordering lock holders. A lock holder can pass
+     * its fencing to the shared resource to fence off previous lock holders.
+     * When this resource receives an operation, it can validate the fencing
+     * token in the operation.
+     *
+     * You can read more about the fencing token idea in Martin Kleppmann's
+     * "How to do distributed locking" blog post and Google's Chubby paper.
+     *
+     * @returns fencing token
+     * @throws LockOwnershipLostError if the underlying CP session was
+     *         closed before the client releases the lock
+     */
+    lock(): Promise<Long>;
+
+    /**
+     * Acquires the lock only if it is free and returns the fencing token
+     * assigned to the current lock acquire.
+     *
+     * If the lock is already held by another caller, then this method
+     * immediately returns `0` (of `Long` type) that represents a failed
+     * lock attempt.
+     *
+     * @param timeout optional timeout in milliseconds to acquire the lock
+     *                before giving up; when it's not specified the operation
+     *                will return immediately after the acquire attempt
+     * @returns fencing token (see {@link FencedLock#lock} for more
+     *          information on fencing tokens)
+     * @throws LockOwnershipLostError if the underlying CP session was
+     *         closed before the client releases the lock
+     */
+    tryLock(timeout?: number): Promise<Long>;
+
+    /**
+     * Releases the lock if the lock is currently held by the client.
+     *
+     * @throws IllegalMonitorStateError if the client does not hold
+     *         the lock
+     * @throws LockOwnershipLostError if the underlying CP session was
+     *         closed before the client releases the lock
+     */
+    unlock(): Promise<void>;
+
+    /**
+     * Returns whether this lock is locked or not.
+     *
+     * @return `true` if this lock is locked by any caller
+     *         in the cluster, `false` otherwise.
+     * @throws LockOwnershipLostError if the underlying CP session was
+     *         closed before the client releases the lock
+     */
+    isLocked(): Promise<boolean>;
+}

--- a/src/proxy/FencedLock.ts
+++ b/src/proxy/FencedLock.ts
@@ -79,12 +79,13 @@ export interface FencedLock extends DistributedObject {
     /**
      * Releases the lock if the lock is currently held by the client.
      *
+     * @param fence fencing token returned from `lock`/`tryLock` method.
      * @throws IllegalMonitorStateError if the client does not hold
      *         the lock
      * @throws LockOwnershipLostError if the underlying CP session was
      *         closed before the client releases the lock
      */
-    unlock(): Promise<void>;
+    unlock(fence: Long): Promise<void>;
 
     /**
      * Returns whether this lock is locked or not.

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -220,6 +220,5 @@ export class ProxyManager {
         } else {
             return Promise.resolve(localProxy);
         }
-
     }
 }

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -22,7 +22,6 @@ import {BaseCPProxy} from './BaseCPProxy';
 import {IAtomicLong} from '../IAtomicLong';
 import {CPProxyManager} from './CPProxyManager';
 import {RaftGroupId} from './RaftGroupId';
-import {CPGroupDestroyCPObjectCodec} from '../../codec/CPGroupDestroyCPObjectCodec';
 import {AtomicLongAddAndGetCodec} from '../../codec/AtomicLongAddAndGetCodec';
 import {AtomicLongCompareAndSetCodec} from '../../codec/AtomicLongCompareAndSetCodec';
 import {AtomicLongGetCodec} from '../../codec/AtomicLongGetCodec';
@@ -32,18 +31,11 @@ import {AtomicLongGetAndSetCodec} from '../../codec/AtomicLongGetAndSetCodec';
 /** @internal */
 export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
 
-    private readonly groupId: RaftGroupId;
-    private readonly objectName: string;
-
-    constructor(client: HazelcastClient, groupId: RaftGroupId, proxyName: string, objectName: string) {
-        super(client, CPProxyManager.ATOMIC_LONG_SERVICE, proxyName);
-        this.groupId = groupId;
-        this.objectName = objectName;
-    }
-
-    destroy(): Promise<void> {
-        return this.encodeInvokeOnRandomTarget(CPGroupDestroyCPObjectCodec,
-            this.groupId, this.serviceName, this.objectName).then();
+    constructor(client: HazelcastClient,
+                groupId: RaftGroupId,
+                proxyName: string,
+                objectName: string) {
+        super(client, CPProxyManager.ATOMIC_LONG_SERVICE, groupId, proxyName, objectName);
     }
 
     addAndGet(delta: Long | number): Promise<Long> {

--- a/src/proxy/cpsubsystem/CPSessionAwareProxy.ts
+++ b/src/proxy/cpsubsystem/CPSessionAwareProxy.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as Long from 'long';
+import * as Promise from 'bluebird';
+import {HazelcastClient} from '../../HazelcastClient';
+import {RaftGroupId} from './RaftGroupId';
+import {BaseCPProxy} from './BaseCPProxy';
+import {CPSubsystemImpl} from '../../CPSubsystem';
+import {CPSessionManager} from './CPSessionManager';
+
+/**
+ * Common super class for CP Subsystem proxies that make use of Raft sessions.
+ * @internal
+ */
+export abstract class CPSessionAwareProxy extends BaseCPProxy {
+
+    protected readonly sessionManager: CPSessionManager;
+    private threadIdSeq = 0;
+
+    constructor(client: HazelcastClient,
+                serviceName: string,
+                groupId: RaftGroupId,
+                proxyName: string,
+                objectName: string) {
+        super(client, serviceName, groupId, proxyName, objectName);
+        this.sessionManager = (client.getCPSubsystem() as CPSubsystemImpl).getCPSessionManager();
+    }
+
+    /**
+     * As Node.js client implements non-reentrant concurrent primitives,
+     * we generate a new "thread id" per each acquire attempt.
+     */
+    protected nextThreadId(): number {
+        return this.threadIdSeq++;
+    }
+
+    protected getSessionId(): Long {
+        return this.sessionManager.getSessionId(this.groupId);
+    }
+
+    protected acquireSession(): Promise<Long> {
+        return this.sessionManager.acquireSession(this.groupId);
+    }
+
+    protected releaseSession(sessionId: Long): void {
+        return this.sessionManager.releaseSession(this.groupId, sessionId);
+    }
+
+    protected invalidateSession(sessionId: Long): void {
+        return this.sessionManager.invalidateSession(this.groupId, sessionId);
+    }
+}

--- a/src/proxy/cpsubsystem/CPSessionManager.ts
+++ b/src/proxy/cpsubsystem/CPSessionManager.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as Long from 'long';
+import * as Promise from 'bluebird';
+import {RaftGroupId} from './RaftGroupId';
+import {HazelcastClient} from '../../HazelcastClient';
+import {
+    IllegalStateError,
+    SessionExpiredError,
+    CPGroupDestroyedError
+} from '../../core';
+import {
+    CPSessionCreateSessionCodec,
+    CPSessionCreateSessionResponseParams
+} from '../../codec/CPSessionCreateSessionCodec';
+import {CPSessionCloseSessionCodec} from '../../codec/CPSessionCloseSessionCodec';
+import {CPSessionHeartbeatSessionCodec} from '../../codec/CPSessionHeartbeatSessionCodec';
+import {
+    scheduleWithRepetition,
+    cancelRepetitionTask,
+    Task
+} from '../../util/Util';
+
+/** @internal */
+export class SessionState {
+
+    readonly id: Long;
+    readonly groupId: RaftGroupId;
+    readonly ttlMillis: number;
+    readonly creationTime: number;
+    acquireCount = 0;
+
+    constructor(id: Long, groupId: RaftGroupId, ttlMillis: number) {
+        this.id = id;
+        this.groupId = groupId;
+        this.ttlMillis = ttlMillis;
+        this.creationTime = Date.now();
+    }
+
+    acquire(count: number): Long {
+        this.acquireCount += count;
+        return this.id;
+    }
+
+    release(count: number): void {
+        this.acquireCount -= count;
+    }
+
+    isValid(): boolean {
+        return this.isInUse() || !this.isExpired(Date.now());
+    }
+
+    isInUse(): boolean {
+        return this.acquireCount > 0;
+    }
+
+    private isExpired(timestamp: number): boolean {
+        let expirationTime = this.creationTime + this.ttlMillis;
+        if (expirationTime < 0) {
+            expirationTime = Number.MAX_SAFE_INTEGER;
+        }
+        return timestamp > expirationTime;
+    }
+}
+
+/** @internal */
+export const NO_SESSION_ID = Long.fromNumber(-1);
+
+/** @internal */
+export class CPSessionManager {
+
+    private readonly client: HazelcastClient;
+    // <group_id, session_state> map
+    private readonly sessions: Map<string, SessionState> = new Map();
+    private heartbeatTask: Task;
+    private isShutdown = false;
+
+    constructor(client: HazelcastClient) {
+        this.client = client;
+    }
+
+    getSessionId(groupId: RaftGroupId): Long {
+        const session = this.sessions.get(groupId.getStringId());
+        return session !== undefined ? session.id : NO_SESSION_ID;
+    }
+
+    acquireSession(groupId: RaftGroupId): Promise<Long> {
+        return this.getOrCreateSession(groupId).then((state) => {
+            return state.acquire(1);
+        });
+    }
+
+    releaseSession(groupId: RaftGroupId, sessionId: Long): void {
+        const session = this.sessions.get(groupId.getStringId());
+        if (session !== undefined && session.id.equals(sessionId)) {
+            session.release(1);
+        }
+    }
+
+    invalidateSession(groupId: RaftGroupId, sessionId: Long): void {
+        const session = this.sessions.get(groupId.getStringId());
+        if (session !== undefined && session.id.equals(sessionId)) {
+            this.sessions.delete(groupId.getStringId());
+        }
+    }
+
+    shutdown(): Promise<void> {
+        if (this.isShutdown) {
+            return;
+        }
+        this.isShutdown = true;
+        this.cancelHeartbeatTask();
+        const closePromises = [];
+        for (const session of this.sessions.values()) {
+            closePromises.push(this.requestCloseSession(session.groupId, session.id));
+        }
+        return Promise.all(closePromises)
+            .catch(() => {
+                // no-op
+            })
+            .then(() => this.sessions.clear());
+    }
+
+    private getOrCreateSession(groupId: RaftGroupId): Promise<SessionState> {
+        if (this.isShutdown) {
+            return Promise.reject(new IllegalStateError('Session manager is already shut down'));
+        }
+        const session = this.sessions.get(groupId.getStringId());
+        if (session == null || !session.isValid()) {
+            return this.createNewSession(groupId);
+        }
+        return Promise.resolve(session);
+    }
+
+    private createNewSession(groupId: RaftGroupId): Promise<SessionState> {
+        return this.requestNewSession(groupId).then((response) => {
+            const state = new SessionState(response.sessionId, groupId, response.ttlMillis.toNumber());
+            this.sessions.set(groupId.getStringId(), state);
+            this.scheduleHeartbeatTask(response.heartbeatMillis.toNumber());
+            return state;
+        });
+    }
+
+    private requestNewSession(groupId: RaftGroupId): Promise<CPSessionCreateSessionResponseParams> {
+        const clientMessage = CPSessionCreateSessionCodec.encodeRequest(groupId, this.client.getName());
+        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage)
+            .then((clientMessage) => {
+                const response = CPSessionCreateSessionCodec.decodeResponse(clientMessage);
+                return response;
+            });
+    }
+
+    private requestCloseSession(groupId: RaftGroupId, sessionId: Long): Promise<boolean> {
+        const clientMessage = CPSessionCloseSessionCodec.encodeRequest(groupId, sessionId);
+        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage)
+            .then((clientMessage) => {
+                const response = CPSessionCloseSessionCodec.decodeResponse(clientMessage);
+                return response.response;
+            });
+    }
+
+    private requestHeartbeat(groupId: RaftGroupId, sessionId: Long): Promise<void> {
+        const clientMessage = CPSessionHeartbeatSessionCodec.encodeRequest(groupId, sessionId);
+        return this.client.getInvocationService().invokeOnRandomTarget(clientMessage).then();
+    }
+
+    private scheduleHeartbeatTask(heartbeatMillis: number): void {
+        if (this.heartbeatTask !== undefined) {
+            return;
+        }
+        this.heartbeatTask = scheduleWithRepetition(() => {
+            for (const session of this.sessions.values()) {
+                if (session.isInUse()) {
+                    this.requestHeartbeat(session.groupId, session.id)
+                        .catch((err) => {
+                            if (err instanceof SessionExpiredError || err instanceof CPGroupDestroyedError) {
+                                this.invalidateSession(session.groupId, session.id);
+                            }
+                        });
+                }
+            }
+        }, heartbeatMillis, heartbeatMillis);
+    }
+
+    private cancelHeartbeatTask(): void {
+        if (this.heartbeatTask !== undefined) {
+            cancelRepetitionTask(this.heartbeatTask);
+        }
+    }
+}

--- a/src/proxy/cpsubsystem/FencedLockProxy.ts
+++ b/src/proxy/cpsubsystem/FencedLockProxy.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import * as assert from 'assert';
+import * as Long from 'long';
+import * as Promise from 'bluebird';
+import {HazelcastClient} from '../../HazelcastClient';
+import {CPSessionAwareProxy} from './CPSessionAwareProxy';
+import {FencedLock} from '../FencedLock';
+import {CPProxyManager} from './CPProxyManager';
+import {NO_SESSION_ID} from './CPSessionManager';
+import {RaftGroupId} from './RaftGroupId';
+import {FencedLockLockCodec} from '../../codec/FencedLockLockCodec';
+import {FencedLockTryLockCodec} from '../../codec/FencedLockTryLockCodec';
+import {FencedLockUnlockCodec} from '../../codec/FencedLockUnlockCodec';
+import {
+    FencedLockGetLockOwnershipCodec,
+    FencedLockGetLockOwnershipResponseParams
+} from '../../codec/FencedLockGetLockOwnershipCodec';
+import {assertNumber} from '../../util/Util';
+import {UuidUtil} from '../../util/UuidUtil';
+import {
+    IllegalMonitorStateError,
+    LockOwnershipLostError,
+    SessionExpiredError,
+    WaitKeyCancelledError,
+    UUID
+} from '../../core';
+
+const INVALID_FENCE = Long.fromNumber(0);
+
+/**
+ * Contains information for the last successful lock acquire.
+ */
+class LastKnownLock {
+
+    // "thread id" that has acquired the lock
+    threadId: number;
+    // session id that has acquired the lock
+    sessionId: Long;
+
+    update(threadId: number, sessionId: Long) {
+        this.threadId = threadId;
+        this.sessionId = sessionId;
+    }
+
+    clear(): void {
+        this.threadId = undefined;
+        this.sessionId = undefined;
+    }
+
+    clearIfSameThread(threadId: number): void {
+        if (this.threadId === threadId) {
+            this.clear();
+        }
+    }
+
+    isEmpty(): boolean {
+        return this.threadId === undefined && this.sessionId === undefined;
+    }
+}
+
+function isValidFence(fence: Long): boolean {
+    return fence.greaterThan(INVALID_FENCE);
+}
+
+function wrapErrorWithPromise(fn: () => void): Promise<any> | undefined {
+    try {
+        fn();
+        return undefined;
+    } catch (err) {
+        return Promise.reject(err);
+    }
+}
+
+/** @internal */
+export class FencedLockProxy extends CPSessionAwareProxy implements FencedLock {
+
+    private readonly lastKnownLock = new LastKnownLock();
+
+    constructor(client: HazelcastClient,
+                groupId: RaftGroupId,
+                proxyName: string,
+                objectName: string) {
+        super(client, CPProxyManager.LOCK_SERVICE, groupId, proxyName, objectName);
+    }
+
+    lock(): Promise<Long> {
+        const threadId = this.nextThreadId();
+        const invocationUid = UuidUtil.generate();
+        return this.doLock(threadId, invocationUid);
+    }
+
+    private doLock(threadId: number, invocationUid: UUID): Promise<Long> {
+        let sessionId: Long;
+        return this.acquireSession()
+            .then((id) => {
+                sessionId = id;
+                this.verifyLockedSessionId(sessionId, true);
+                return this.requestLock(sessionId, Long.fromNumber(threadId), invocationUid);
+            })
+            .then((fence) => {
+                assert(isValidFence(fence), 'FencedLock somehow hit reentrant lock limit');
+                this.lastKnownLock.update(threadId, sessionId);
+                return fence;
+            })
+            .catch((err) => {
+                if (err instanceof SessionExpiredError) {
+                    this.invalidateSession(sessionId);
+                    return this.doLock(threadId, invocationUid);
+                }
+                if (err instanceof WaitKeyCancelledError) {
+                    this.releaseSession(sessionId);
+                    throw new IllegalMonitorStateError('Lock[' + this.objectName
+                        + '] not acquired because the lock call on the CP group was cancelled.');
+                }
+                throw err;
+            });
+    }
+
+    tryLock(timeout?: number): Promise<Long> {
+        if (timeout === undefined) {
+            timeout = 0;
+        }
+        assertNumber(timeout);
+        const threadId = this.nextThreadId();
+        const invocationUid = UuidUtil.generate();
+        return this.doTryLock(timeout, threadId, invocationUid);
+    }
+
+    private doTryLock(timeout: number, threadId: number, invocationUid: UUID): Promise<Long> {
+        const start = Date.now();
+        let sessionId: Long;
+        return this.acquireSession()
+            .then((id) => {
+                sessionId = id;
+                this.verifyLockedSessionId(sessionId, true);
+                return this.requestTryLock(sessionId, Long.fromNumber(threadId), invocationUid, timeout);
+            })
+            .then((fence) => {
+                if (isValidFence(fence)) {
+                    this.lastKnownLock.update(threadId, sessionId);
+                } else {
+                    this.releaseSession(sessionId);
+                }
+                return fence;
+            })
+            .catch((err) => {
+                if (err instanceof WaitKeyCancelledError) {
+                    this.releaseSession(sessionId);
+                    return INVALID_FENCE;
+                }
+                if (err instanceof SessionExpiredError) {
+                    this.invalidateSession(sessionId);
+
+                    timeout -= Date.now() - start;
+                    if (timeout < 0) {
+                        return INVALID_FENCE;
+                    }
+                    return this.doTryLock(timeout, threadId, invocationUid);
+                }
+                throw err;
+            });
+    }
+
+    unlock(): Promise<void> {
+        const threadId = this.lastKnownLock.threadId;
+        const sessionId = this.getSessionId();
+        const rejected = wrapErrorWithPromise(() => this.verifyLockedSessionId(sessionId, false));
+        if (rejected) {
+            return rejected;
+        }
+        if (this.lastKnownLock.isEmpty() || NO_SESSION_ID.equals(sessionId)) {
+            this.lastKnownLock.clear();
+            return Promise.reject(
+                new IllegalMonitorStateError('Client is not owner of the Lock[' + this.proxyName + '].')
+            );
+        }
+
+        return this.requestUnlock(sessionId, Long.fromNumber(threadId), UuidUtil.generate())
+            .then(() => {
+                this.lastKnownLock.clearIfSameThread(threadId);
+                this.releaseSession(sessionId);
+            })
+            .catch((err) => {
+                if (err instanceof SessionExpiredError) {
+                    this.lastKnownLock.clearIfSameThread(threadId);
+                    this.invalidateSession(sessionId);
+
+                    throw this.newLockOwnershipLostError(sessionId);
+                }
+                if (err instanceof IllegalMonitorStateError) {
+                    this.lastKnownLock.clearIfSameThread(threadId);
+                }
+                throw err;
+            });
+    }
+
+    isLocked(): Promise<boolean> {
+        const sessionId = this.getSessionId();
+        const rejected = wrapErrorWithPromise(() => this.verifyLockedSessionId(sessionId, false));
+        if (rejected) {
+            return rejected;
+        }
+
+        return this.requestLockOwnershipState().then((state) => {
+            const locked = isValidFence(state.fence);
+            if (locked && sessionId.equals(state.sessionId)) {
+                this.lastKnownLock.update(state.threadId.toNumber(), state.sessionId);
+            }
+            return locked;
+        });
+    }
+
+    private requestLock(sessionId: Long, threadId: Long, invocationUid: UUID): Promise<Long> {
+        return this.encodeInvokeOnRandomTarget(
+            FencedLockLockCodec, this.groupId, this.objectName, sessionId, threadId, invocationUid
+        ).then((clientMessage) => {
+            const response = FencedLockLockCodec.decodeResponse(clientMessage);
+            return response.response;
+        });
+    }
+
+    private requestTryLock(sessionId: Long, threadId: Long, invocationUid: UUID, timeout: number): Promise<Long> {
+        return this.encodeInvokeOnRandomTarget(
+            FencedLockTryLockCodec, this.groupId, this.objectName, sessionId, threadId, invocationUid, timeout
+        ).then((clientMessage) => {
+            const response = FencedLockTryLockCodec.decodeResponse(clientMessage);
+            return response.response;
+        });
+    }
+
+    private requestUnlock(sessionId: Long, threadId: Long, invocationUid: UUID): Promise<boolean> {
+        return this.encodeInvokeOnRandomTarget(
+            FencedLockUnlockCodec, this.groupId, this.objectName, sessionId, threadId, invocationUid
+        ).then((clientMessage) => {
+            const response = FencedLockUnlockCodec.decodeResponse(clientMessage);
+            return response.response;
+        });
+    }
+
+    private requestLockOwnershipState(): Promise<FencedLockGetLockOwnershipResponseParams> {
+        return this.encodeInvokeOnRandomTarget(
+            FencedLockGetLockOwnershipCodec, this.groupId, this.objectName
+        ).then((clientMessage) => {
+            const response = FencedLockGetLockOwnershipCodec.decodeResponse(clientMessage);
+            return response;
+        });
+    }
+
+    private verifyLockedSessionId(sessionId: Long, releaseSession: boolean): void {
+        const lockedSessionId = this.lastKnownLock.sessionId;
+        if (lockedSessionId !== undefined && !lockedSessionId.equals(sessionId)) {
+            this.lastKnownLock.clear();
+            if (releaseSession) {
+                this.releaseSession(sessionId);
+            }
+            throw this.newLockOwnershipLostError(lockedSessionId);
+        }
+    }
+
+    private newLockOwnershipLostError(sessionId: Long) {
+        return new LockOwnershipLostError('Client is not owner of the Lock[' + this.proxyName
+            + '] because its Session[' + sessionId.toString() + '] was closed by server!');
+    }
+}

--- a/src/proxy/cpsubsystem/FencedLockProxy.ts
+++ b/src/proxy/cpsubsystem/FencedLockProxy.ts
@@ -66,6 +66,11 @@ export class FencedLockProxy extends CPSessionAwareProxy implements FencedLock {
         super(client, CPProxyManager.LOCK_SERVICE, groupId, proxyName, objectName);
     }
 
+    destroy(): Promise<void> {
+        return super.destroy()
+            .then(() => this.lockedSessionIds.clear());
+    }
+
     lock(): Promise<Fence> {
         const threadId = this.nextThreadId();
         const invocationUid = UuidUtil.generate();

--- a/src/proxy/cpsubsystem/RaftGroupId.ts
+++ b/src/proxy/cpsubsystem/RaftGroupId.ts
@@ -20,13 +20,37 @@ import * as Long from 'long';
 /** @internal */
 export class RaftGroupId {
 
-    name: string;
-    seed: Long;
-    id: Long;
+    readonly name: string;
+    readonly seed: Long;
+    readonly id: Long;
+    private stringId: string;
 
     constructor(name: string, seed: Long, id: Long) {
         this.name = name;
         this.seed = seed;
         this.id = id;
+    }
+
+    getStringId(): string {
+        if (this.stringId !== undefined) {
+            return this.stringId;
+        }
+        this.stringId = this.name;
+        this.stringId += ':' + this.seed.toString();
+        this.stringId += ':' + this.id.toString();
+        return this.stringId;
+    }
+
+    equals(other: RaftGroupId): boolean {
+        if (other == null) {
+            return false;
+        }
+        if (this.name !== other.name) {
+            return false;
+        }
+        if (!this.seed.equals(other.seed)) {
+            return false;
+        }
+        return this.id.equals(other.id);
     }
 }

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -36,3 +36,4 @@ export * from './Ringbuffer';
 export * from './MessageListener';
 export * from './TopicOverloadPolicy';
 export * from './IAtomicLong';
+export * from './FencedLock';

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -37,6 +37,11 @@ export function assertString(v: any): void {
 }
 
 /** @internal */
+export function assertNumber(v: any): void {
+    assert(typeof v === 'number', 'Number value expected.');
+}
+
+/** @internal */
 export function shuffleArray<T>(array: T[]): void {
     let randomIndex: number;
     let temp: T;

--- a/test/AutoPipeliningDisabledTest.js
+++ b/test/AutoPipeliningDisabledTest.js
@@ -46,7 +46,7 @@ describe('AutoPipeliningDisabledTest', function () {
     });
 
     after(async function () {
-        client.shutdown();
+        await client.shutdown();
         return RC.terminateCluster(cluster.id);
     });
 

--- a/test/ClientHotRestartEventTest.js
+++ b/test/ClientHotRestartEventTest.js
@@ -62,7 +62,7 @@ describe('ClientHotRestartEventTest', function () {
     });
 
     afterEach(async function () {
-        client.shutdown();
+        await client.shutdown();
         return RC.terminateCluster(cluster.id);
     });
 

--- a/test/ClientReconnectTest.js
+++ b/test/ClientReconnectTest.js
@@ -24,8 +24,8 @@ describe('ClientReconnectTest', function () {
     let cluster, client;
 
     afterEach(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('member restarts, while map.put in progress', function () {

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -43,8 +43,8 @@ describe('ClusterServiceTest', function () {
     });
 
     afterEach(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('should know when a new member joins to cluster', function (done) {
@@ -65,7 +65,7 @@ describe('ClusterServiceTest', function () {
         let member2;
 
         const membershipListener = {
-            memberRemoved: (event) => {
+            memberRemoved: () => {
                 expect(client.getClusterService().getSize()).to.be.eq(1);
                 done();
             }
@@ -83,7 +83,7 @@ describe('ClusterServiceTest', function () {
         let member2, member3;
 
         const membershipListener = {
-            memberRemoved: (event) => {
+            memberRemoved: () => {
                 const remainingMemberList = client.getClusterService().getMemberList();
                 expect(remainingMemberList).to.have.length(2);
                 const portList = remainingMemberList.map(function (member) {
@@ -120,7 +120,7 @@ describe('ClusterServiceTest', function () {
                     clusterConnectTimeoutMillis: 2000
                 }
             }
-        }).catch(function (err) {
+        }).catch(function () {
             done();
         }).then(function (client) {
             if (client) {
@@ -143,16 +143,16 @@ describe('ClusterServiceTest', function () {
                 }
             }
         }).then(function (newClient) {
-            newClient.shutdown();
-            done(new Error('Client falsely started with wrong cluster name'));
-        }).catch(function (err) {
+            return newClient.shutdown()
+                .then(() => done(new Error('Client falsely started with wrong cluster name')));
+        }).catch(function () {
             done();
         });
     });
 
     it('should not run when listener was removed', function (done) {
         const membershipListener = {
-            memberAdded: (event) => {
+            memberAdded: () => {
                 done(new Error('Listener falsely fired'));
             }
         };

--- a/test/HazelcastClientTest.js
+++ b/test/HazelcastClientTest.js
@@ -92,8 +92,8 @@ configParams.forEach(function (cfg) {
         });
 
         after(function () {
-            client.shutdown();
-            return RC.terminateCluster(cluster.id);
+            return client.shutdown()
+                .then(() => RC.terminateCluster(cluster.id));
         });
 
         it('getDistributedObject returns empty array when there is no distributed object', function () {

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -40,8 +40,8 @@ describe('MembershipListenerTest', function () {
     });
 
     afterEach(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('sees member added event', function () {

--- a/test/cpsubsystem/FencedLockTest.js
+++ b/test/cpsubsystem/FencedLockTest.js
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const fs = require('fs');
+const { AssertionError } = require('assert');
+const RC = require('./../RC');
+const {
+    Client,
+    DistributedObjectDestroyedError,
+    IllegalMonitorStateError
+} = require('../../');
+
+describe('FencedLockTest', function () {
+
+    this.timeout(30000);
+
+    let cluster;
+    let client;
+    let lock;
+
+    let anotherLockSeq = 0;
+    async function getAnotherLock() {
+        return client.getCPSubsystem().getLock('another-lock-' + anotherLockSeq++);
+    }
+
+    function expectValidFence(fence) {
+        expect(fence.toNumber()).to.be.greaterThan(0);
+    }
+
+    function expectInvalidFence(fence) {
+        expect(fence.toNumber()).to.be.equal(0);
+    }
+
+    function expectValidFenceSequence(fences) {
+        let prevFence;
+        for (const fence of fences) {
+            expectValidFence(fence);
+            if (prevFence !== undefined) {
+                expect(fence.toNumber() - prevFence.toNumber()).to.be.greaterThan(0);
+            }
+            prevFence = fence;
+        }
+    }
+
+    function expectSingleValidFence(fences) {
+        let validCnt = 0;
+        for (const fence of fences) {
+            if (fence.toNumber() > 0) {
+                validCnt++;
+            }
+        }
+        expect(validCnt).to.be.equal(1);
+    }
+
+    before(async function () {
+        cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_cpsubsystem.xml', 'utf8'))
+        await Promise.all([
+            RC.startMember(cluster.id),
+            RC.startMember(cluster.id),
+            RC.startMember(cluster.id)
+        ]);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
+        lock = await client.getCPSubsystem().getLock('alock');
+    });
+
+    after(async function () {
+        await client.shutdown();
+        return RC.shutdownCluster(cluster.id);
+    });
+
+    it('should create FencedLock with respect to given CP group', async function () {
+        const lockInAnotherGroup = await client.getCPSubsystem().getLock('alock@mygroup');
+
+        await lockInAnotherGroup.lock();
+        try {
+            const locked = await lock.isLocked();
+            expect(locked).to.be.false;
+        } finally {
+            await lockInAnotherGroup.unlock();
+        }
+    });
+
+    it('should release locks on shutdown', async function () {
+        const anotherClient = await Client.newHazelcastClient({ clusterName: cluster.id });
+        const lockOfAnotherClient = await anotherClient.getCPSubsystem().getLock('alock');
+
+        await lockOfAnotherClient.lock();
+        let locked = await lock.isLocked();
+        expect(locked).to.be.true;
+
+        anotherClient.shutdown();
+
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        locked = await lock.isLocked();
+        expect(locked).to.be.false;
+    });
+
+    it('destroy: should destroy FencedLock and throw on operation', async function () {
+        const anotherLock = await getAnotherLock();
+        await anotherLock.destroy();
+        // the next destroy call should be ignored
+        await anotherLock.destroy();
+
+        expect(anotherLock.isLocked()).to.be.rejectedWith(DistributedObjectDestroyedError);
+    });
+
+    it('isLocked: should return false when not locked', async function () {
+        const locked = await lock.isLocked();
+        expect(locked).to.be.false;
+    });
+
+    it('isLocked: should return true when locked with lock', async function () {
+        await lock.lock();
+        try {
+            const locked = await lock.isLocked();
+            expect(locked).to.be.true;
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('isLocked: should return true when locked with tryLock', async function () {
+        await lock.tryLock();
+        try {
+            const locked = await lock.isLocked();
+            expect(locked).to.be.true;
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('lock: should return valid fence when not locked', async function () {
+        const fence = await lock.lock();
+        try {
+            expectValidFence(fence);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('lock: should be non-reentrant', function (done) {
+        let unlockedByTimer = false;
+        lock.lock()
+            .then(() => {
+                setTimeout(() => {
+                    unlockedByTimer = true;
+                    // passes only if
+                    lock.unlock()
+                        .catch(done);
+                }, 1000);
+                return lock.lock();
+            })
+            .then(() => {
+                if (unlockedByTimer) {
+                    done();
+                }
+                return lock.unlock();
+            })
+            .catch(done);
+    });
+
+    it('lock: should succeed for one call in case of concurrent calls', async function () {
+        // use separate Lock here as it will remain locked
+        const anotherLock = await getAnotherLock();
+
+        let lockCnt = 0;
+        const lockPromises = [];
+        for (let i = 0; i < 5; i++) {
+            lockPromises.push(
+                anotherLock.lock()
+                    .then((fence) => {
+                        expectValidFence(fence);
+                        lockCnt++;
+                    })
+                    .catch(() => {
+                        // no-op
+                    })
+            );
+        }
+        await Promise.race(lockPromises);
+
+        expect(lockCnt).to.be.equal(1);
+    });
+
+    it('tryLock: should throw when timeout is not a number', async function () {
+        expect(() => lock.tryLock('invalid timeout')).to.throw(AssertionError);
+    });
+
+    it('tryLock: should return valid fence when not locked and timeout not specified', async function () {
+        const fence = await lock.tryLock();
+        try {
+            expectValidFence(fence);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('tryLock: should return invalid fence when locked and timeout not specified', async function () {
+        await lock.lock();
+        const fence = await lock.tryLock();
+        try {
+            expectInvalidFence(fence);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('tryLock: should return valid fence when not locked and timeout specified', async function () {
+        const fence = await lock.tryLock(100);
+        try {
+            expectValidFence(fence);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('tryLock: should return invalid fence when locked and timeout specified', async function () {
+        await lock.lock();
+        const fence = await lock.tryLock(100);
+        try {
+            expectInvalidFence(fence);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('tryLock: should keep retrying until timeout when locked', async function () {
+        const start = Date.now();
+        try {
+            await lock.lock();
+            await lock.tryLock(1000);
+            expect(Date.now() - start).to.be.greaterThan(900);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('tryLock: should succeed for one call in case of concurrent calls', async function () {
+        try {
+            const tryLockPromises = [];
+            for (let i = 0; i < 5; i++) {
+                tryLockPromises.push(lock.tryLock());
+            }
+            const fences = await Promise.all(tryLockPromises);
+            expectSingleValidFence(fences);
+        } finally {
+            await lock.unlock();
+        }
+    });
+
+    it('unlock: should throw when not locked', async function () {
+        await expect(lock.unlock()).to.be.rejectedWith(IllegalMonitorStateError);
+    });
+
+    it('lock-unlock: should return monotonical fence sequence', async function () {
+        const fences = [];
+        for (let i = 0; i < 3; i++) {
+            const fence = await lock.lock();
+            fences.push(fence);
+            await lock.unlock();
+        }
+
+        expectValidFenceSequence(fences);
+    });
+
+    it('tryLock-unlock: should return monotonical fence sequence', async function () {
+        const fences = [];
+        for (let i = 0; i < 3; i++) {
+            const fence = await lock.tryLock();
+            fences.push(fence);
+            await lock.unlock();
+        }
+
+        expectValidFenceSequence(fences);
+    });
+});

--- a/test/cpsubsystem/FencedLockTest.js
+++ b/test/cpsubsystem/FencedLockTest.js
@@ -105,7 +105,7 @@ describe('FencedLockTest', function () {
         let locked = await lock.isLocked();
         expect(locked).to.be.true;
 
-        anotherClient.shutdown();
+        await anotherClient.shutdown();
 
         await new Promise((resolve) => setTimeout(resolve, 5000));
         locked = await lock.isLocked();

--- a/test/cpsubsystem/FencedLockTest.js
+++ b/test/cpsubsystem/FencedLockTest.js
@@ -45,10 +45,6 @@ describe('FencedLockTest', function () {
         expect(fence.toNumber()).to.be.greaterThan(0);
     }
 
-    function expectInvalidFence(fence) {
-        expect(fence.toNumber()).to.be.equal(0);
-    }
-
     function expectValidFenceSequence(fences) {
         let prevFence;
         for (const fence of fences) {
@@ -64,7 +60,7 @@ describe('FencedLockTest', function () {
         let validFence;
         let validCnt = 0;
         for (const fence of fences) {
-            if (fence.toNumber() > 0) {
+            if (fence !== undefined && fence.toNumber() > 0) {
                 validCnt++;
                 validFence = fence;
             }
@@ -150,7 +146,7 @@ describe('FencedLockTest', function () {
         }
     });
 
-    it('lock: should return valid fence when not locked', async function () {
+    it('lock: should return fence when not locked', async function () {
         const fence = await lock.lock();
         try {
             expectValidFence(fence);
@@ -207,7 +203,7 @@ describe('FencedLockTest', function () {
         expect(() => lock.tryLock('invalid timeout')).to.throw(AssertionError);
     });
 
-    it('tryLock: should return valid fence when not locked and timeout not specified', async function () {
+    it('tryLock: should return fence when not locked and timeout not specified', async function () {
         const fence = await lock.tryLock();
         try {
             expectValidFence(fence);
@@ -216,17 +212,17 @@ describe('FencedLockTest', function () {
         }
     });
 
-    it('tryLock: should return invalid fence when locked and timeout not specified', async function () {
+    it('tryLock: should return undefined when locked and timeout not specified', async function () {
         const fence = await lock.lock();
         const invalidFence = await lock.tryLock();
         try {
-            expectInvalidFence(invalidFence);
+            expect(invalidFence).to.be.undefined;
         } finally {
             await lock.unlock(fence);
         }
     });
 
-    it('tryLock: should return valid fence when not locked and timeout specified', async function () {
+    it('tryLock: should return fence when not locked and timeout specified', async function () {
         const fence = await lock.tryLock(100);
         try {
             expectValidFence(fence);
@@ -235,11 +231,11 @@ describe('FencedLockTest', function () {
         }
     });
 
-    it('tryLock: should return invalid fence when locked and timeout specified', async function () {
+    it('tryLock: should return undefined when locked and timeout specified', async function () {
         const fence = await lock.lock();
         const invalidFence = await lock.tryLock(100);
         try {
-            expectInvalidFence(invalidFence);
+            expect(invalidFence).to.be.undefined;
         } finally {
             await lock.unlock(fence);
         }

--- a/test/flakeid/FlakeIdGeneratorOutOfRangeTest.js
+++ b/test/flakeid/FlakeIdGeneratorOutOfRangeTest.js
@@ -23,82 +23,62 @@ const RC = require('./../RC');
 const { Client, HazelcastError } = require('../../.');
 const Util = require('../Util');
 
-describe("FlakeIdGeneratorOutOfRangeTest", function () {
+describe('FlakeIdGeneratorOutOfRangeTest', function () {
+
+    this.timeout(30000);
 
     let cluster, client;
     let flakeIdGenerator;
 
-    afterEach(function () {
-        return flakeIdGenerator.destroy().then(function () {
-            client.shutdown();
-            return RC.terminateCluster(cluster.id);
-        });
+    afterEach(async function () {
+        await flakeIdGenerator.destroy();
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    function assignOverflowedNodeId(clusterId, instanceNum) {
+    async function assignOverflowedNodeId(clusterId, instanceNum) {
         const script =
-            'function assignOverflowedNodeId() {' +
-            '   instance_' + instanceNum + '.getCluster().getLocalMember().setMemberListJoinVersion(100000);' +
-            '   return instance_' + instanceNum + '.getCluster().getLocalMember().getMemberListJoinVersion();' +
-            '}' +
-            'result=""+assignOverflowedNodeId();';
+            `function assignOverflowedNodeId() {
+                instance_${instanceNum}.getCluster().getLocalMember().setMemberListJoinVersion(100000);
+                return instance_${instanceNum}.getCluster().getLocalMember().getMemberListJoinVersion();
+            }
+            result=""+assignOverflowedNodeId();`;
         return RC.executeOnController(clusterId, script, 1);
     }
 
     for (let repeat = 0; repeat < 10; repeat++) {
-        it('newId succeeds as long as there is one suitable member in the cluster (repeat: ' + repeat + '/10)', function () {
-            this.timeout(30000);
-            return RC.createCluster().then(function (response) {
-                cluster = response;
-                return RC.startMember(cluster.id);
-            }).then(function () {
-                return RC.startMember(cluster.id);
-            }).then(function () {
-                return assignOverflowedNodeId(cluster.id, Util.getRandomInt(0, 2));
-            }).then(function () {
-                return Client.newHazelcastClient({
-                    clusterName: cluster.id,
-                    network: {
-                        smartRouting: false
-                    }
-                });
-            }).then(function (value) {
-                client = value;
-                return client.getFlakeIdGenerator('test');
-            }).then(function (idGenerator) {
-                flakeIdGenerator = idGenerator;
-                let promise = Promise.resolve();
-                for (let i = 0; i < 100; i++) {
-                    promise = promise.then(function () {
-                        return flakeIdGenerator.newId();
-                    });
+        it('newId should succeed while there is at least one suitable member (repeat: ' + repeat + '/10)', async function () {
+            cluster = await RC.createCluster();
+            await RC.startMember(cluster.id);
+            await RC.startMember(cluster.id);
+            await assignOverflowedNodeId(cluster.id, Util.getRandomInt(0, 2));
+
+            client = await Client.newHazelcastClient({
+                clusterName: cluster.id,
+                network: {
+                    smartRouting: false
                 }
-                return promise;
             });
+
+            flakeIdGenerator = await client.getFlakeIdGenerator('test');
+            for (let i = 0; i < 100; i++) {
+                await flakeIdGenerator.newId();
+            }
         });
     }
 
-    it('throws NodeIdOutOfRangeError when there is no server with a join id smaller than 2^16', function () {
-        this.timeout(20000);
-        return RC.createCluster().then(function (response) {
-            cluster = response;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return assignOverflowedNodeId(cluster.id, 0);
-        }).then(function () {
-            return assignOverflowedNodeId(cluster.id, 1);
-        }).then(function () {
-            return Client.newHazelcastClient({
-                clusterName: cluster.id
-            });
-        }).then(function (cl) {
-            client = cl;
-            return client.getFlakeIdGenerator('test');
-        }).then(function (idGenerator) {
-            flakeIdGenerator = idGenerator;
-            return expect(flakeIdGenerator.newId(flakeIdGenerator)).to.be.rejectedWith(HazelcastError);
+    it('should throw when there is no server with a join id smaller than 2^16', async function () {
+        cluster = await RC.createCluster();
+        await RC.startMember(cluster.id);
+        await RC.startMember(cluster.id);
+        await assignOverflowedNodeId(cluster.id, 0);
+        await assignOverflowedNodeId(cluster.id, 1);
+
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id
         });
+        flakeIdGenerator = await client.getFlakeIdGenerator('test');
+
+        await expect(flakeIdGenerator.newId(flakeIdGenerator)).to.be.rejectedWith(HazelcastError);
     });
 });

--- a/test/flakeid/FlakeIdGeneratorProxyTest.js
+++ b/test/flakeid/FlakeIdGeneratorProxyTest.js
@@ -55,8 +55,8 @@ describe("FlakeIdGeneratorProxyTest", function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     function addToListFunction(l) {

--- a/test/hazelcast_json_value/HJVHazelcastJsonValueSerializerTest.js
+++ b/test/hazelcast_json_value/HJVHazelcastJsonValueSerializerTest.js
@@ -55,8 +55,8 @@ describe('HazelcastJsonValue with HazelcastJsonValueSerializer', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('storing JavaScript objects', function () {

--- a/test/hazelcast_json_value/HJVJsonSerializerTest.js
+++ b/test/hazelcast_json_value/HJVJsonSerializerTest.js
@@ -53,8 +53,8 @@ describe('HazelcastJsonValue with JsonSerializer', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('storing JavaScript objects', function () {

--- a/test/hazelcast_json_value/HazelcastJsonValueQueryTest.js
+++ b/test/hazelcast_json_value/HazelcastJsonValueQueryTest.js
@@ -56,8 +56,8 @@ describe('HazelcastJsonValue query test', function () {
         if (!client) {
             return;
         }
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('querying over JavaScript objects', function () {

--- a/test/heartbeat/HeartbeatFromClientTest.js
+++ b/test/heartbeat/HeartbeatFromClientTest.js
@@ -85,8 +85,9 @@ describe('HeartbeatFromClientTest', function () {
         }).then(function () {
             clearInterval(pushTask);
             expect(connectionClosedEventCount).to.equal(0);
-            client1.shutdown();
-            client2.shutdown();
+            return client1.shutdown();
+        }).then(function () {
+            return client2.shutdown();
         });
     });
 });

--- a/test/heartbeat/HeartbeatFromServerTest.js
+++ b/test/heartbeat/HeartbeatFromServerTest.js
@@ -86,8 +86,7 @@ describe('HeartbeatFromServerTest', function () {
                 if (remoteAddress.host === member2.host && remoteAddress.port === member2.port) {
                     if (connection.closedReason === 'Heartbeat timed out'
                             && connection.closedCause instanceof TargetDisconnectedError) {
-                        done();
-                        client.shutdown();
+                        return client.shutdown().then(() => done());
                     } else {
                         done(new Error('Connection does not closed due to heartbeat timeout. Reason: '
                             + connection.closedReason + ', cause: ' + connection.closedCause));
@@ -148,8 +147,7 @@ describe('HeartbeatFromServerTest', function () {
             client.getConnectionManager().once('connectionAdded', function (connection) {
                 const remoteAddress = connection.getRemoteAddress();
                 if (remoteAddress.host === member2.host && remoteAddress.port === member2.port) {
-                    done();
-                    client.shutdown();
+                    return client.shutdown().then(() => done());
                 } else {
                     done(new Error(remoteAddress.host + ':' + remoteAddress.port + ' is added instead of '
                         + member2.host + ':' + member2.port));

--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -15,7 +15,10 @@
  */
 'use strict';
 
-const { expect } = require('chai');
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const { Client, IndeterminateOperationStateError } = require('../../');
@@ -75,11 +78,7 @@ describe('ClientBackupAcksTest', function () {
         sandbox.replace(ClientLocalBackupListenerCodec, 'handle', sinon.fake());
         const map = await client.getMap('test-map');
 
-        try {
-            await map.set('foo', 'bar');
-        } catch (err) {
-            expect(err).to.be.instanceof(IndeterminateOperationStateError);
-        }
+        await expect(map.set('foo', 'bar')).to.be.rejectedWith(IndeterminateOperationStateError);
     });
 
     it('should not throw when backup acks were lost in smart mode when prop is not set', async function () {

--- a/test/integration/DistributedObjectsTest.js
+++ b/test/integration/DistributedObjectsTest.js
@@ -22,7 +22,7 @@ chai.use(chaiAsPromised);
 
 const expect = require('chai').expect;
 const Client = require('../../.').Client;
-const Controller = require('../RC');
+const RC = require('../RC');
 const Util = require('../Util');
 
 describe('DistributedObjectsTest', function () {
@@ -35,10 +35,10 @@ describe('DistributedObjectsTest', function () {
     }
 
     beforeEach(function () {
-        return Controller.createCluster(null, null)
+        return RC.createCluster(null, null)
             .then((c) => {
                 cluster = c;
-                return Controller.startMember(cluster.id);
+                return RC.startMember(cluster.id);
             })
             .then(() => {
                 return Client.newHazelcastClient({
@@ -51,8 +51,8 @@ describe('DistributedObjectsTest', function () {
     });
 
     afterEach(function () {
-        client.shutdown();
-        return Controller.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('get distributed objects with no object on cluster', function () {
@@ -122,7 +122,7 @@ describe('DistributedObjectsTest', function () {
             .then((objects) => {
                 // Make sure that live objects are not deleted
                 expect(toNamespace(objects)).to.have.deep.members(toNamespace([map, set, queue]));
-                otherClient.shutdown();
+                return otherClient.shutdown();
             });
     });
 
@@ -174,7 +174,7 @@ describe('DistributedObjectsTest', function () {
             })
             .then((objects) => {
                 expect(objects).to.have.lengthOf(0);
-                otherClient.shutdown();
+                return otherClient.shutdown();
             });
     });
 });

--- a/test/integration/InitialMembershipListenerTest.js
+++ b/test/integration/InitialMembershipListenerTest.js
@@ -19,10 +19,10 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
+const { expect } = require('chai');
 
-const expect = require('chai').expect;
-const Client = require('../../.').Client;
 const RC = require('../RC');
+const { Client } = require('../../.');
 const Util = require('../../lib/util/Util');
 
 describe('InitialMembershipListenerTest', function () {
@@ -33,26 +33,19 @@ describe('InitialMembershipListenerTest', function () {
     let initialMember;
     let client;
 
-    beforeEach(function () {
-       return RC.createCluster(null, null)
-           .then((c) => {
-               cluster = c;
-               return RC.startMember(cluster.id);
-           })
-           .then((m) => {
-               initialMember = m;
-           })
+    beforeEach(async function () {
+       cluster = await RC.createCluster(null, null);
+       initialMember = await RC.startMember(cluster.id);
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         if (client != null) {
-            client.shutdown();
+            await client.shutdown();
         }
-
         return RC.terminateCluster(cluster.id);
     });
 
-    it('receives available member when added before client start', function (done) {
+    it('should receive available member when added before client start', function (done) {
         const config = {
             clusterName: cluster.id,
             membershipListeners: [
@@ -73,9 +66,10 @@ describe('InitialMembershipListenerTest', function () {
             .then((c) => {
                 client = c;
             })
+            .catch(done);
     });
 
-    it('receives available member when added after client start', function (done) {
+    it('should receive available member when added after client start', function (done) {
         const membershipListener = {
             init: (event) => {
                 const members = event.members;
@@ -91,10 +85,11 @@ describe('InitialMembershipListenerTest', function () {
             .then((c) => {
                 client = c;
                 client.getClusterService().addMembershipListener(membershipListener);
-            });
+            })
+            .catch(done);
     });
 
-    it('receives events after initial event', function (done) {
+    it('should receive events after initial event', function (done) {
         let newMember;
         const newMemberResolved = Util.DeferredPromise();
 
@@ -133,9 +128,6 @@ describe('InitialMembershipListenerTest', function () {
                 newMember = m;
                 newMemberResolved.resolve();
             })
-            .catch((e) => {
-                done(e);
-            });
+            .catch(done);
     });
-
 });

--- a/test/list/ListProxyTest.js
+++ b/test/list/ListProxyTest.js
@@ -50,8 +50,8 @@ describe('ListProxyTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('appends one item', function () {

--- a/test/map/MapAggregatorsDoubleTest.js
+++ b/test/map/MapAggregatorsDoubleTest.js
@@ -42,8 +42,8 @@ describe('MapAggregatorsDoubleTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/map/MapAggregatorsIntTest.js
+++ b/test/map/MapAggregatorsIntTest.js
@@ -47,8 +47,8 @@ describe('MapAggregatorsIntTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/map/MapAggregatorsLongTest.js
+++ b/test/map/MapAggregatorsLongTest.js
@@ -48,8 +48,8 @@ describe('MapAggregatorsLongTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/map/MapEntryProcessorTest.js
+++ b/test/map/MapEntryProcessorTest.js
@@ -53,8 +53,8 @@ describe('Entry Processor', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/map/MapPartitionAwareTest.js
+++ b/test/map/MapPartitionAwareTest.js
@@ -68,9 +68,8 @@ describe('MapPartitionAwareTest', function () {
     });
 
     after(function () {
-        this.timeout(30000);
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/map/MapPredicateTest.js
+++ b/test/map/MapPredicateTest.js
@@ -69,8 +69,8 @@ describe('MapPredicateTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     function fillMap(size) {

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -74,8 +74,8 @@ describe('MapProxyTest', function () {
             });
 
             after(function () {
-                client.shutdown();
-                return RC.terminateCluster(cluster.id);
+                return client.shutdown()
+                    .then(() => RC.terminateCluster(cluster.id));
             });
 
             function generateLockScript(mapName, keyName) {

--- a/test/map/MapStoreTest.js
+++ b/test/map/MapStoreTest.js
@@ -56,8 +56,8 @@ describe('MapStoreTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('loadAll with no arguments loads all keys', function () {

--- a/test/map/NearCachedMapStressTest.js
+++ b/test/map/NearCachedMapStressTest.js
@@ -67,9 +67,9 @@ describe('NearCachedMapStress', function () {
     });
 
     after(function () {
-        client1.shutdown();
-        validatingClient.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client1.shutdown()
+            .then(() => validatingClient.shutdown())
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     function completeOperation() {

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -73,9 +73,9 @@ describe('NearCachedMapTest', function () {
             });
 
             after(function () {
-                client1.shutdown();
-                client2.shutdown();
-                return RC.terminateCluster(cluster.id);
+                return client1.shutdown()
+                    .then(() => client2.shutdown())
+                    .then(() => RC.terminateCluster(cluster.id));
             });
 
             function getNearCacheStats(map) {

--- a/test/multimap/MultiMapProxyListenersTest.js
+++ b/test/multimap/MultiMapProxyListenersTest.js
@@ -50,8 +50,8 @@ describe("MultiMap Proxy Listener", function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     function Listener(eventName, doneCallback, expectedName, expectedKey, expectedValue, expectedOldValue,

--- a/test/multimap/MultiMapProxyLockTest.js
+++ b/test/multimap/MultiMapProxyLockTest.js
@@ -61,9 +61,9 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     after(function () {
-        clientOne.shutdown();
-        clientTwo.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return clientOne.shutdown()
+            .then(() => clientTwo.shutdown())
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
 

--- a/test/multimap/MultiMapProxyTest.js
+++ b/test/multimap/MultiMapProxyTest.js
@@ -52,8 +52,8 @@ describe('MultiMapProxyTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('adds and retrieves a single item', function () {

--- a/test/nearcache/InvalidationMetadataDistortionTest.js
+++ b/test/nearcache/InvalidationMetadataDistortionTest.js
@@ -45,8 +45,8 @@ describe('Invalidation metadata distortion', function () {
     });
 
     afterEach(function () {
-        client.shutdown();
-        validationClient.shutdown();
+        return client.shutdown()
+            .then(() => validationClient.shutdown());
     });
 
     function createConfig(withNearCache) {

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -85,8 +85,8 @@ describe('LostInvalidationTest', function () {
     });
 
     afterEach(function () {
-        client.shutdown();
-        modifyingClient.shutdown();
+        return client.shutdown()
+            .then(() => modifyingClient.shutdown());
     });
 
     after(function () {

--- a/test/nearcache/MigratedDataTest.js
+++ b/test/nearcache/MigratedDataTest.js
@@ -91,7 +91,7 @@ describe('MigratedDataTest', function () {
     });
 
     afterEach(function () {
-        client.shutdown();
+        return client.shutdown();
     });
 
     after(function () {

--- a/test/nearcache/NearCacheSimpleInvalidationTest.js
+++ b/test/nearcache/NearCacheSimpleInvalidationTest.js
@@ -56,9 +56,9 @@ describe('NearCacheSimpleInvalidationTest', function () {
             });
 
             after(function () {
-                client.shutdown();
-                updaterClient.shutdown();
-                return RC.terminateCluster(cluster.id);
+                return client.shutdown()
+                    .then(() => updaterClient.shutdown())
+                    .then(() => RC.terminateCluster(cluster.id));
             });
 
             it('client observes outside invalidations', function () {

--- a/test/nearcache/impl/RepairingTaskTest.js
+++ b/test/nearcache/impl/RepairingTaskTest.js
@@ -34,7 +34,7 @@ describe('RepairingTask', function () {
 
     afterEach(function () {
         if (client != null) {
-            client.shutdown();
+            return client.shutdown();
         }
     });
 

--- a/test/pncounter/PNCounterBasicTest.js
+++ b/test/pncounter/PNCounterBasicTest.js
@@ -37,8 +37,8 @@ describe('PNCounterBasicTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/pncounter/PNCounterWithLiteMembersTest.js
+++ b/test/pncounter/PNCounterWithLiteMembersTest.js
@@ -45,8 +45,8 @@ describe('PNCounterWithLiteMembersTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {

--- a/test/queue/QueueProxyTest.js
+++ b/test/queue/QueueProxyTest.js
@@ -69,8 +69,8 @@ describe('QueueProxyTest', function () {
     }
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('size', function () {

--- a/test/replicatedmap/ReplicatedMapProxyTest.js
+++ b/test/replicatedmap/ReplicatedMapProxyTest.js
@@ -54,8 +54,8 @@ describe('ReplicatedMapProxyTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('puts one entry and gets one entry', function () {

--- a/test/rest_value/RestValueTest.js
+++ b/test/rest_value/RestValueTest.js
@@ -45,8 +45,8 @@ describe('RestValueTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('client should receive REST events from server as RestValue', function (done) {

--- a/test/ringbuffer/RingbufferProxyTest.js
+++ b/test/ringbuffer/RingbufferProxyTest.js
@@ -51,8 +51,8 @@ describe('RingbufferProxyTest', function () {
     });
 
     after(async function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('adds one item and reads back', async function () {

--- a/test/serialization/DefaultSerializersLiveTest.js
+++ b/test/serialization/DefaultSerializersLiveTest.js
@@ -40,8 +40,8 @@ describe('DefaultSerializersLiveTest', function () {
     });
 
     after(async function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     function generateGet(key) {

--- a/test/serialization/config/CustomSerializerConfigTest.js
+++ b/test/serialization/config/CustomSerializerConfigTest.js
@@ -33,8 +33,8 @@ describe('CustomSerializerConfigTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     function createConfig(clusterName) {

--- a/test/serialization/config/FactoriesTest.js
+++ b/test/serialization/config/FactoriesTest.js
@@ -39,7 +39,7 @@ describe('FactoriesTest', function () {
 
     afterEach(function () {
         if (client != null) {
-            client.shutdown();
+            return client.shutdown();
         }
     });
 

--- a/test/set/SetProxyTest.js
+++ b/test/set/SetProxyTest.js
@@ -49,8 +49,8 @@ describe('SetProxyTest', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('adds one item', function () {

--- a/test/ssl/ClientSSLAuthenticationTest.js
+++ b/test/ssl/ClientSSLAuthenticationTest.js
@@ -120,7 +120,7 @@ describe('ClientSSLAuthenticationTest', function () {
                         './client1-key.pem', './client1-cert.pem', './server1-cert.pem'
                     ));
                 }).then(function (client) {
-                    client.shutdown();
+                    return client.shutdown();
                 });
             });
 
@@ -154,7 +154,7 @@ describe('ClientSSLAuthenticationTest', function () {
                         './client1-key.pem', './client1-cert.pem', './server1-cert.pem'
                     ));
                 }).then(function (client) {
-                    client.shutdown();
+                    return client.shutdown();
                 });
             });
 

--- a/test/statistics/StatisticsTest.js
+++ b/test/statistics/StatisticsTest.js
@@ -90,8 +90,8 @@ describe('StatisticsTest (default period)', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     beforeEach(function () {
@@ -193,8 +193,8 @@ describe('StatisticsTest (non-default period)', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('should not change before period', function () {
@@ -248,8 +248,8 @@ describe('StatisticsTest (negative period)', function () {
     });
 
     after(function () {
-        client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return client.shutdown()
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('should be enabled via configuration', function () {

--- a/test/topic/ReliableTopicTest.js
+++ b/test/topic/ReliableTopicTest.js
@@ -67,9 +67,9 @@ describe('ReliableTopicTest', function () {
     });
 
     after(async function () {
-        clientOne.shutdown();
-        clientTwo.shutdown();
-        return RC.terminateCluster(cluster.id);
+        return clientOne.shutdown()
+            .then(() => clientTwo.shutdown())
+            .then(() => RC.terminateCluster(cluster.id));
     });
 
     it('writes and reads messages', function (done) {

--- a/test/unit/proxy/cpsubsystem/CPSessionManagerTest.js
+++ b/test/unit/proxy/cpsubsystem/CPSessionManagerTest.js
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const Long = require('long');
+const {
+    Client,
+    IllegalStateError,
+    SessionExpiredError
+} = require('../../../../');
+const {
+    SessionState,
+    CPSessionManager
+} = require('../../../../lib/proxy/cpsubsystem/CPSessionManager');
+const { RaftGroupId } = require('../../../../lib/proxy/cpsubsystem/RaftGroupId');
+
+describe('CPSessionManagerTest', function () {
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('SessionState', function () {
+
+        it('acquire: should increment counter', function () {
+            const state = new SessionState(Long.fromNumber(42), null, 1000);
+
+            expect(state.acquireCount).to.be.equal(0);
+
+            const id = state.acquire(5);
+            expect(id.toNumber()).to.be.equal(42);
+            expect(state.acquireCount).to.be.equal(5);
+        });
+
+        it('release: should decrement counter', function () {
+            const state = new SessionState(Long.fromNumber(42), null, 1000);
+
+            state.acquire(3);
+            expect(state.acquireCount).to.be.equal(3);
+
+            state.release(2);
+            expect(state.acquireCount).to.be.equal(1);
+        });
+
+        it('isInUse: should consider current acquire count', function () {
+            const state = new SessionState(Long.fromNumber(42), null, 1000);
+
+            expect(state.acquireCount).to.be.equal(0);
+            expect(state.isInUse()).to.be.false;
+
+            state.acquire(1);
+            expect(state.isInUse()).to.be.true;
+        });
+
+        it('isValid: should consider current acquire count', function () {
+            sandbox.useFakeTimers(0);
+            const state = new SessionState(Long.fromNumber(42), null, 1000);
+
+            // session should be expired now
+            sandbox.useFakeTimers(2000);
+            expect(state.isValid()).to.be.false;
+
+            state.acquire(1);
+            expect(state.isValid()).to.be.true;
+        });
+
+        it('isValid: should consider current acquire count', function () {
+            sandbox.useFakeTimers(0);
+            const state = new SessionState(Long.fromNumber(42), null, 1000);
+
+            // session should be expired now
+            sandbox.useFakeTimers(2000);
+            expect(state.isValid()).to.be.false;
+
+            state.acquire(1);
+            expect(state.isValid()).to.be.true;
+        });
+
+        it('isValid: should consider current time', function () {
+            sandbox.useFakeTimers(0);
+            const state = new SessionState(Long.fromNumber(42), null, 1000);
+
+            expect(state.isValid()).to.be.true;
+
+            // session should be expired now
+            sandbox.useFakeTimers(2000);
+            expect(state.isValid()).to.be.false;
+        });
+    });
+
+    describe('CPProxySessionManager', function () {
+
+        const GROUP_ID = 42;
+        const GROUP_ID_AS_STRING = prepareGroupId().getStringId();
+        const SESSION_ID = 24;
+        const TTL_MILLIS = 1000;
+        const HEARTBEAT_MILLIS = 100;
+
+        let clientStub;
+        let sessionManager;
+
+        function prepareGroupId() {
+            return new RaftGroupId('test', Long.fromNumber(0), Long.fromNumber(GROUP_ID));
+        }
+
+        function prepareSessionState(groupId) {
+            return new SessionState(Long.fromNumber(SESSION_ID), groupId, TTL_MILLIS);
+        }
+
+        function stubRequestNewSession() {
+            const stub = sandbox.stub(sessionManager, 'requestNewSession');
+            stub.returns(Promise.resolve({
+                sessionId: Long.fromNumber(SESSION_ID),
+                ttlMillis: Long.fromNumber(TTL_MILLIS),
+                heartbeatMillis: Long.fromNumber(HEARTBEAT_MILLIS)
+            }));
+            return stub;
+        }
+
+        beforeEach(function () {
+            clientStub = sandbox.stub(Client.prototype);
+            sessionManager = new CPSessionManager(clientStub);
+        });
+
+        afterEach(async function () {
+            // prevents from requestCloseSession calls
+            sessionManager.sessions.clear();
+            return sessionManager.shutdown();
+        });
+
+        it('getSessionId: should return no session id for unknown session', function () {
+            const id = sessionManager.getSessionId(prepareGroupId());
+            expect(id.toNumber()).to.be.equal(-1);
+        });
+
+        it('getSessionId: should return session id for known session', function () {
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, prepareSessionState());
+            let id = sessionManager.getSessionId(prepareGroupId());
+            expect(id.toNumber()).to.be.equal(SESSION_ID);
+        });
+
+        it('acquireSession: should reject when shut down', async function () {
+            await sessionManager.shutdown();
+
+            expect(sessionManager.acquireSession(prepareGroupId(42))).to.be.rejectedWith(IllegalStateError);
+        });
+
+        it('acquireSession: should create new session for unknown group id', async function () {
+            stubRequestNewSession();
+
+            const id = await sessionManager.acquireSession(prepareGroupId());
+            expect(id.toNumber()).to.be.equal(SESSION_ID);
+            expect(sessionManager.sessions.get(GROUP_ID_AS_STRING).acquireCount).to.be.equal(1);
+        });
+
+        it('acquireSession: should create new session for existing invalid session', async function () {
+            const requestNewSessionStub = stubRequestNewSession();
+
+            const groupId = prepareGroupId();
+            const state = prepareSessionState(groupId);
+            sandbox.stub(state, 'isValid').returns(false);
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, state);
+
+            const id = await sessionManager.acquireSession(groupId);
+            expect(id.toNumber()).to.be.equal(SESSION_ID);
+            expect(requestNewSessionStub.withArgs(state.groupId).calledOnce).to.be.true;
+            expect(sessionManager.sessions.get(GROUP_ID_AS_STRING).acquireCount).to.be.equal(1);
+        });
+
+        it('acquireSession: should not create new session for existing valid session', async function () {
+            const requestNewSessionStub = stubRequestNewSession();
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, prepareSessionState());
+
+            const id = await sessionManager.acquireSession(prepareGroupId());
+            expect(id.toNumber()).to.be.equal(SESSION_ID);
+            expect(requestNewSessionStub.notCalled).to.be.true;
+            expect(sessionManager.sessions.get(GROUP_ID_AS_STRING).acquireCount).to.be.equal(1);
+        });
+
+        it('releaseSession: should decrement acquire counter for known session', function () {
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, prepareSessionState());
+
+            sessionManager.releaseSession(prepareGroupId(), Long.fromNumber(SESSION_ID));
+            expect(sessionManager.sessions.get(GROUP_ID_AS_STRING).acquireCount).to.be.equal(-1);
+        });
+
+        it('releaseSession: should not decrement acquire counter for unknown session', function () {
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, prepareSessionState());
+
+            sessionManager.releaseSession(prepareGroupId(), Long.fromNumber(1));
+            expect(sessionManager.sessions.get(GROUP_ID_AS_STRING).acquireCount).to.be.equal(0);
+        });
+
+        it('invalidateSession: should forget known session', function () {
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, prepareSessionState());
+
+            sessionManager.invalidateSession(prepareGroupId(), Long.fromNumber(SESSION_ID));
+            expect(sessionManager.sessions.size).to.be.equal(0);
+        });
+
+        it('invalidateSession: should do nothing when called for unknown session', function () {
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, prepareSessionState());
+
+            sessionManager.invalidateSession(prepareGroupId(), Long.fromNumber(1));
+            expect(sessionManager.sessions.size).to.be.equal(1);
+        });
+
+        it('shutdown: should cancel heartbeat task', async function () {
+            sessionManager.heartbeatTask = {};
+            const cancelStub = sandbox.stub(sessionManager, 'cancelHeartbeatTask');
+
+            await sessionManager.shutdown();
+            expect(cancelStub.calledOnce).to.be.true;
+        });
+
+        it('shutdown: should close known sessions', async function () {
+            const groupId = prepareGroupId();
+            const state = prepareSessionState(groupId);
+            sessionManager.sessions.set(GROUP_ID_AS_STRING, state);
+            const closeSessionStub = sandbox.stub(sessionManager, 'requestCloseSession');
+            closeSessionStub.returns(Promise.resolve());
+
+            await sessionManager.shutdown();
+            expect(closeSessionStub.withArgs(state.groupId, state.id).calledOnce).to.be.true;
+            expect(sessionManager.sessions.size).to.be.equal(0);
+        });
+
+        it('heartbeatTask: should send heartbeats periodically', function (done) {
+            stubRequestNewSession();
+
+            const requestHeartbeatStub = sandbox.stub(sessionManager, 'requestHeartbeat');
+            requestHeartbeatStub.returns(Promise.resolve());
+
+            const groupId = prepareGroupId();
+            sessionManager.acquireSession(groupId)
+                .then((sessionId) => {
+                    setTimeout(() => {
+                        expect(requestHeartbeatStub.withArgs(groupId, sessionId).callCount).to.be.greaterThan(1);
+                        expect(sessionManager.sessions.size).to.be.equal(1);
+                        done();
+                    }, HEARTBEAT_MILLIS * 5);
+                })
+                .catch(done);
+        });
+
+        it('heartbeatTask: should invalidate sessions when error received', function (done) {
+            stubRequestNewSession();
+
+            sandbox.replace(sessionManager, 'requestHeartbeat', function () {
+                return Promise.reject(new SessionExpiredError());
+            });
+
+            const groupId = prepareGroupId();
+            sessionManager.acquireSession(groupId)
+                .then(() => {
+                    setTimeout(() => {
+                        expect(sessionManager.sessions.size).to.be.equal(0);
+                        done();
+                    }, HEARTBEAT_MILLIS * 5);
+                })
+                .catch(done);
+        });
+    });
+});

--- a/test/unit/proxy/cpsubsystem/FencedLockProxyTest.js
+++ b/test/unit/proxy/cpsubsystem/FencedLockProxyTest.js
@@ -151,11 +151,11 @@ describe('FencedLockProxyTest', function () {
         stubRequestTryLock(0);
 
         const fence = await proxy.tryLock();
-        expect(fence.toNumber()).to.be.equal(0);
+        expect(fence).to.be.undefined;
         expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
     });
 
-    it('tryLock: should return invalid fence on expired session error and no timeout', async function () {
+    it('tryLock: should return undefined on expired session error and no timeout', async function () {
         sandbox.useFakeTimers(0);
         prepareAcquireSession(1);
         stubRequestTryLock(2, new SessionExpiredError());
@@ -165,7 +165,7 @@ describe('FencedLockProxyTest', function () {
         sandbox.useFakeTimers(100);
         const fence = await promise;
 
-        expect(fence.toNumber()).to.be.equal(0);
+        expect(fence).to.be.undefined;
         expect(cpSessionManagerStub.invalidateSession.calledOnce).to.be.true;
     });
 
@@ -183,13 +183,13 @@ describe('FencedLockProxyTest', function () {
         expect(cpSessionManagerStub.invalidateSession.calledOnce).to.be.true;
     });
 
-    it('tryLock: should return invalid fence on wait key cancelled error', async function () {
+    it('tryLock: should return undefined on wait key cancelled error', async function () {
         prepareAcquireSession(1);
         stubRequestTryLock(2, new WaitKeyCancelledError());
 
         const fence = await proxy.tryLock();
 
-        expect(fence.toNumber()).to.be.equal(0);
+        expect(fence).to.be.undefined;
         expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
     });
 
@@ -212,7 +212,7 @@ describe('FencedLockProxyTest', function () {
         expect(() => proxy.unlock()).to.throw(TypeError);
     });
 
-    it('unlock: should throw on invalid token given', function () {
+    it('unlock: should throw on invalid fence given', function () {
         expect(() => proxy.unlock(Long.fromNumber(1))).to.throw(TypeError);
     });
 

--- a/test/unit/proxy/cpsubsystem/FencedLockProxyTest.js
+++ b/test/unit/proxy/cpsubsystem/FencedLockProxyTest.js
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+const Long = require('long');
+const {
+    Client,
+    IllegalMonitorStateError,
+    LockOwnershipLostError,
+    SessionExpiredError,
+    WaitKeyCancelledError
+} = require('../../../../');
+const { FencedLockProxy } = require('../../../../lib/proxy/cpsubsystem/FencedLockProxy');
+const { CPSessionManager } = require('../../../../lib/proxy/cpsubsystem/CPSessionManager');
+const { RaftGroupId } = require('../../../../lib/proxy/cpsubsystem/RaftGroupId');
+
+describe('FencedLockProxyTest', function () {
+
+    let clientStub;
+    let cpSessionManagerStub;
+    let proxy;
+
+    function prepareGroupId() {
+        return new RaftGroupId('test', Long.fromNumber(0), Long.fromNumber(42));
+    }
+
+    function prepareAcquireSession(sessionId) {
+        cpSessionManagerStub.acquireSession.returns(Promise.resolve(Long.fromNumber(sessionId)));
+    }
+
+    function prepareGetSession(sessionId) {
+        cpSessionManagerStub.getSessionId.returns(Long.fromNumber(sessionId));
+    }
+
+    async function prepareForUnlock(lockedSessionId, currentSessionId) {
+        prepareAcquireSession(lockedSessionId);
+        stubRequestLock(2);
+        await proxy.lock();
+
+        prepareGetSession(currentSessionId);
+    }
+
+    function stubRequest(methodName, result, firstCallErr) {
+        let called = 0;
+        const stub = sandbox.stub(proxy, methodName).callsFake(() => {
+            if (++called === 1 && firstCallErr !== undefined) {
+                return Promise.reject(firstCallErr);
+            }
+            if (result !== undefined && typeof result === 'number') {
+                return Promise.resolve(Long.fromNumber(result));
+            }
+            return Promise.resolve(result);
+        });
+        return stub;
+    }
+
+    function stubRequestLock(fence, firstCallErr) {
+        return stubRequest('requestLock', fence, firstCallErr);
+    }
+
+    function stubRequestTryLock(fence, firstCallErr) {
+        return stubRequest('requestTryLock', fence, firstCallErr);
+    }
+
+    function stubRequestUnlock(firstCallErr) {
+        return stubRequest('requestUnlock', undefined, firstCallErr);
+    }
+
+    function stubRequestLockOwnershipState(state, firstCallErr) {
+        return stubRequest('requestLockOwnershipState', {
+            fence: Long.fromNumber(state.fence),
+            sessionId: Long.fromNumber(state.sessionId),
+            threadId: Long.fromNumber(state.threadId)
+        }, firstCallErr);
+    }
+
+    beforeEach(function () {
+        clientStub = sandbox.stub(Client.prototype);
+        cpSessionManagerStub = sandbox.stub(CPSessionManager.prototype);
+        clientStub.getCPSubsystem.returns({
+            getCPSessionManager: () => cpSessionManagerStub
+        });
+        proxy = new FencedLockProxy(clientStub, prepareGroupId(), 'mylock@mygroup', 'mylock');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('lock: should return fence on successful acquire', async function () {
+        prepareAcquireSession(1);
+        stubRequestLock(2);
+
+        const fence = await proxy.lock();
+        expect(fence.toNumber()).to.be.equal(2);
+    });
+
+    it('lock: should keep trying to acquire on expired session error', async function () {
+        prepareAcquireSession(1);
+        stubRequestLock(2, new SessionExpiredError());
+
+        const fence = await proxy.lock();
+        expect(fence.toNumber()).to.be.equal(2);
+        expect(cpSessionManagerStub.invalidateSession.calledOnce).to.be.true;
+    });
+
+    it('lock: should throw on wait key cancelled error', async function () {
+        prepareAcquireSession(1);
+        stubRequestLock(2, new WaitKeyCancelledError());
+
+        await expect(proxy.lock()).to.be.rejectedWith(IllegalMonitorStateError);
+        expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
+    });
+
+    it('lock: should throw on unexpected error', async function () {
+        prepareAcquireSession(1);
+        stubRequestLock(2, new Error());
+
+        await expect(proxy.lock()).to.be.rejectedWith(Error);
+    });
+
+    it('tryLock: should return fence on successful acquire', async function () {
+        prepareAcquireSession(1);
+        stubRequestTryLock(2);
+
+        const fence = await proxy.tryLock();
+        expect(fence.toNumber()).to.be.equal(2);
+    });
+
+    it('tryLock: should return release session on failed acquire', async function () {
+        prepareAcquireSession(1);
+        stubRequestTryLock(0);
+
+        const fence = await proxy.tryLock();
+        expect(fence.toNumber()).to.be.equal(0);
+        expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
+    });
+
+    it('tryLock: should return invalid fence on expired session error and no timeout', async function () {
+        sandbox.useFakeTimers(0);
+        prepareAcquireSession(1);
+        stubRequestTryLock(2, new SessionExpiredError());
+
+        const promise = proxy.tryLock();
+        // advance time as if requests were real
+        sandbox.useFakeTimers(100);
+        const fence = await promise;
+
+        expect(fence.toNumber()).to.be.equal(0);
+        expect(cpSessionManagerStub.invalidateSession.calledOnce).to.be.true;
+    });
+
+    it('tryLock: should keep trying on expired session error and specified timeout', async function () {
+        sandbox.useFakeTimers(0);
+        prepareAcquireSession(1);
+        stubRequestTryLock(2, new SessionExpiredError());
+
+        const promise = proxy.tryLock(1000);
+        // advance time as if requests were real
+        sandbox.useFakeTimers(100);
+        const fence = await promise;
+
+        expect(fence.toNumber()).to.be.equal(2);
+        expect(cpSessionManagerStub.invalidateSession.calledOnce).to.be.true;
+    });
+
+    it('tryLock: should return invalid fence on wait key cancelled error', async function () {
+        prepareAcquireSession(1);
+        stubRequestTryLock(2, new WaitKeyCancelledError());
+
+        const fence = await proxy.tryLock();
+
+        expect(fence.toNumber()).to.be.equal(0);
+        expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
+    });
+
+    it('tryLock: should throw on unexpected error', async function () {
+        prepareAcquireSession(1);
+        stubRequestTryLock(2, new Error());
+
+        await expect(proxy.tryLock()).to.be.rejectedWith(Error);
+    });
+
+    it('unlock: should release session when lock held', async function () {
+        await prepareForUnlock(1, 1);
+        stubRequestUnlock();
+
+        await proxy.unlock();
+        expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
+    });
+
+    it('unlock: should throw when no lock held', async function () {
+        await expect(proxy.unlock()).to.be.rejectedWith(IllegalMonitorStateError);
+    });
+
+    it('unlock: should throw when session id has changed', async function () {
+        await prepareForUnlock(1, 2);
+
+        await expect(proxy.unlock()).to.be.rejectedWith(LockOwnershipLostError);
+    });
+
+    it('unlock: should throw when no active session id', async function () {
+        prepareGetSession(-1);
+
+        await expect(proxy.unlock()).to.be.rejectedWith(IllegalMonitorStateError);
+    });
+
+    it('unlock: should throw on expired session error', async function () {
+        await prepareForUnlock(1, 1);
+        stubRequestUnlock(new SessionExpiredError());
+
+        await expect(proxy.unlock()).to.be.rejectedWith(LockOwnershipLostError);
+        expect(cpSessionManagerStub.invalidateSession.calledOnce).to.be.true;
+    });
+
+    it('isLocked: should throw when session id has changed', async function () {
+        await prepareForUnlock(1, 2);
+
+        await expect(proxy.isLocked()).to.be.rejectedWith(LockOwnershipLostError);
+    });
+
+    it('isLocked: should return true when lock is held', async function () {
+        prepareGetSession(1);
+        stubRequestLockOwnershipState({
+            fence: 2,
+            sessionId: 3,
+            threadId: 3
+        });
+
+        const result = await proxy.isLocked();
+        expect(result).to.be.true;
+    });
+
+    it('isLocked: should return true when lock is held', async function () {
+        prepareGetSession(1);
+        stubRequestLockOwnershipState({
+            fence: 0,
+            sessionId: 0,
+            threadId: 0
+        });
+
+        const result = await proxy.isLocked();
+        expect(result).to.be.false;
+    });
+
+    it('isLocked: should throw on unexpected error', async function () {
+        prepareGetSession(1);
+        stubRequestLockOwnershipState({}, new Error());
+
+        await expect(proxy.isLocked()).to.be.rejectedWith(Error);
+    });
+});


### PR DESCRIPTION
* Adds `FencedLock` as the second part of CP Subsystem support
* Introduces `CPSubsystem` component to keep the API consistent with Java client
* Converts `Client#shutdown` into async method and updates tests accordingly
* Includes code samples and documentation
* Migrates some tests to async/await syntax
* Converts benchmark runners code base to use async/await syntax and `process.hrtime`
* Also includes minor tsdoc and code style improvements

Corresponding PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1457030796/Node.js+Client+CP+Sub+System