### PR TITLE
Reuse coalescing buffer in PipelinedWriter

### DIFF
--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -23,7 +23,7 @@ import {BuildInfo} from '../BuildInfo';
 import {HazelcastClient} from '../HazelcastClient';
 import {AddressImpl, IOError, UUID} from '../core';
 import {ClientMessageHandler} from '../protocol/ClientMessage';
-import {DeferredPromise} from '../util/Util';
+import {DeferredPromise, writeBuffers} from '../util/Util';
 import {ILogger} from '../logging/ILogger';
 import {
     ClientMessage,
@@ -31,31 +31,30 @@ import {
     SIZE_OF_FRAME_LENGTH_AND_FLAGS
 } from '../protocol/ClientMessage';
 
-const FROZEN_ARRAY = Object.freeze([]) as OutputQueueItem[];
+const FROZEN_ARRAY = Object.freeze([]);
 const PROPERTY_PIPELINING_ENABLED = 'hazelcast.client.autopipelining.enabled';
 const PROPERTY_PIPELINING_THRESHOLD = 'hazelcast.client.autopipelining.threshold.bytes';
 const PROPERTY_NO_DELAY = 'hazelcast.client.socket.no.delay';
-
-interface OutputQueueItem {
-    buffer: Buffer;
-    resolver: Promise.Resolver<void>;
-}
 
 /** @internal */
 export class PipelinedWriter extends EventEmitter {
 
     private readonly socket: net.Socket;
-    private queue: OutputQueueItem[] = [];
+    private queuedBufs: Buffer[] = [];
+    private queuedResolvers: Promise.Resolver<void>[] = [];
     private error: Error;
     private scheduled = false;
     private canWrite = true;
     // coalescing threshold in bytes
     private readonly threshold: number;
+    // reusable buffer for coalescing
+    private readonly coalesceBuf: Buffer;
 
     constructor(socket: net.Socket, threshold: number) {
         super();
         this.socket = socket;
         this.threshold = threshold;
+        this.coalesceBuf = Buffer.allocUnsafe(threshold);
 
         // write queued items on drain event
         socket.on('drain', () => {
@@ -69,7 +68,8 @@ export class PipelinedWriter extends EventEmitter {
             // if there was a write error, it's useless to keep writing to the socket
             return process.nextTick(() => resolver.reject(this.error));
         }
-        this.queue.push({ buffer, resolver });
+        this.queuedBufs.push(buffer);
+        this.queuedResolvers.push(resolver);
         this.schedule();
     }
 
@@ -86,16 +86,17 @@ export class PipelinedWriter extends EventEmitter {
             return;
         }
 
-        const buffers: Buffer[] = [];
-        const resolvers: Array<Promise.Resolver<void>> = [];
         let totalLength = 0;
-
-        while (this.queue.length > 0 && totalLength < this.threshold) {
-            const item = this.queue.shift();
-            const data = item.buffer;
-            totalLength += data.length;
-            buffers.push(data);
-            resolvers.push(item.resolver);
+        let queueIdx = 0;
+        while (queueIdx < this.queuedBufs.length && totalLength < this.threshold) {
+            const buf = this.queuedBufs[queueIdx];
+            // if the next buffer exceeds the threshold,
+            // try to take multiple queued buffers which fit this.coalesceBuf
+            if (queueIdx > 0 && totalLength + buf.length > this.threshold) {
+                break;
+            }
+            totalLength += buf.length;
+            queueIdx++;
         }
 
         if (totalLength === 0) {
@@ -103,19 +104,33 @@ export class PipelinedWriter extends EventEmitter {
             return;
         }
 
-        // coalesce buffers and write to the socket: no further writes until flushed
-        const merged = buffers.length === 1 ? buffers[0] : Buffer.concat(buffers, totalLength);
-        this.canWrite = this.socket.write(merged as any, (err: Error) => {
+        const buffers = this.queuedBufs.slice(0, queueIdx);
+        this.queuedBufs = this.queuedBufs.slice(queueIdx);
+        const resolvers = this.queuedResolvers.slice(0, queueIdx);
+        this.queuedResolvers = this.queuedResolvers.slice(queueIdx);
+
+        let buf;
+        if (buffers.length === 1) {
+            // take the only buffer
+            buf = buffers[0];
+        } else {
+            // coalesce buffers
+            writeBuffers(this.coalesceBuf, buffers, totalLength);
+            buf = this.coalesceBuf.slice(0, totalLength);
+        }
+
+        // write to the socket: no further writes until flushed
+        this.canWrite = this.socket.write(buf, (err: Error) => {
             if (err) {
                 this.handleError(err, resolvers);
                 return;
             }
 
             this.emit('write');
-            for (const r of resolvers) {
-                r.resolve();
+            for (const resolver of resolvers) {
+                resolver.resolve();
             }
-            if (this.queue.length === 0 || !this.canWrite) {
+            if (this.queuedBufs.length === 0 || !this.canWrite) {
                 // will start running on the next message or drain event
                 this.scheduled = false;
                 return;
@@ -131,10 +146,11 @@ export class PipelinedWriter extends EventEmitter {
             r.reject(this.error);
         }
         // no more items can be added now
-        const q = this.queue;
-        this.queue = FROZEN_ARRAY;
-        for (const it of q) {
-            it.resolver.reject(this.error);
+        const resolvers = this.queuedResolvers;
+        this.queuedResolvers = FROZEN_ARRAY as Promise.Resolver<void>[];
+        this.queuedBufs = FROZEN_ARRAY as Buffer[];
+        for (const resolver of resolvers) {
+            resolver.reject(this.error);
         }
     }
 }

--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -23,7 +23,7 @@ import {BuildInfo} from '../BuildInfo';
 import {HazelcastClient} from '../HazelcastClient';
 import {AddressImpl, IOError, UUID} from '../core';
 import {ClientMessageHandler} from '../protocol/ClientMessage';
-import {DeferredPromise, writeBuffers} from '../util/Util';
+import {DeferredPromise, copyBuffers} from '../util/Util';
 import {ILogger} from '../logging/ILogger';
 import {
     ClientMessage,
@@ -130,7 +130,7 @@ export class PipelinedWriter extends Writer {
             buf = buffers[0];
         } else {
             // coalesce buffers
-            writeBuffers(this.coalesceBuf, buffers, totalLength);
+            copyBuffers(this.coalesceBuf, buffers, totalLength);
             buf = this.coalesceBuf.slice(0, totalLength);
         }
 

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -266,3 +266,22 @@ export function DeferredPromise<T>(): Promise.Resolver<T> {
         promise,
     } as Promise.Resolver<T>;
 }
+
+/**
+ * Writes given array of buffers into the target.
+ *
+ * @param target target buffer
+ * @param sources source buffers
+ * @param totalLength total length of all source buffers
+ * @internal
+ */
+export function writeBuffers(target: Buffer, sources: Buffer[], totalLength: number): void {
+    if (target.length < totalLength) {
+        throw new RangeError('Target length ' + target.length + ' is less than requested ' + totalLength);
+    }
+    let pos = 0;
+    for (const source of sources) {
+        source.copy(target, pos);
+        pos += source.length;
+    }
+}

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -268,14 +268,14 @@ export function DeferredPromise<T>(): Promise.Resolver<T> {
 }
 
 /**
- * Writes given array of buffers into the target.
+ * Copy contents of the given array of buffers into the target buffer.
  *
  * @param target target buffer
  * @param sources source buffers
  * @param totalLength total length of all source buffers
  * @internal
  */
-export function writeBuffers(target: Buffer, sources: Buffer[], totalLength: number): void {
+export function copyBuffers(target: Buffer, sources: Buffer[], totalLength: number): void {
     if (target.length < totalLength) {
         throw new RangeError('Target length ' + target.length + ' is less than requested ' + totalLength);
     }

--- a/test/invocation/InvocationTest.js
+++ b/test/invocation/InvocationTest.js
@@ -20,6 +20,7 @@ const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 const { Client, IndeterminateOperationStateError } = require('../../');
 const { Invocation, InvocationService } = require('../../lib/invocation/InvocationService');
+const { LifecycleServiceImpl } = require('../../lib/LifecycleService');
 const { ClientMessage } = require('../../lib/protocol/ClientMessage');
 
 describe('InvocationTest', function () {
@@ -31,6 +32,7 @@ describe('InvocationTest', function () {
         clientStub = sandbox.stub(Client.prototype);
         serviceStub = sandbox.stub(InvocationService.prototype);
         clientStub.getInvocationService.returns(serviceStub);
+        clientStub.getLifecycleService.returns(sandbox.stub(LifecycleServiceImpl.prototype));
     });
 
     afterEach(function () {

--- a/test/unit/UtilTest.js
+++ b/test/unit/UtilTest.js
@@ -17,31 +17,31 @@
 'use strict';
 
 const { expect } = require('chai');
-const { writeBuffers } = require('../../lib/util/Util');
+const { copyBuffers } = require('../../lib/util/Util');
 
 describe('UtilTest', function () {
 
-    it('writeBuffers: throws on invalid total length', function () {
-        expect(() => writeBuffers(Buffer.from([0x1]), [ Buffer.from([0x2]) ], 3))
+    it('copyBuffers: throws on invalid total length', function () {
+        expect(() => copyBuffers(Buffer.from([0x1]), [ Buffer.from([0x2]) ], 3))
             .to.throw(RangeError);
     });
 
-    it('writeBuffers: writes single buffer of less length', function () {
+    it('copyBuffers: writes single buffer of less length', function () {
         const target = Buffer.from('abc');
         const sources = [ Buffer.from('d') ];
-        writeBuffers(target, sources, 1);
+        copyBuffers(target, sources, 1);
 
         expect(Buffer.compare(target, Buffer.from('dbc'))).to.be.equal(0);
     });
 
-    it('writeBuffers: writes multiple buffers of same total length', function () {
+    it('copyBuffers: writes multiple buffers of same total length', function () {
         const target = Buffer.from('abc');
         const sources = [
             Buffer.from('d'),
             Buffer.from('e'),
             Buffer.from('f')
         ];
-        writeBuffers(target, sources, 3);
+        copyBuffers(target, sources, 3);
 
         expect(Buffer.compare(target, Buffer.from('def'))).to.be.equal(0);
     });

--- a/test/unit/UtilTest.js
+++ b/test/unit/UtilTest.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { expect } = require('chai');
+const { writeBuffers } = require('../../lib/util/Util');
+
+describe('UtilTest', function () {
+
+    it('writeBuffers: throws on invalid total length', function () {
+        expect(() => writeBuffers(Buffer.from([0x1]), [ Buffer.from([0x2]) ], 3))
+            .to.throw(RangeError);
+    });
+
+    it('writeBuffers: writes single buffer of less length', function () {
+        const target = Buffer.from('abc');
+        const sources = [ Buffer.from('d') ];
+        writeBuffers(target, sources, 1);
+
+        expect(Buffer.compare(target, Buffer.from('dbc'))).to.be.equal(0);
+    });
+
+    it('writeBuffers: writes multiple buffers of same total length', function () {
+        const target = Buffer.from('abc');
+        const sources = [
+            Buffer.from('d'),
+            Buffer.from('e'),
+            Buffer.from('f')
+        ];
+        writeBuffers(target, sources, 3);
+
+        expect(Buffer.compare(target, Buffer.from('def'))).to.be.equal(0);
+    });
+});

--- a/test/unit/UuidTest.js
+++ b/test/unit/UuidTest.js
@@ -20,7 +20,8 @@ const UUID = require('../../lib/core/UUID').UUID;
 const expect = require('chai').expect;
 const Long = require('long');
 
-describe('UUID', function () {
+describe('UuidTest', function () {
+
     it('with small most significant high bits', function () {
         const uuid = new UUID(new Long(-99999, 1), new Long(213231, -213321));
         // Should pad first part with zeros


### PR DESCRIPTION
Depends on #584

* Reuse coalescing buffer in `PipelinedWriter`. Before we were using `Buffer.concat()` which allocated a new `Buffer` on each write queue processing
* Also closes #583