### PR TITLE
Fix flaky HeartbeatFromServerTest

### DIFF
--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -412,8 +412,8 @@ export class ClientConnection {
 
         this.logClose();
 
-        this.socket.end();
         this.writer.close();
+        this.socket.end();
 
         this.client.getConnectionManager().onConnectionClose(this);
     }

--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -315,6 +315,7 @@ export class FragmentedClientMessageHandler {
 
 /** @internal */
 export class ClientConnection {
+
     private readonly connectionId: number;
     private remoteAddress: AddressImpl;
     private remoteUuid: UUID;

--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -145,7 +145,7 @@ export class ClientConnectionManager extends EventEmitter {
         this.reconnectMode = connectionStrategyConfig.reconnectMode;
     }
 
-    public start(): Promise<void> {
+    start(): Promise<void> {
         if (this.alive) {
             return Promise.resolve();
         }
@@ -160,7 +160,7 @@ export class ClientConnectionManager extends EventEmitter {
             });
     }
 
-    public connectToAllClusterMembers(): Promise<void> {
+    connectToAllClusterMembers(): Promise<void> {
         if (!this.isSmartRoutingEnabled) {
             return Promise.resolve();
         }
@@ -169,7 +169,7 @@ export class ClientConnectionManager extends EventEmitter {
         return this.tryConnectToAllClusterMembers(members);
     }
 
-    public shutdown(): void {
+    shutdown(): void {
         if (!this.alive) {
             return;
         }
@@ -192,11 +192,11 @@ export class ClientConnectionManager extends EventEmitter {
         this.removeAllListeners(CONNECTION_ADDED_EVENT_NAME);
     }
 
-    public getConnection(uuid: UUID): ClientConnection {
+    getConnection(uuid: UUID): ClientConnection {
         return this.activeConnections.get(uuid.toString());
     }
 
-    public checkIfInvocationAllowed(): Error {
+    checkIfInvocationAllowed(): Error {
         const state = this.clientState;
         if (state === ClientState.INITIALIZED_ON_CLUSTER && this.activeConnections.size > 0) {
             return null;
@@ -217,19 +217,19 @@ export class ClientConnectionManager extends EventEmitter {
         return error;
     }
 
-    public getActiveConnections(): ClientConnection[] {
+    getActiveConnections(): ClientConnection[] {
         return Array.from(this.activeConnections.values());
     }
 
-    public isAlive(): boolean {
+    isAlive(): boolean {
         return this.alive;
     }
 
-    public getClientUuid(): UUID {
+    getClientUuid(): UUID {
         return this.clientUuid;
     }
 
-    public getOrConnect(address: AddressImpl): Promise<ClientConnection> {
+    getOrConnect(address: AddressImpl): Promise<ClientConnection> {
         if (!this.client.getLifecycleService().isRunning()) {
             return Promise.reject(new ClientNotActiveError('Client is not active.'));
         }
@@ -278,7 +278,7 @@ export class ClientConnectionManager extends EventEmitter {
         ).finally(() => this.pendingConnections.delete(addressKey));
     }
 
-    public getRandomConnection(): ClientConnection {
+    getRandomConnection(): ClientConnection {
         if (this.isSmartRoutingEnabled) {
             const member = this.loadBalancer.next();
             if (member != null) {
@@ -298,7 +298,7 @@ export class ClientConnectionManager extends EventEmitter {
         }
     }
 
-    public onConnectionClose(connection: ClientConnection): void {
+    onConnectionClose(connection: ClientConnection): void {
         const endpoint = connection.getRemoteAddress();
         const memberUuid = connection.getRemoteUuid();
 

--- a/src/network/HeartbeatManager.ts
+++ b/src/network/HeartbeatManager.ts
@@ -51,7 +51,7 @@ export class HeartbeatManager {
     /**
      * Starts sending periodic heartbeat operations.
      */
-    public start(): void {
+    start(): void {
         this.timer = scheduleWithRepetition(
             this.heartbeatFunction.bind(this), this.heartbeatInterval, this.heartbeatInterval);
     }
@@ -59,14 +59,14 @@ export class HeartbeatManager {
     /**
      * Cancels the periodic heartbeat operation.
      */
-    public shutdown(): void {
+    shutdown(): void {
         cancelRepetitionTask(this.timer);
     }
 
     /**
      * Returns the heartbeat timeout in milliseconds.
      */
-    public getHeartbeatTimeout(): number {
+    getHeartbeatTimeout(): number {
         return this.heartbeatTimeout;
     }
 

--- a/src/network/HeartbeatManager.ts
+++ b/src/network/HeartbeatManager.ts
@@ -38,7 +38,7 @@ export class HeartbeatManager {
     private readonly heartbeatTimeout: number;
     private readonly heartbeatInterval: number;
     private logger: ILogger;
-    private timer: Task;
+    private task: Task;
 
     constructor(client: HazelcastClient, connectionManager: ClientConnectionManager) {
         this.client = client;
@@ -52,7 +52,7 @@ export class HeartbeatManager {
      * Starts sending periodic heartbeat operations.
      */
     start(): void {
-        this.timer = scheduleWithRepetition(
+        this.task = scheduleWithRepetition(
             this.heartbeatFunction.bind(this), this.heartbeatInterval, this.heartbeatInterval);
     }
 
@@ -60,7 +60,7 @@ export class HeartbeatManager {
      * Cancels the periodic heartbeat operation.
      */
     shutdown(): void {
-        cancelRepetitionTask(this.timer);
+        cancelRepetitionTask(this.task);
     }
 
     /**

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -232,8 +232,8 @@ export function randomInt(upperBound: number): number {
 
 /** @internal */
 export class Task {
-    intervalId: NodeJS.Timer;
     timeoutId: NodeJS.Timer;
+    intervalId: NodeJS.Timer;
 }
 
 /** @internal */

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -237,34 +237,31 @@ export class Task {
 }
 
 /** @internal */
-export function scheduleWithRepetition(callback: (...args: any[]) => void,
-                                       initialDelay: number,
-                                       periodMillis: number): Task {
+export function scheduleWithRepetition(callback: () => void,
+                                       initialDelayMs: number,
+                                       periodMs: number): Task {
     const task = new Task();
-    task.timeoutId = setTimeout(function (): void {
+    task.timeoutId = setTimeout(() => {
         callback();
-        task.intervalId = setInterval(callback, periodMillis);
-    }, initialDelay);
-
+        task.intervalId = setInterval(callback, periodMs);
+    }, initialDelayMs);
     return task;
 }
 
 /** @internal */
 export function cancelRepetitionTask(task: Task): void {
-    if (task.intervalId != null) {
+    if (task.intervalId !== undefined) {
         clearInterval(task.intervalId);
-    } else if (task.timeoutId != null) {
+    } else if (task.timeoutId !== undefined) {
         clearTimeout(task.timeoutId);
     }
 }
 
 /** @internal */
 export interface DeferredPromise<T> {
-
     promise: Promise<T>;
     resolve: (result: T) => void;
     reject: (err: Error) => void;
-
 }
 
 /**

--- a/test/heartbeat/HeartbeatFromServerTest.js
+++ b/test/heartbeat/HeartbeatFromServerTest.js
@@ -56,7 +56,7 @@ describe('HeartbeatFromServerTest', function () {
     });
 
     it('connectionRemoved fired when second member stops heartbeating', function (done) {
-        const memberAddedPromise = new deferredPromise();
+        const memberAddedPromise = deferredPromise();
         RC.startMember(cluster.id).then(() => {
             return Client.newHazelcastClient({
                 clusterName: cluster.id,
@@ -104,7 +104,7 @@ describe('HeartbeatFromServerTest', function () {
 
     it('connectionAdded fired when second member comes back', function (done) {
         let member2;
-        const memberAddedPromise = new deferredPromise();
+        const memberAddedPromise = deferredPromise();
         RC.startMember(cluster.id).then(() => {
             return Client.newHazelcastClient({
                 clusterName: cluster.id,

--- a/test/heartbeat/HeartbeatFromServerTest.js
+++ b/test/heartbeat/HeartbeatFromServerTest.js
@@ -71,8 +71,11 @@ describe('HeartbeatFromServerTest', function () {
             const membershipListener = {
                 memberAdded: (membershipEvent) => {
                     const address = new AddressImpl(membershipEvent.member.address.host, membershipEvent.member.address.port);
-                    warmUpConnectionToAddressWithRetry(client, address);
-                    memberAddedPromise.resolve();
+                    warmUpConnectionToAddressWithRetry(client, address)
+                        .then(() => {
+                            memberAddedPromise.resolve();
+                        })
+                        .catch(done);
                 }
             };
 


### PR DESCRIPTION
* Fixes `warmUpConnectionToAddressWithRetry` handling in `HeartbeatFromServerTest`. Previous test implementation was leading to flakiness (e.g. see this [failed test](http://jenkins.hazelcast.com/job/NodeJS-pr-builder/558/testReport/junit/(root)/connectionRemoved%20fired%20when%20second%20member%20stops%20heartbeating/HeartbeatFromServerTest_connectionRemoved_fired_when_second_member_stops_heartbeating/))
* Also includes minor code style improvements