### PR TITLE
[CP Subsystem] Add AtomicReference support

### DIFF
--- a/code_samples/atomic_reference.js
+++ b/code_samples/atomic_reference.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { Client } = require('hazelcast-client');
+
+(async () => {
+    try {
+        const client = await Client.newHazelcastClient();
+
+        const ref = await client.getCPSubsystem().getAtomicReference('my-ref');
+        await ref.set(42);
+
+        const value = await ref.get();
+        console.log('Value:', value);
+
+        const result = await ref.compareAndSet(42, 'value');
+        console.log('CAS result:', result);
+
+        await client.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/code_samples/org-website/AtomicReferenceSample.js
+++ b/code_samples/org-website/AtomicReferenceSample.js
@@ -29,7 +29,7 @@ const { Client } = require('hazelcast-client');
         // Read the value
         const value = await ref.get();
         console.log('Value:', value);
-        // Performa compare-and-set atomic operation
+        // Perform compare-and-set atomic operation
         const result = await ref.compareAndSet(42, 'value');
         console.log('CAS result:', result);
         // Shutdown this Hazelcast client

--- a/code_samples/org-website/AtomicReferenceSample.js
+++ b/code_samples/org-website/AtomicReferenceSample.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { Client } = require('hazelcast-client');
+
+(async () => {
+    try {
+        // Start the Hazelcast Client and connect to an already running
+        // Hazelcast Cluster on 127.0.0.1
+        const hz = await Client.newHazelcastClient();
+        // Get the Distributed AtomicReference from CP Subsystem
+        const ref = await hz.getCPSubsystem().getAtomicReference('my-ref');
+        // Set the value atomically
+        await ref.set(42);
+        // Read the value
+        const value = await ref.get();
+        console.log('Value:', value);
+        // Performa compare-and-set atomic operation
+        const result = await ref.compareAndSet(42, 'value');
+        console.log('CAS result:', result);
+        // Shutdown this Hazelcast client
+        await hz.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+    }
+})();

--- a/src/CPSubsystem.ts
+++ b/src/CPSubsystem.ts
@@ -16,6 +16,7 @@
 
 import {
     IAtomicLong,
+    IAtomicReference,
     ICountDownLatch,
     FencedLock,
     ISemaphore
@@ -63,6 +64,30 @@ export interface CPSubsystem {
     getAtomicLong(name: string): Promise<IAtomicLong>;
 
     /**
+     * Returns the distributed AtomicReference instance with given name.
+     * The instance is created on CP Subsystem.
+     *
+     * If no group name is given within the `name` argument, then the
+     * AtomicLong instance will be created on the DEFAULT CP group.
+     * If a group name is given, like `.getAtomicReference('myRef@group1')`,
+     * the given group will be initialized first, if not initialized
+     * already, and then the instance will be created on this group.
+     */
+    getAtomicReference<E>(name: string): Promise<IAtomicReference<E>>;
+
+    /**
+     * Returns the distributed CountDownLatch instance with given name.
+     * The instance is created on CP Subsystem.
+     *
+     * If no group name is given within the `name` argument, then the
+     * ICountDownLatch instance will be created on the DEFAULT CP group.
+     * If a group name is given, like `.getCountDownLatch('myLatch@group1')`,
+     * the given group will be initialized first, if not initialized
+     * already, and then the instance will be created on this group.
+     */
+    getCountDownLatch(name: string): Promise<ICountDownLatch>;
+
+    /**
      * Returns the distributed FencedLock instance instance with given name.
      * The instance is created on CP Subsystem.
      *
@@ -86,18 +111,6 @@ export interface CPSubsystem {
      */
     getSemaphore(name: string): Promise<ISemaphore>;
 
-    /**
-     * Returns the distributed CountDownLatch instance with given name.
-     * The instance is created on CP Subsystem.
-     *
-     * If no group name is given within the `name` argument, then the
-     * ICountDownLatch instance will be created on the DEFAULT CP group.
-     * If a group name is given, like `.getCountDownLatch('myLatch@group1')`,
-     * the given group will be initialized first, if not initialized
-     * already, and then the instance will be created on this group.
-     */
-    getCountDownLatch(name: string): Promise<ICountDownLatch>;
-
 }
 
 /** @internal */
@@ -115,16 +128,20 @@ export class CPSubsystemImpl implements CPSubsystem {
         return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.ATOMIC_LONG_SERVICE) as Promise<IAtomicLong>;
     }
 
+    getAtomicReference<E>(name: string): Promise<IAtomicReference<E>> {
+        return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.ATOMIC_REF_SERVICE) as Promise<IAtomicReference<E>>;
+    }
+
+    getCountDownLatch(name: string): Promise<ICountDownLatch> {
+        return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.LATCH_SERVICE) as Promise<ICountDownLatch>;
+    }
+
     getLock(name: string): Promise<FencedLock> {
         return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.LOCK_SERVICE) as Promise<FencedLock>;
     }
 
     getSemaphore(name: string): Promise<ISemaphore> {
         return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.SEMAPHORE_SERVICE) as Promise<ISemaphore>;
