### PR TITLE
Reduce number of allocated Buffers for writes

### DIFF
--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -515,7 +515,7 @@ export class InvocationService {
     }
 
     private write(invocation: Invocation, connection: ClientConnection): Promise<void> {
-        return connection.write(invocation.request.toBuffer());
+        return connection.write(invocation.request);
     }
 
     private notifyError(invocation: Invocation, error: Error): void {

--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -135,8 +135,7 @@ export class PipelinedWriter extends Writer {
             // coalesce buffers
             let pos = 0;
             for (const item of writeBatch) {
-                item.message.writeTo(this.coalesceBuf, pos);
-                pos += item.message.getTotalLength();
+                pos = item.message.writeTo(this.coalesceBuf, pos);
             }
             buf = this.coalesceBuf.slice(0, totalLength);
         }

--- a/src/protocol/ClientMessage.ts
+++ b/src/protocol/ClientMessage.ts
@@ -181,7 +181,6 @@ export class ClientMessage {
             this._nextFrame = frame;
             return;
         }
-
         this.endFrame.next = frame;
         this.endFrame = frame;
     }
@@ -230,14 +229,14 @@ export class ClientMessage {
         this.connection = connection;
     }
 
-    getTotalFrameLength(): number {
-        let frameLength = 0;
+    getTotalLength(): number {
+        let totalLength = 0;
         let currentFrame = this.startFrame;
         while (currentFrame != null) {
-            frameLength += currentFrame.getLength();
+            totalLength += currentFrame.getLength();
             currentFrame = currentFrame.next;
         }
-        return frameLength;
+        return totalLength;
     }
 
     getFragmentationId(): number {
@@ -264,27 +263,30 @@ export class ClientMessage {
         return newMessage;
     }
 
-    toBuffer(): Buffer {
-        const buffers: Buffer[] = [];
-        let totalLength = 0;
+    writeTo(buffer: Buffer, offset = 0): number {
+        let pos = offset;
         let currentFrame = this.startFrame;
         while (currentFrame != null) {
             const isLastFrame = currentFrame.next == null;
-            const frameLengthAndFlags = Buffer.allocUnsafe(SIZE_OF_FRAME_LENGTH_AND_FLAGS);
-            frameLengthAndFlags.writeInt32LE(currentFrame.content.length + SIZE_OF_FRAME_LENGTH_AND_FLAGS, 0);
-
+            buffer.writeInt32LE(currentFrame.content.length + SIZE_OF_FRAME_LENGTH_AND_FLAGS, pos);
             if (isLastFrame) {
-                frameLengthAndFlags.writeUInt16LE(currentFrame.flags | IS_FINAL_FLAG, BitsUtil.INT_SIZE_IN_BYTES);
+                buffer.writeUInt16LE(currentFrame.flags | IS_FINAL_FLAG, pos + BitsUtil.INT_SIZE_IN_BYTES);
             } else {
-                frameLengthAndFlags.writeUInt16LE(currentFrame.flags, BitsUtil.INT_SIZE_IN_BYTES);
+                buffer.writeUInt16LE(currentFrame.flags, pos + BitsUtil.INT_SIZE_IN_BYTES);
             }
-            totalLength += SIZE_OF_FRAME_LENGTH_AND_FLAGS;
-            buffers.push(frameLengthAndFlags);
-            totalLength += currentFrame.content.length;
-            buffers.push(currentFrame.content);
+            pos += SIZE_OF_FRAME_LENGTH_AND_FLAGS;
+            currentFrame.content.copy(buffer, pos);
+            pos += currentFrame.content.length;
             currentFrame = currentFrame.next;
         }
-        return Buffer.concat(buffers, totalLength);
+        return pos;
+    }
+
+    toBuffer(): Buffer {
+        const totalLength = this.getTotalLength();
+        const buffer = Buffer.allocUnsafe(totalLength);
+        this.writeTo(buffer);
+        return buffer;
     }
 }
 

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -336,26 +336,3 @@ export function timedPromise<T>(wrapped: Promise<T>, timeout: number, err?: Erro
 
     return deferred.promise;
 }
-
-type Binary = {
-    buffer: Buffer;
-}
-
-/**
- * Copy contents of the given array of objects with buffers into the target buffer.
- *
- * @param target target buffer
- * @param sources source objects that contain buffers
- * @param totalLength total length of all source buffers
- * @internal
- */
-export function copyBuffers(target: Buffer, sources: Binary[], totalLength: number): void {
-    if (target.length < totalLength) {
-        throw new RangeError('Target length ' + target.length + ' is less than requested ' + totalLength);
-    }
-    let pos = 0;
-    for (const source of sources) {
-        source.buffer.copy(target, pos);
-        pos += source.buffer.length;
-    }
-}

--- a/test/unit/UtilTest.js
+++ b/test/unit/UtilTest.js
@@ -17,37 +17,11 @@
 
 const { expect } = require('chai');
 const {
-    copyBuffers,
     deferredPromise,
     timedPromise
 } = require('../../lib/util/Util');
 
 describe('UtilTest', function () {
-
-    it('copyBuffers: throws on invalid total length', function () {
-        expect(() => copyBuffers(Buffer.from([0x1]), [ { buffer: Buffer.from([0x2]) } ], 3))
-            .to.throw(RangeError);
-    });
-
-    it('copyBuffers: writes single buffer of less length', function () {
-        const target = Buffer.from('abc');
-        const sources = [ { buffer: Buffer.from('d') } ];
-        copyBuffers(target, sources, 1);
-
-        expect(Buffer.compare(target, Buffer.from('dbc'))).to.be.equal(0);
-    });
-
-    it('copyBuffers: writes multiple buffers of same total length', function () {
-        const target = Buffer.from('abc');
-        const sources = [
-            { buffer: Buffer.from('d') },
-            { buffer: Buffer.from('e') },
-            { buffer: Buffer.from('f') }
-        ];
-        copyBuffers(target, sources, 3);
-
-        expect(Buffer.compare(target, Buffer.from('def'))).to.be.equal(0);
-    });
 
     it('deferredPromise: resolves promise on resolve call', function (done) {
         const deferred = deferredPromise();


### PR DESCRIPTION
Refs: #559

Gets rid of almost all unnecessary `Buffer` allocations done in the client message write process. The performance impact of this change is around 8-10% in `map.set(42, 42)` benchmark.