### PR TITLE
Revert single queue in PipelinedWriter

### DIFF
--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -182,13 +182,14 @@ export class ClientConnectionManager extends EventEmitter {
             pending.reject(new ClientNotActiveError('Hazelcast client is shutting down'));
         });
 
+        // HeartbeatManager should be shut down before connections are closed
+        this.heartbeatManager.shutdown();
         this.activeConnections.forEach((connection) => {
             connection.close('Hazelcast client is shutting down', null);
         });
 
         this.removeAllListeners(CONNECTION_REMOVED_EVENT_NAME);
         this.removeAllListeners(CONNECTION_ADDED_EVENT_NAME);
-        this.heartbeatManager.shutdown();
     }
 
     public getConnection(uuid: UUID): ClientConnection {

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -333,21 +333,25 @@ export function timedPromise<T>(wrapped: Promise<T>, timeout: number, err?: Erro
     return deferred.promise;
 }
 
+type Binary = {
+    buffer: Buffer;
+}
+
 /**
- * Copy contents of the given array of buffers into the target buffer.
+ * Copy contents of the given array of objects with buffers into the target buffer.
  *
  * @param target target buffer
- * @param sources source buffers
+ * @param sources source objects that contain buffers
  * @param totalLength total length of all source buffers
  * @internal
  */
-export function copyBuffers(target: Buffer, sources: Buffer[], totalLength: number): void {
+export function copyBuffers(target: Buffer, sources: Binary[], totalLength: number): void {
     if (target.length < totalLength) {
         throw new RangeError('Target length ' + target.length + ' is less than requested ' + totalLength);
     }
     let pos = 0;
     for (const source of sources) {
-        source.copy(target, pos);
-        pos += source.length;
+        source.buffer.copy(target, pos);
+        pos += source.buffer.length;
     }
 }

--- a/test/unit/UtilTest.js
+++ b/test/unit/UtilTest.js
@@ -25,13 +25,13 @@ const {
 describe('UtilTest', function () {
 
     it('copyBuffers: throws on invalid total length', function () {
-        expect(() => copyBuffers(Buffer.from([0x1]), [ Buffer.from([0x2]) ], 3))
+        expect(() => copyBuffers(Buffer.from([0x1]), [ { buffer: Buffer.from([0x2]) } ], 3))
             .to.throw(RangeError);
     });
 
     it('copyBuffers: writes single buffer of less length', function () {
         const target = Buffer.from('abc');
-        const sources = [ Buffer.from('d') ];
+        const sources = [ { buffer: Buffer.from('d') } ];
         copyBuffers(target, sources, 1);
 
         expect(Buffer.compare(target, Buffer.from('dbc'))).to.be.equal(0);
@@ -40,9 +40,9 @@ describe('UtilTest', function () {
     it('copyBuffers: writes multiple buffers of same total length', function () {
         const target = Buffer.from('abc');
         const sources = [
-            Buffer.from('d'),
-            Buffer.from('e'),
-            Buffer.from('f')
+            { buffer: Buffer.from('d') },
+            { buffer: Buffer.from('e') },
+            { buffer: Buffer.from('f') }
         ];
         copyBuffers(target, sources, 3);
 


### PR DESCRIPTION
Depends on #587
A follow-up for #585

* Partially reverts `PipelinedWriter` to have a single queue array. To do so, updates `Util.copyBuffers` to handle arrays of objects instead of arrays of buffers.
  - The motivation is the following. This change allows to reduce the number of array copying done in `schedule()` by half, which should be beneficial for the hot path performance.
* Also fixes `ClientConnectionManager` shut down order, so that `HeartbeatManager` is shut down before connections are closed. This should fix flaky tests

#### Additional context

Approach with `Array.slice()`, which was introduced in #585, is significantly faster than the old shift-and-push approach. This may be seen in the following microbenchmark:
https://github.com/puzpuzpuz/microbenchmarks/blob/master/src/slice-vs-push.js

On Node.js v14.8.0 (Ubuntu 18.04) it gives the following output:
```
$ node src/slice-vs-push.js 
slice x 819,592 ops/sec ±1.42% (87 runs sampled)
shift and push x 166,645 ops/sec ±0.17% (96 runs sampled)
```