-    }
-
-    getCountDownLatch(name: string): Promise<ICountDownLatch> {
-        return this.cpProxyManager.getOrCreateProxy(name, CPProxyManager.LATCH_SERVICE) as Promise<ICountDownLatch>;
     }
 
     getCPSessionManager(): CPSessionManager {

--- a/src/proxy/IAtomicReference.ts
+++ b/src/proxy/IAtomicReference.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {DistributedObject} from '../core';
+
+/**
+ * A distributed, highly available object reference with atomic operations.
+ *
+ * IAtomicReference offers linearizability during crash failures and network
+ * partitions. It is CP with respect to the CAP principle. If a network
+ * partition occurs, it remains available on at most one side of the partition.
+ *
+ * The following are some considerations you need to know when you use IAtomicReference:
+ * <ul>
+ * <li>
+ * IAtomicReference works based on the byte-content and not on the object-reference.
+ * If you use the `compareAndSet()` method, do not change to the original value because
+ * its serialized content will then be different.
+ * </li>
+ * <li>
+ * All methods returning an object return a private copy. You can modify the private
+ * copy, but the rest of the world is shielded from your changes. If you want these
+ * changes to be visible to the rest of the world, you need to write the change back
+ * to the `IAtomicReference`; but be careful about introducing a data-race.
+ * </li>
+ * <li>
+ * The 'in-memory format' of an `IAtomicReference` is `binary`. The receiving side
+ * does not need to have the class definition available unless it needs to be
+ * deserialized on the other side., e.g., because a method like `alter()` is executed.
+ * This deserialization is done for every call that needs to have the object instead
+ * of the binary content, so be careful with expensive object graphs that need to be
+ * deserialized.
+ * </li>
+ * <li>
+ * If you have an object with many fields or an object graph and you only need to
+ * calculate some information or need a subset of fields, you can use the `apply()`
+ * method. With the `apply()` method, the whole object does not need to be sent over
+ * the line; only the information that is relevant is sent.
+ * </li>
+ * </ul>
+ *
+ * `IFunction`-based methods, like `alter()` or `apply()` are not yet supported by
+ * Hazelcast Node.js client.
+ *
+ * IAtomicReference does not offer exactly-once / effectively-once
+ * execution semantics. It goes with at-least-once execution semantics
+ * by default and can cause an API call to be committed multiple times
+ * in case of CP member failures. It can be tuned to offer at-most-once
+ * execution semantics. Please see `fail-on-indeterminate-operation-state`
+ * server-side setting.
+ */
+export interface IAtomicReference<E> extends DistributedObject {
+
+    /**
+     * Atomically sets the value to the given updated value
+     * only if the current value is equal to the expected value.
+     *
+     * @param expect the expected value
+     * @param update the new value
+     * @returns `true` if successful, or `false` if the actual value
+     *          was not equal to the expected value
+     */
+    compareAndSet(expect: E, update: E): Promise<boolean>;
+
+    /**
+     * Gets the current value.
+     *
+     * @returns the current value
+     */
+    get(): Promise<E>;
+
+    /**
+     * Atomically sets the given value.
+     *
+     * @param newValue the new value
+     */
+    set(newValue: E): Promise<void>;
+
+    /**
+     * Gets the old value and sets the new value.
+     *
+     * @param newValue the new value
+     * @returns the old value
+     */
+    getAndSet(newValue: E): Promise<E>;
+
+    /**
+     * Checks if the stored reference is `null`.
+     *
+     * @returns `true` if `null`, `false` otherwise
+     */
+    isNull(): Promise<boolean>;
+
+    /**
+     * Clears the current stored reference, so it becomes a `null`.
+     */
+    clear(): Promise<void>;
+
+    /**
+     * Checks if the reference contains the value.
+     *
+     * @param value the value to check (is allowed to be `null`)
+     * @returns `true` if the value is found, `false` otherwise
+     */
+    contains(value: E): Promise<boolean>;
+}

--- a/src/proxy/ISemaphore.ts
+++ b/src/proxy/ISemaphore.ts
@@ -63,7 +63,7 @@ import {DistributedObject} from '../core';
  * implementation by enabling JDK compatibility `jdk-compatible` server-side
  * setting. Refer to Semaphore configuration documentation for more details.
  * </li>
- * <ul>
+ * </ul>
  */
 export interface ISemaphore extends DistributedObject {
 

--- a/src/proxy/cpsubsystem/AtomicRefProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicRefProxy.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** @ignore *//** */
+
+import {HazelcastClient} from '../../HazelcastClient';
+import {BaseCPProxy} from './BaseCPProxy';
+import {IAtomicReference} from '../IAtomicReference';
+import {CPProxyManager} from './CPProxyManager';
+import {RaftGroupId} from './RaftGroupId';
+import {AtomicRefCompareAndSetCodec} from '../../codec/AtomicRefCompareAndSetCodec';
+import {AtomicRefGetCodec} from '../../codec/AtomicRefGetCodec';
+import {AtomicRefSetCodec} from '../../codec/AtomicRefSetCodec';
+import {AtomicRefContainsCodec} from '../../codec/AtomicRefContainsCodec';
+
+/** @internal */
+export class AtomicRefProxy<E> extends BaseCPProxy implements IAtomicReference<E> {
+
+    constructor(client: HazelcastClient,
+                groupId: RaftGroupId,
+                proxyName: string,
+                objectName: string) {
+        super(client, CPProxyManager.ATOMIC_REF_SERVICE, groupId, proxyName, objectName);
+    }
+
+    compareAndSet(expect: E, update: E): Promise<boolean> {
+        const expectedData = this.toData(expect);
+        const newData = this.toData(update);
+        return this.encodeInvokeOnRandomTarget(
+            AtomicRefCompareAndSetCodec,
+            this.groupId,
+            this.objectName,
+            expectedData,
+            newData
+        ).then((clientMessage) => {
+            const response = AtomicRefCompareAndSetCodec.decodeResponse(clientMessage);
+            return response.response;
+        });
+    }
+
+    get(): Promise<E> {
+        return this.encodeInvokeOnRandomTarget(
+            AtomicRefGetCodec,
+            this.groupId,
+            this.objectName
+        ).then((clientMessage) => {
+            const response = AtomicRefGetCodec.decodeResponse(clientMessage);
+            return this.toObject(response.response);
+        });
+    }
+
+    set(newValue: E): Promise<void> {
+        const newData = this.toData(newValue);
+        return this.encodeInvokeOnRandomTarget(
+            AtomicRefSetCodec,
+            this.groupId,
+            this.objectName,
+            newData,
+            false
+        ).then();
+    }
+
+    getAndSet(newValue: E): Promise<E> {
+        const newData = this.toData(newValue);
+        return this.encodeInvokeOnRandomTarget(
+            AtomicRefSetCodec,
+            this.groupId,
+            this.objectName,
+            newData,
+            true
+        ).then((clientMessage) => {
+            const response = AtomicRefSetCodec.decodeResponse(clientMessage);
+            return this.toObject(response.response);
+        });
+    }
+
+    isNull(): Promise<boolean> {
+        return this.contains(null);
+    }
+
+    clear(): Promise<void> {
+        return this.set(null);
+    }
+
+    contains(value: E): Promise<boolean> {
+        const valueData = this.toData(value);
+        return this.encodeInvokeOnRandomTarget(
+            AtomicRefContainsCodec,
+            this.groupId,
+            this.objectName,
+            valueData
+        ).then((clientMessage) => {
+            const response = AtomicRefContainsCodec.decodeResponse(clientMessage);
+            return response.response;
+        });
+    }
+}

--- a/src/proxy/cpsubsystem/BaseCPProxy.ts
+++ b/src/proxy/cpsubsystem/BaseCPProxy.ts
@@ -20,6 +20,7 @@ import {ClientMessage} from '../../protocol/ClientMessage';
 import {RaftGroupId} from './RaftGroupId';
 import {CPGroupDestroyCPObjectCodec} from '../../codec/CPGroupDestroyCPObjectCodec';
 import {UnsupportedOperationError} from '../../core';
+import {Data} from '../../serialization/Data';
 
 /**
  * Common super class for any CP Subsystem proxy.
@@ -64,6 +65,14 @@ export abstract class BaseCPProxy {
     destroy(): Promise<void> {
         return this.encodeInvokeOnRandomTarget(CPGroupDestroyCPObjectCodec,
             this.groupId, this.serviceName, this.objectName).then();
+    }
+
+    protected toData(object: any): Data {
+        return this.client.getSerializationService().toData(object);
+    }
+
+    protected toObject(data: Data): any {
+        return this.client.getSerializationService().toObject(data);
     }
 
     /**

--- a/src/proxy/cpsubsystem/CPProxyManager.ts
+++ b/src/proxy/cpsubsystem/CPProxyManager.ts
@@ -22,6 +22,7 @@ import {
 } from '../../core';
 import {HazelcastClient} from '../../HazelcastClient';
 import {AtomicLongProxy} from './AtomicLongProxy';
+import {AtomicRefProxy} from './AtomicRefProxy';
 import {CountDownLatchProxy} from './CountDownLatchProxy';
 import {FencedLock} from '../FencedLock';
 import {FencedLockProxy} from './FencedLockProxy';
@@ -70,9 +71,10 @@ export function getObjectNameForProxy(name: string): string {
 export class CPProxyManager {
 
     static readonly ATOMIC_LONG_SERVICE = 'hz:raft:atomicLongService';
+    static readonly ATOMIC_REF_SERVICE = 'hz:raft:atomicRefService';
+    static readonly LATCH_SERVICE = 'hz:raft:countDownLatchService';
     static readonly LOCK_SERVICE = 'hz:raft:lockService';
     static readonly SEMAPHORE_SERVICE = 'hz:raft:semaphoreService';
-    static readonly LATCH_SERVICE = 'hz:raft:countDownLatchService';
 
     private readonly client: HazelcastClient;
     private readonly lockProxies: Map<string, FencedLockProxy> = new Map();
@@ -88,6 +90,8 @@ export class CPProxyManager {
         return this.getGroupId(proxyName).then((groupId): DistributedObject | Promise<DistributedObject> => {
             if (serviceName === CPProxyManager.ATOMIC_LONG_SERVICE) {
                 return new AtomicLongProxy(this.client, groupId, proxyName, objectName);
+            } else if (serviceName === CPProxyManager.ATOMIC_REF_SERVICE) {
+                return new AtomicRefProxy(this.client, groupId, proxyName, objectName);
             } else if (serviceName === CPProxyManager.LATCH_SERVICE) {
                 return new CountDownLatchProxy(this.client, groupId, proxyName, objectName);
             } else if (serviceName === CPProxyManager.LOCK_SERVICE) {

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -36,6 +36,7 @@ export * from './Ringbuffer';
 export * from './MessageListener';
 export * from './TopicOverloadPolicy';
 export * from './IAtomicLong';
+export * from './IAtomicReference';
+export * from './ICountDownLatch';
 export * from './FencedLock';
 export * from './ISemaphore';
-export * from './ICountDownLatch';

--- a/test/cpsubsystem/AtomicReferenceTest.js
+++ b/test/cpsubsystem/AtomicReferenceTest.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const chai = require('chai');
+chai.should();
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const fs = require('fs');
+const RC = require('./../RC');
+const {
+    Client,
+    DistributedObjectDestroyedError
+} = require('../../');
+
+describe('AtomicReferenceTest', function () {
+
+    this.timeout(30000);
+
+    let cluster;
+    let client;
+    let ref;
+
+    before(async function () {
+        cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_cpsubsystem.xml', 'utf8'))
+        await Promise.all([
+            RC.startMember(cluster.id),
+            RC.startMember(cluster.id),
+            RC.startMember(cluster.id)
+        ]);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
+        ref = await client.getCPSubsystem().getAtomicReference('aref');
+    });
+
+    afterEach(async function () {
+        // return to default value
+        await ref.clear();
+    });
+
+    after(async function () {
+        await client.shutdown();
+        return RC.shutdownCluster(cluster.id);
+    });
+
+    it('should create AtomicReference with respect to given CP group', async function () {
+        const refInAnotherGroup = await client.getCPSubsystem().getAtomicReference('aref@mygroup');
+
+        await refInAnotherGroup.set(42);
+        let value = await refInAnotherGroup.get();
+        expect(value).to.be.equal(42);
+
+        value = await ref.get();
+        expect(value).to.be.not.equal(42);
+    });
+
+    it('destroy: should destroy AtomicReference and throw on operation', async function () {
+        const anotherRef = await client.getCPSubsystem().getAtomicReference('another-aref');
+        await anotherRef.destroy();
+        // the next destroy call should be ignored
+        await anotherRef.destroy();
+
+        await expect(anotherRef.get()).to.be.rejectedWith(DistributedObjectDestroyedError);
+    });
+
+    it('compareAndSet: should succeed on expected value match', async function () {
+        let result = await ref.compareAndSet(null, 'foo');
+        expect(result).to.be.true;
+
+        result = await ref.compareAndSet('foo', { foo: 'bar' });
+        expect(result).to.be.true;
+
+        result = await ref.compareAndSet({ foo: 'bar' }, 42);
+        expect(result).to.be.true;
+    });
+
+    it('compareAndSet: should not succeed on expected value mismatch', async function () {
+        await ref.set('foo');
+
+        let result = await ref.compareAndSet(42, 'bar');
+        expect(result).to.be.false;
+    });
+
+    it('get: should return null when value not set yet', async function () {
+        const value = await ref.get();
+        expect(value).to.be.null;
+    });
+
+    it('set: should set string value', async function () {
+        await ref.set('foo');
+        const value = await ref.get();
+        expect(value).to.be.equal('foo');
+    });
+
+    it('set: should set object value', async function () {
+        await ref.set({ foo: 'bar' });
+        const value = await ref.get();
+        expect(value).to.be.deep.equal({ foo: 'bar' });
+    });
+
+    it('getAndSet: should return old value and set new one', async function () {
+        let value = await ref.getAndSet('foo');
+        expect(value).to.be.null;
+
+        value = await ref.getAndSet('bar');
+        expect(value).to.be.equal('foo');
+
+        value = await ref.get();
+        expect(value).to.be.equal('bar');
+    });
+
+    it('isNull: should return true when null', async function () {
+        const isNull = await ref.isNull();
+        expect(isNull).to.be.true;
+    });
+
+    it('isNull: should return false when not null', async function () {
+        await ref.set('foo');
+        const isNull = await ref.isNull();
+        expect(isNull).to.be.false;
+    });
+
+    it('isNull: should return false when not null', async function () {
+        await ref.set('foo');
+        await ref.clear();
+        const isNull = await ref.isNull();
+        expect(isNull).to.be.true;
+    });
+
+    it('contains: should return true on matching values', async function () {
+        let result = await ref.contains(null);
+        expect(result).to.be.true;
+
+        await ref.set('foo');
+        result = await ref.contains('foo');
+        expect(result).to.be.true;
+
+        await ref.set({ foo: 'bar' });
+        result = await ref.contains({ foo: 'bar' });
+        expect(result).to.be.true;
+    });
+
+    it('contains: should return false on non-matching values', async function () {
+        await ref.set(42);
+
+        let result = await ref.contains('foo');
+        expect(result).to.be.false;
+
+        result = await ref.contains({ foo: 'bar' });
+        expect(result).to.be.false;
+
+        result = await ref.contains(null);
+        expect(result).to.be.false;
+    });
+});


### PR DESCRIPTION
Depends on #591

Closes: #581

* Adds `IAtomicReference` as the last part of CP Subsystem support in v4.0
* Includes code samples and documentation
* Also includes minor tsdoc, documentation and code style improvements

Corresponding client protocol PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/342

Corresponding PRD: https://hazelcast.atlassian.net/wiki/spaces/PM/pages/1457030796/Node.js+Client+CP+Sub+System