### PR TITLE
Document reentrancy in map lock methods

### DIFF
--- a/src/proxy/IMap.ts
+++ b/src/proxy/IMap.ts
@@ -33,7 +33,7 @@ export interface IMap<K, V> extends DistributedObject {
 
     /**
      * Applies the aggregation logic on all map entries and returns the result
-     * <p>
+     *
      * Fast-Aggregations are the successor of the Map-Reduce Aggregators.
      * They are equivalent to the Map-Reduce Aggregators in most of the use-cases, but instead of running on the Map-Reduce
      * engine they run on the Query infrastructure. Their performance is tens to hundreds times better due to the fact
@@ -41,13 +41,13 @@ export interface IMap<K, V> extends DistributedObject {
      *
      * @param aggregator aggregator to aggregate the entries with
      * @param <R> type of the result
-     * @return the result of the given type
+     * @returns the result of the given type
      */
     aggregate<R>(aggregator: Aggregator<R>): Promise<R>;
 
     /**
      * Applies the aggregation logic on map entries filtered with the Predicated and returns the result
-     * <p>
+     *
      * Fast-Aggregations are the successor of the Map-Reduce Aggregators.
      * They are equivalent to the Map-Reduce Aggregators in most of the use-cases, but instead of running on the Map-Reduce
      * engine they run on the Query infrastructure. Their performance is tens to hundreds times better due to the fact
@@ -56,53 +56,55 @@ export interface IMap<K, V> extends DistributedObject {
      * @param aggregator aggregator to aggregate the entries with
      * @param predicate predicate to filter the entries with
      * @param <R> type of the result
-     * @return the result of the given type
+     * @returns the result of the given type
      */
     aggregateWithPredicate<R>(aggregator: Aggregator<R>, predicate: Predicate): Promise<R>;
 
     /**
      * Adds an index to this map for the specified entries so
      * that queries can run faster.
-     * <p>
+     *
      * Let's say your map values are Employee objects.
-     * <pre>
-     *   class Employee implements Portable {
+     * ```
+     * class Employee implements Portable {
      *     active: boolean = false;
      *     age: number;
      *     name: string = null;
      *     // other fields
      *
      *     // portable implementation
-     *   }
-     * </pre>
+     * }
+     * ```
+     *
      * If you are querying your values mostly based on age and active then
      * you may consider indexing these fields.
-     * <pre>
-     *   const imap = client.getMap('employees');
-     *   // Sorted index for range queries:
-     *   imap.addIndex({
-     *       type: 'SORTED',
-     *       attributes: ['age']
-     *   });
-     *   // Hash index for equality predicates:
-     *   imap.addIndex({
-     *       type: 'HASH',
-     *       attributes: ['active']
-     *   });
-     * </pre>
+     * ```
+     * const map = client.getMap('employees');
+     * // Sorted index for range queries:
+     * map.addIndex({
+     *     type: 'SORTED',
+     *     attributes: ['age']
+     * });
+     * // Hash index for equality predicates:
+     * map.addIndex({
+     *     type: 'HASH',
+     *     attributes: ['active']
+     * });
+     * ```
+     *
      * Index attribute should either have a getter method or be public.
      * You should also make sure to add the indexes before adding
      * entries to this map.
-     * <p>
-     * <b>Time to Index</b>
-     * <p>
+     *
+     * **Time to Index**
+     *
      * Indexing time is executed in parallel on each partition by operation threads. The Map
      * is not blocked during this operation.
-     * <p>
+     *
      * The time taken in proportional to the size of the Map and the number Members.
-     * <p>
-     * <b>Searches while indexes are being built</b>
-     * <p>
+     *
+     * **Searches while indexes are being built**
+     *
      * Until the index finishes being created, any searches for the attribute will use a full Map scan,
      * thus avoiding using a partially built index and returning incorrect results.
      *
@@ -113,16 +115,16 @@ export interface IMap<K, V> extends DistributedObject {
     /**
      * Returns `true` if this map has an item associated with key.
      * @param key
-     * @throws {RangeError} if key is undefined or null
-     * @return `true` if the map contains the key, `false` otherwise.
+     * @throws RangeError if key is `null` or `undefined`
+     * @returns `true` if the map contains the key, `false` otherwise.
      */
     containsKey(key: K): Promise<boolean>;
 
     /**
      * Returns `true` if this map has key(s) associated with given value.
      * @param value
-     * @throws {RangeError} if value is undefined or null
-     * @return `true` if the map has key or keys associated with given value.
+     * @throws RangeError if value is `null` or `undefined`
+     * @returns `true` if the map has key or keys associated with given value
      */
     containsValue(value: V): Promise<boolean>;
 
@@ -134,19 +136,20 @@ export interface IMap<K, V> extends DistributedObject {
      * @param value
      * @param ttl Time to live in milliseconds. 0 means infinite.
      * If ttl is not an integer, it is rounded up to the nearest integer value.
-     * @throws {RangeError} if specified key or value is undefined or null or ttl is negative.
-     * @return old value if there was any, `undefined` otherwise.
+     * @throws RangeError if specified key or value is `undefined` or `null`
+     *                    or ttl is negative.
+     * @returns old value if there was any, `undefined` otherwise
      */
     put(key: K, value: V, ttl?: number): Promise<V>;
 
     /**
      * Puts all key value pairs from this array to the map as key -> value mappings.
-     * <p>
+     *
      * The behaviour of this operation is undefined if the specified pairs are modified
      * while this operation is in progress.
      *
-     * <p><b>Interactions with the map store</b>
-     * <p>
+     *<b>Interactions with the map store</b>
+     *
      * For each element not found in memory
      * MapLoader#load(Object) is invoked to load the value from
      * the map store backing the map, which may come at a significant
@@ -154,7 +157,7 @@ export interface IMap<K, V> extends DistributedObject {
      * and are propagated to the caller. The elements which were added
      * before the exception was thrown will remain in the map, the rest
      * will not be added.
-     * <p>
+     *
      * If write-through persistence mode is configured,
      * MapStore#store(Object, Object) is invoked for each element
      * before the element is added in memory, which may come at a
@@ -162,7 +165,7 @@ export interface IMap<K, V> extends DistributedObject {
      * operation and are propagated to the caller. The elements which
      * were added before the exception was thrown will remain in the map,
      * the rest will not be added.
-     * <p>
+     *
      * If write-behind persistence mode is configured with
      * write-coalescing turned off,
      * this call may be rejected with {@link ReachedMaxSizeError}
@@ -176,15 +179,15 @@ export interface IMap<K, V> extends DistributedObject {
     /**
      * Puts all key value pairs from this array to the map as key -> value mappings without loading
      * non-existing elements from map store (which is more efficient than {@link putAll}).
-     * <p>
+     *
      * This method breaks the contract of EntryListener.
-     * EntryEvent of all the updated entries will have null oldValue even if they exist previously.
-     * <p>
+     * EntryEvent of all the updated entries will have `null` oldValue even if they exist previously.
+     *
      * The behaviour of this operation is undefined if the specified pairs are modified
      * while this operation is in progress.
      *
-     * <p><b>Interactions with the map store</b>
-     * <p>
+     *<b>Interactions with the map store</b>
+     *
      * If write-through persistence mode is configured,
      * MapStore#store(Object, Object) is invoked for each element
      * before the element is added in memory, which may come at a
@@ -192,7 +195,7 @@ export interface IMap<K, V> extends DistributedObject {
      * operation and are propagated to the caller. The elements which
      * were added before the exception was thrown will remain in the map,
      * the rest will not be added.
-     * <p>
+     *
      * If write-behind persistence mode is configured with
      * write-coalescing turned off,
      * this call may be rejected with {@link ReachedMaxSizeError}
@@ -207,8 +210,8 @@ export interface IMap<K, V> extends DistributedObject {
     /**
      * Retrieves the value associated with given key.
      * @param key
-     * @throws {RangeError} if key is undefined or null
-     * @return value associated with key, undefined if the key does not exist.
+     * @throws RangeError if key is `null` or `undefined`
+     * @returns value associated with key, `undefined` if the key does not exist
      */
     get(key: K): Promise<V>;
 
@@ -219,28 +222,31 @@ export interface IMap<K, V> extends DistributedObject {
     getAll(keys: K[]): Promise<Array<[K, V]>>;
 
     /**
-     * Removes specified key from map. If optional value is specified, the key is removed only if currently mapped to
-     * given value.
+     * Removes specified key from map. If optional value is specified, the key
+     * is removed only if currently mapped to given value.
      * Note that serialized version of value is used in comparison.
+     *
      * @param key
      * @param value
-     * @throws {RangeError} if key is undefined or null
-     * @return value associated with key, `undefined` if the key did not exist before. If optional value is specified,
-     * a boolean representing whether or not entry is removed is returned.
+     * @throws RangeError if key is `null` or `undefined`
+     * @returns value associated with key, `undefined` if the key did not exist
+     *          before. If optional value is specified, a `boolean` representing
+     *          whether or not entry is removed is returned
      */
     remove(key: K, value?: V): Promise<V | boolean>;
 
     /**
      * Removes specified key from map. Unlike {@link remove} this method does not return deleted value.
      * Therefore it eliminates deserialization cost of returned value.
-     * @throws {RangeError} if key is null or undefined.
+     *
+     * @throws RangeError if key is `null` or `undefined`
      * @param key
      */
     delete(key: K): Promise<void>;
 
     /**
      * Retrieves the number of elements in map
-     * @return number of elements in map
+     * @returns number of elements in map
      */
     size(): Promise<number>;
 
@@ -264,13 +270,13 @@ export interface IMap<K, V> extends DistributedObject {
      * Queries the map based on the specified predicate and returns matching entries.
      * Specified predicate runs on all members in parallel.
      * @param predicate specified query criteria.
-     * @return result entry set of the query.
+     * @returns result entry set of the query.
      */
     entrySetWithPredicate(predicate: Predicate): Promise<Array<[K, V]>>;
 
     /**
      * Evicts the specified key from this map.
-     * @throws {RangeError} if key is null or undefined.
+     * @throws RangeError if key is `null` or `undefined`
      * @param key
      */
     evict(key: K): Promise<boolean>;
@@ -287,17 +293,19 @@ export interface IMap<K, V> extends DistributedObject {
 
     /**
      * Releases the lock for the specified key regardless of the owner.
-     * It always unlocks the key.
-     * @throws {RangeError} if key is null or undefined.
+     * This operation always unlocks the key.
+     *
+     * @throws RangeError if key is `null` or `undefined`
      * @param key
      */
     forceUnlock(key: K): Promise<void>;
 
     /**
      * Checks whether given key is locked.
+     *
      * @param key
-     * @throws {RangeError} if key is null or undefined.
-     * @return `true` if key is locked, `false` otherwise
+     * @throws RangeError if key is `null` or `undefined`
+     * @returns `true` if key is locked, `false` otherwise
      */
     isLocked(key: K): Promise<boolean>;
 
@@ -306,10 +314,14 @@ export interface IMap<K, V> extends DistributedObject {
      * This means it may never be resolved if some other process holds the lock and does not unlock it.
      * A lock may be acquired on non-existent keys. Other processes wait on non-existent key.
      * When this client puts the non-existent key, it is allowed to do that.
-     * Locks are re-entrant meaning that if lock is taken N times, it should be released N times.
+     *
+     * Locking is reentrant, meaning that the lock owner client can obtain the lock multiple times.
+     * If the lock was acquired multiple times, then `unlock()` method must be called the same amount of
+     * times, otherwise the lock will remain unavailable.
+     *
      * @param key
-     * @param ttl lock is automatically unlocked after `ttl` milliseconds.
-     * @throws {RangeError} if key is null or undefined.
+     * @param ttl lock is automatically unlocked after `ttl` milliseconds
+     * @throws RangeError if key is `null` or `undefined`
      */
     lock(key: K, ttl?: number): Promise<void>;
 
@@ -333,48 +345,53 @@ export interface IMap<K, V> extends DistributedObject {
 
     /**
      * Puts specified key value association if it was not present before.
+     *
      * @param key
      * @param value
-     * @param ttl if set, key will be evicted automatically after `ttl` milliseconds.
-     * @throws {RangeError} if key or value is null or undefined.
-     * @return old value of the entry.
+     * @param ttl if set, key will be evicted automatically after `ttl` milliseconds
+     * @throws RangeError if key or value is `null` or `undefined`
+     * @returns old value of the entry.
      */
     putIfAbsent(key: K, value: V, ttl?: number): Promise<V>;
 
     /**
      * Same as {@link put} except it does not call underlying MapStore.
+     *
      * @param key
      * @param value
      * @param ttl
-     * @throws {RangeError} if key or value is null or undefined.
+     * @throws RangeError if key or value is `null` or `undefined`
      */
     putTransient(key: K, value: V, ttl?: number): Promise<void>;
 
     /**
      * Replaces value of the key if only it was associated to `oldValue`.
+     *
      * @param key
      * @param value
      * @param oldValue
-     * @throws {RangeError} if key, oldValue or newValue is null or undefined.
-     * @return `true` if the value was replaced.
+     * @throws RangeError if key, oldValue or newValue is `null` or `undefined`
+     * @returns `true` if the value was replaced
      */
     replaceIfSame(key: K, oldValue: V, newValue: V): Promise<boolean>;
 
     /**
      * Replaces value of given key with `newValue`.
+     *
      * @param key
      * @param newValue
-     * @throws {RangeError} if key or newValue is null or undefined.
-     * @return previous value
+     * @throws RangeError if key or newValue is `null` or `undefined`
+     * @returns previous value
      */
     replace(key: K, newValue: V): Promise<V>;
 
     /**
      * Similar to {@link put} except it does not return the old value.
+     *
      * @param key
      * @param value
      * @param ttl
-     * @throws {RangeError} if key or value is null or undefined.
+     * @throws RangeError if key or value is `null` or `undefined`
      */
     set(key: K, value: V, ttl?: number): Promise<void>;
 
@@ -382,8 +399,9 @@ export interface IMap<K, V> extends DistributedObject {
      * Releases the lock for this key.
      * If this client holds the lock, hold count is decremented.
      * If hold count is zero, lock is released.
-     * @throws {RangeError} if this client is not the owner of the key.
+     *
      * @param key
+     * @throws RangeError if this client is not the owner of the key
      */
     unlock(key: K): Promise<void>;
 
@@ -393,27 +411,33 @@ export interface IMap<K, V> extends DistributedObject {
     values(): Promise<ReadOnlyLazyList<V>>;
 
     /**
-     * Queries the map based on the specified predicate and returns the values of matching entries.
-     * Specified predicate runs on all members in parallel.
+     * Queries the map based on the specified predicate and returns the values of
+     * matching entries. Specified predicate runs on all members in parallel.
+     *
      * @param predicate
-     * @return a list of values that satisfies the given predicate.
+     * @returns a list of values that satisfies the given predicate
      */
     valuesWithPredicate(predicate: Predicate): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * Returns a key-value pair representing the association of given key
      * @param key
-     * @throws {RangeError} if key is null or undefined.
+     * @throws RangeError if key is `null` or `undefined`
      */
     getEntryView(key: K): Promise<SimpleEntryView<K, V>>;
 
     /**
      * Tries to acquire the lock for the specified key.
-     * If lock is not available, server immediately responds with {false}
+     * If lock is not available, server immediately responds with `false`.
+     *
+     * Locking is reentrant, meaning that the lock owner client can obtain the lock multiple times.
+     * If the lock was acquired multiple times, then `unlock()` method must be called the same amount of
+     * times, otherwise the lock will remain unavailable.
+     *
      * @param key
-     * @param timeout Server waits for `timeout` milliseconds to acquire the lock before giving up.
-     * @param lease lock is automatically release after `lease` milliseconds.
-     * @throws {RangeError} if key is null or undefined.
+     * @param timeout Server waits for `timeout` milliseconds to acquire the lock before giving up
+     * @param lease lock is automatically release after `lease` milliseconds
+     * @throws RangeError if key is `null` or `undefined`
      */
     tryLock(key: K, timeout?: number, lease?: number): Promise<boolean>;
 
@@ -421,10 +445,11 @@ export interface IMap<K, V> extends DistributedObject {
      * Tries to put specified key value pair into map. If this method returns
      * false, it indicates that caller thread was not able to acquire the lock for
      * given key in `timeout` milliseconds.
+     *
      * @param key
      * @param value
      * @param timeout
-     * @throws {RangeError} if key or value is null or undefined.
+     * @throws RangeError if key or value is `null` or `undefined`
      */
     tryPut(key: K, value: V, timeout: number): Promise<boolean>;
 
@@ -432,37 +457,42 @@ export interface IMap<K, V> extends DistributedObject {
      * Tries to remove specified key from map. If this method returns
      * false, it indicates that caller thread was not able to acquire the lock for
      * given key in `timeout` milliseconds.
+     *
      * @param key
      * @param timeout
-     * @throws {RangeError} if key is null or undefined.
+     * @throws RangeError if key is `null` or `undefined`
      */
     tryRemove(key: K, timeout: number): Promise<boolean>;
 
     /**
      * Adds a {@link MapListener} for this map.
+     *
      * @param listener
-     * @param key Events are triggered for only this key if set.
-     * @param includeValue Event message contains new value of the key if set to {true}.
-     * @return Registration id of the listener.
+     * @param key Events are triggered for only this key if set
+     * @param includeValue Event message contains new value of the key if set to {true}
+     * @returns registration id of the listener
      */
     addEntryListener(listener: MapListener<K, V>, key?: K, includeValue?: boolean): Promise<string>;
 
     /**
      * Adds a {@link MapListener} for this map.
      * Listener will get notified for map add/remove/update/evict events filtered by the given predicate.
+     *
      * @param listener
      * @param predicate
-     * @param key Events are triggered for only this key if set.
-     * @param includeValue Event message contains new value of the key if set to `true`.
-     * @return Registration id of the listener.
+     * @param key Events are triggered for only this key if set
+     * @param includeValue Event message contains new value of the key if set to `true`
+     * @returns registration id of the listener
      */
     addEntryListenerWithPredicate(listener: MapListener<K, V>, predicate: Predicate,
                                   key?: K, includeValue?: boolean): Promise<string>;
 
     /**
      * Removes a {@link MapListener} from this map.
-     * @param listenerId Registration Id of the listener.
-     * @return `true` if remove operation is successful, `false` if unsuccessful or this listener did not exist.
+     *
+     * @param listenerId registration Id of the listener
+     * @returns `true` if remove operation is successful, `false` if unsuccessful or this listener
+     *          did not exist
      */
     removeEntryListener(listenerId: string): Promise<boolean>;
 
@@ -470,17 +500,20 @@ export interface IMap<K, V> extends DistributedObject {
      * Applies the user defined EntryProcessor to the all entries in the map.
      * Returns the results mapped by each key in the map
      * Note that {entryProcessor} should be registered at server side too.
+     *
      * @param entryProcessor
-     * @param predicate if specified, entry processor is applied to the entries that satisfis this predicate.
-     * @return entries after entryprocessor is applied.
+     * @param predicate if specified, entry processor is applied to the entries that satisfies
+     *                  this predicate
+     * @returns entries after entryprocessor is applied
      */
     executeOnEntries(entryProcessor: IdentifiedDataSerializable | Portable, predicate?: Predicate): Promise<Array<[K, V]>>;
 
     /**
      * Applies the user defined EntryProcessor to the entry mapped by the key.
-     * @param key entry processor is applied only to the value that is mapped with this key.
-     * @param entryProcessor entry processor to be applied.
-     * @return result of entry process.
+     *
+     * @param key entry processor is applied only to the value that is mapped with this key
+     * @param entryProcessor entry processor to be applied
+     * @returns result of entry process
      */
     executeOnKey(key: K, entryProcessor: IdentifiedDataSerializable | Portable): Promise<V>;
 
@@ -489,7 +522,7 @@ export interface IMap<K, V> extends DistributedObject {
      *
      * @param keys keys to be processed
      * @param entryProcessor
-     * @return result of entry process
+     * @returns result of entry process
      */
     executeOnKeys(keys: K[], entryProcessor: IdentifiedDataSerializable | Portable): Promise<Array<[K, V]>>;
 }

--- a/src/proxy/IMap.ts
+++ b/src/proxy/IMap.ts
@@ -116,7 +116,7 @@ export interface IMap<K, V> extends DistributedObject {
      * Returns `true` if this map has an item associated with key.
      * @param key
      * @throws RangeError if key is `null` or `undefined`
-     * @returns `true` if the map contains the key, `false` otherwise.
+     * @returns `true` if the map contains the key, `false` otherwise
      */
     containsKey(key: K): Promise<boolean>;
 
@@ -137,8 +137,8 @@ export interface IMap<K, V> extends DistributedObject {
      * @param ttl Time to live in milliseconds. 0 means infinite.
      * If ttl is not an integer, it is rounded up to the nearest integer value.
      * @throws RangeError if specified key or value is `undefined` or `null`
-     *                    or ttl is negative.
-     * @returns old value if there was any, `undefined` otherwise
+     *                    or ttl is negative
+     * @returns old value if there was any, `null` otherwise
      */
     put(key: K, value: V, ttl?: number): Promise<V>;
 
@@ -211,7 +211,7 @@ export interface IMap<K, V> extends DistributedObject {
      * Retrieves the value associated with given key.
      * @param key
      * @throws RangeError if key is `null` or `undefined`
-     * @returns value associated with key, `undefined` if the key does not exist
+     * @returns value associated with key, `null` if the key does not exist
      */
     get(key: K): Promise<V>;
 
@@ -229,7 +229,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @param key
      * @param value
      * @throws RangeError if key is `null` or `undefined`
-     * @returns value associated with key, `undefined` if the key did not exist
+     * @returns value associated with key, `null` if the key did not exist
      *          before. If optional value is specified, a `boolean` representing
      *          whether or not entry is removed is returned
      */
@@ -350,7 +350,7 @@ export interface IMap<K, V> extends DistributedObject {
      * @param value
      * @param ttl if set, key will be evicted automatically after `ttl` milliseconds
      * @throws RangeError if key or value is `null` or `undefined`
-     * @returns old value of the entry.
+     * @returns old value of the entry
      */
     putIfAbsent(key: K, value: V, ttl?: number): Promise<V>;
 

--- a/src/proxy/MultiMap.ts
+++ b/src/proxy/MultiMap.ts
@@ -31,7 +31,7 @@ export interface MultiMap<K, V> extends DistributedObject {
      * will not replace the old value. Instead, both values will be associated with the same key.
      * @param key key to add.
      * @param value value to associate with the key.
-     * @return `true` if this multi-map did not have the specified value associated
+     * @returns `true` if this multi-map did not have the specified value associated
      * with the specified key, `false` otherwise.
      */
     put(key: K, value: V): Promise<boolean>;
@@ -39,7 +39,7 @@ export interface MultiMap<K, V> extends DistributedObject {
     /**
      * Retrieves a list of values associated with the specified key.
      * @param key key to search for.
-     * @return a list of values associated with the specified key.
+     * @returns a list of values associated with the specified key.
      */
     get(key: K): Promise<ReadOnlyLazyList<V>>;
 
@@ -48,31 +48,31 @@ export interface MultiMap<K, V> extends DistributedObject {
      * other values associated with the same key.
      * @param key key from which the value should be detached.
      * @param value value to be removed.
-     * @return `true` if the value was detached from the specified key, `false` if it was not.
+     * @returns `true` if the value was detached from the specified key, `false` if it was not.
      */
     remove(key: K, value: V): Promise<boolean>;
 
     /**
      * Detaches all values from the specified key.
      * @param key key from which all entries should be removed.
-     * @return a list of old values that were associated with this key prior to this method call.
+     * @returns a list of old values that were associated with this key prior to this method call.
      */
     removeAll(key: K): Promise<ReadOnlyLazyList<V>>;
 
     /**
-     * @return an array of all keys in this multi-map.
+     * @returns an array of all keys in this multi-map.
      */
     keySet(): Promise<K[]>;
 
     /**
-     * @return a flat list of all values stored in this multi-map.
+     * @returns a flat list of all values stored in this multi-map.
      */
     values(): Promise<ReadOnlyLazyList<V>>;
 
     /**
      * Returns all entries in this multi-map. If a certain key has multiple values associated with it,
      * then one pair will be returned for each value.
-     * @return an array of all key value pairs stored in this multi-map.
+     * @returns an array of all key value pairs stored in this multi-map.
      */
     entrySet(): Promise<Array<[K, V]>>;
 
@@ -85,7 +85,7 @@ export interface MultiMap<K, V> extends DistributedObject {
 
     /**
      * @param value value to search for.
-     * @return `true` if the specified value is associated with at least one key in this multi-map,
+     * @returns `true` if the specified value is associated with at least one key in this multi-map,
      * `false` otherwise.
      */
     containsValue(value: V): Promise<boolean>;
@@ -93,13 +93,13 @@ export interface MultiMap<K, V> extends DistributedObject {
     /**
      * @param key key to match against.
      * @param value value to match against.
-     * @return `true` if this multi-map has an association between
+     * @returns `true` if this multi-map has an association between
      * the specified key and the specified value, `false` otherwise.
      */
     containsEntry(key: K, value: V): Promise<boolean>;
 
     /**
-     * @return the total number of values in this multi-map.
+     * @returns the total number of values in this multi-map.
      */
     size(): Promise<number>;
 
@@ -110,7 +110,7 @@ export interface MultiMap<K, V> extends DistributedObject {
 
     /**
      * @param key key to search for.
-     * @return the number of values associated with the specified key.
+     * @returns the number of values associated with the specified key.
      */
     valueCount(key: K): Promise<number>;
 
@@ -119,7 +119,7 @@ export interface MultiMap<K, V> extends DistributedObject {
      * @param listener entry listener to be attached
      * @param key if specified then this entry listener will only be notified of updates related to this key.
      * @param includeValue if `true`, then the event will include the modified value.
-     * @return registration ID for this entry listener
+     * @returns registration ID for this entry listener
      */
     addEntryListener(listener: EntryListener<K, V>, key?: K, includeValue?: boolean): Promise<string>;
 
@@ -135,14 +135,15 @@ export interface MultiMap<K, V> extends DistributedObject {
      * only when the lock becomes available.
      * All attempts to access the locked key will block until the lock is released.
      *
-     * Locking is reentrant, meaning that the lock owner can obtain the lock multiple times.
-     * If the lock was acquired multiple times, then `unlock` method must be called the same amount of
+     * Locking is reentrant, meaning that the lock owner client can obtain the lock multiple times.
+     * If the lock was acquired multiple times, then `unlock()` method must be called the same amount of
      * times, otherwise the lock will remain unavailable.
      *
      * If lease time is specified, then the lock will automatically become available
      * after the specified time has passed.
      * If lease time is not specified or is less than zero,
      * then lock owner must call `unlock` to make the lock available.
+     *
      * @param key key to be locked.
      * @param leaseMillis lease time in milliseconds.
      */
@@ -150,7 +151,7 @@ export interface MultiMap<K, V> extends DistributedObject {
 
     /**
      * @param key key to be checked
-     * @return `true` if this key is locked, `false` otherwise
+     * @returns `true` if this key is locked, `false` otherwise
      */
     isLocked(key: K): Promise<boolean>;
 
@@ -163,14 +164,15 @@ export interface MultiMap<K, V> extends DistributedObject {
      * only when the lock becomes available.
      * All attempts to access the locked key will block until the lock is released.
      *
-     * Locking is reentrant, meaning that the lock owner can obtain the lock multiple times.
-     * If the lock was acquired multiple times, then `unlock` method must be called the same amount of
+     * Locking is reentrant, meaning that the lock owner client can obtain the lock multiple times.
+     * If the lock was acquired multiple times, then `unlock()` method must be called the same amount of
      * times, otherwise the lock will remain unavailable.
      *
      * If lease time is specified, then the lock will automatically become available
      * after the specified time has passed.
      * If lease time is not specified or is less than zero,
      * then lock owner must call `unlock` to make the lock available.
+     *
      * @param key key to be locked
      * @param timeoutMillis timeout for locking, in milliseconds
      * @param leaseMillis lease time in milliseconds
@@ -193,14 +195,14 @@ export interface MultiMap<K, V> extends DistributedObject {
 
     /**
      * Stores the given key, value array pairs in the MultiMap.
-     * <p>
+     *
      * The behaviour of this operation is undefined if the specified pairs are modified
      * while this operation is in progress.
-     * <p>
+     *
      * No atomicity guarantees are given. It could be that in case of failure
      * some of the key/value-pairs get written, while others are not.
-     * <p>
-     * @param pairs key, value array pairs
+     *
+     * @param pairs key-value array pairs
      */
     putAll(pairs: Array<[K, V[]]>): Promise<void>;
 }

--- a/src/proxy/ReplicatedMap.ts
+++ b/src/proxy/ReplicatedMap.ts
@@ -23,7 +23,11 @@ import {
     ReadOnlyLazyList
 } from '../core';
 
+/**
+ * A specialized map whose values locally stored on every node of the cluster.
+ */
 export interface ReplicatedMap<K, V> extends DistributedObject {
+
     /**
      * Associates a given value to the specified key and replicates it to the
      * cluster. If there is an old value, it will be replaced by the specified
@@ -32,7 +36,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      * @param key key with which the specified value is to be associated.
      * @param value value to be associated with the specified key.
      * @param ttl milliseconds to be associated with the specified key-value pair.
-     * @return old value if there was any, `null` otherwise.
+     * @returns old value if there was any, `null` otherwise.
      */
     put(key: K, value: V, ttl?: Long | number): Promise<V>;
 
@@ -45,17 +49,17 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
     clear(): Promise<void>;
 
     /**
-     * Returns the value to which the specified key is mapped, or null if this map
+     * Returns the value to which the specified key is mapped, or `null` if this map
      * contains no mapping for the key.
      *
-     * If this map permits null values, then a return value of null does not
+     * If this map permits `null` values, then a return value of `null` does not
      * necessarily indicate that the map contains no mapping for the key; it's also
      * possible that the map explicitly maps the key to null. The {@link containsKey}
      * operation may be used to distinguish these two cases. This message is
      * idempotent.
      *
      * @param key key to search for.
-     * @return value associated with the specified key.
+     * @returns value associated with the specified key.
      */
     get(key: K): Promise<V>;
 
@@ -63,7 +67,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      * Returns true if this map contains a mapping for the specified key. This message is idempotent.
      *
      * @param key key to search for.
-     * @return `true` if this map contains the specified key, `false` otherwise.
+     * @returns `true` if this map contains the specified key, `false` otherwise.
      */
     containsKey(key: K): Promise<boolean>;
 
@@ -71,31 +75,31 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      * Returns true if this map maps one or more keys to the specified value.
      *
      * @param value value to search for.
-     * @return `true` if the specified value is associated with at least one key.
+     * @returns `true` if the specified value is associated with at least one key.
      */
     containsValue(value: V): Promise<boolean>;
 
     /**
      * If the map contains more than Integer.MAX_VALUE elements, returns Integer.MAX_VALUE.
-     * @return Returns the number of key-value mappings in this map.
+     * @returns Returns the number of key-value mappings in this map.
      */
     size(): Promise<number>;
 
     /**
-     * @return `true` if this map has no entries, `false` otherwise.
+     * @returns `true` if this map has no entries, `false` otherwise.
      */
     isEmpty(): Promise<boolean>;
 
     /**
      * Removes the mapping for a key from this map if it is present (optional operation).
      * Returns the value to which this map previously associated the key,
-     * or null if the map contained no mapping for the key. If this map permits null values,
-     * then a return value of null does not necessarily indicate that the map contained
+     * or `null` if the map contained no mapping for the key. If this map permits `null` values,
+     * then a return value of `null` does not necessarily indicate that the map contained
      * no mapping for the key; it's also possible that the map explicitly mapped the key to null.
      * The map will not contain a mapping for the specified key once the call returns.
      *
      * @param key key to remove.
-     * @return value associated with key, `null` if the key did not exist before.
+     * @returns value associated with key, `null` if the key did not exist before.
      */
     remove(key: K): Promise<V>;
 
@@ -115,18 +119,18 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
     /**
      * Returns a view of the key contained in this map.
      *
-     * @return keys of this map as an array.
+     * @returns keys of this map as an array.
      */
     keySet(): Promise<K[]>;
 
     /**
      * @param comparator optional ListComparator function to sort the returned elements.
-     * @return a list of values contained in this map.
+     * @returns a list of values contained in this map.
      */
     values(comparator?: ListComparator<V>): Promise<ReadOnlyLazyList<V>>;
 
     /**
-     * @return Returns entries as an array of key-value pairs.
+     * @returns Returns entries as an array of key-value pairs.
      */
     entrySet(): Promise<Array<[K, V]>>;
 
@@ -138,7 +142,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      * @param key
      * @param predicate
      * @param localOnly
-     * @return Registration id of the listener.
+     * @returns Registration id of the listener.
      */
     addEntryListenerToKeyWithPredicate(listener: EntryListener<K, V>, key: K, predicate: Predicate): Promise<string>;
 
@@ -148,7 +152,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      *
      * @param listener
      * @param predicate
-     * @return Registration id of the listener.
+     * @returns Registration id of the listener.
      */
     addEntryListenerWithPredicate(listener: EntryListener<K, V>, predicate: Predicate): Promise<string>;
 
@@ -158,7 +162,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      *
      * @param listener
      * @param key
-     * @return Registration id of the listener.
+     * @returns Registration id of the listener.
      */
     addEntryListenerToKey(listener: EntryListener<K, V>, key: K): Promise<string>;
 
@@ -167,7 +171,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      * map add/remove/update/evict events.
      *
      * @param listener
-     * @return Registration id of the listener.
+     * @returns Registration id of the listener.
      */
     addEntryListener(listener: EntryListener<K, V>): Promise<string>;
 
@@ -176,7 +180,7 @@ export interface ReplicatedMap<K, V> extends DistributedObject {
      * listener added before. This message is idempotent.
      *
      * @param listenerId
-     * @return `true` if remove operation is successful, `false` if unsuccessful or this listener did not exist.
+     * @returns `true` if remove operation is successful, `false` if unsuccessful or this listener did not exist.
      */
     removeEntryListener(listenerId: string): Promise<boolean>;
 }


### PR DESCRIPTION
Refs: #594 

* Documents reentrancy in map lock methods. Existing documentation was unclear
* Also improves tsdoc for all maps