### PR TITLE
Reject pending invocations on connection close and client shutdown

### DIFF
--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -429,7 +429,10 @@ export class InvocationService {
 
         const pendingInvocation = this.pending.get(correlationId);
         if (pendingInvocation === undefined) {
-            this.logger.trace('InvocationService', 'Found no registration for invocation id ' + correlationId);
+            if (!this.isShutdown) {
+                this.logger.warn('InvocationService',
+                    'Found no registration for invocation id ' + correlationId);
+            }
             return;
         }
         const messageType = clientMessage.getMessageType();
@@ -452,7 +455,7 @@ export class InvocationService {
         }
 
         let invocationPromise: Promise<void>;
-        if (invocation.connection !== undefined) {
+        if (invocation.hasOwnProperty('connection')) {
             invocationPromise = this.send(invocation, invocation.connection);
             invocationPromise.catch((err) => {
                 this.notifyError(invocation, err);
@@ -486,7 +489,7 @@ export class InvocationService {
         }
 
         let invocationPromise: Promise<void>;
-        if (invocation.connection !== undefined) {
+        if (invocation.hasOwnProperty('connection')) {
             invocationPromise = this.send(invocation, invocation.connection);
         } else {
             invocationPromise = this.invokeOnRandomConnection(invocation);

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -428,6 +428,10 @@ export class InvocationService {
         }
 
         const pendingInvocation = this.pending.get(correlationId);
+        if (pendingInvocation === undefined) {
+            this.logger.trace('InvocationService', 'Found no registration for invocation id ' + correlationId);
+            return;
+        }
         const messageType = clientMessage.getMessageType();
         if (messageType === EXCEPTION_MESSAGE_TYPE) {
             const remoteError = this.client.getErrorFactory().createErrorFromClientMessage(clientMessage);

--- a/src/network/ClientConnection.ts
+++ b/src/network/ClientConnection.ts
@@ -430,6 +430,10 @@ export class ClientConnection {
         return this.closedTime === 0;
     }
 
+    getClosedReason(): string {
+        return this.closedReason;
+    }
+
     getStartTime(): number {
         return this.startTime;
     }

--- a/test/ClientRedoEnabledTest.js
+++ b/test/ClientRedoEnabledTest.js
@@ -52,7 +52,7 @@ describe('ClientRedoEnabledTest', function () {
         });
 
         const list = await client.getList('list');
-        expect(list.get(0)).to.be.rejectedWith(IndexOutOfBoundsError);
+        await expect(list.get(0)).to.be.rejectedWith(IndexOutOfBoundsError);
     });
 
     it('Map.unlock should throw when not locked', async function () {
@@ -64,7 +64,7 @@ describe('ClientRedoEnabledTest', function () {
         });
 
         const map = await client.getMap('map');
-        expect(map.unlock('foo')).to.be.rejectedWith(IllegalMonitorStateError);
+        await expect(map.unlock('foo')).to.be.rejectedWith(IllegalMonitorStateError);
     });
 
     it('should redo operations in smart mode when member goes down', async function () {

--- a/test/cpsubsystem/FencedLockTest.js
+++ b/test/cpsubsystem/FencedLockTest.js
@@ -117,7 +117,7 @@ describe('FencedLockTest', function () {
         // the next destroy call should be ignored
         await anotherLock.destroy();
 
-        expect(anotherLock.isLocked()).to.be.rejectedWith(DistributedObjectDestroyedError);
+        await expect(anotherLock.isLocked()).to.be.rejectedWith(DistributedObjectDestroyedError);
     });
 
     it('isLocked: should return false when not locked', async function () {

--- a/test/cpsubsystem/SemaphoreCommonTest.js
+++ b/test/cpsubsystem/SemaphoreCommonTest.js
@@ -75,7 +75,7 @@ describe('SemaphoreCommonTest', function () {
         // the next destroy call should be ignored
         await semaphore.destroy();
 
-        expect(semaphore.availablePermits()).to.be.rejectedWith(DistributedObjectDestroyedError);
+        await expect(semaphore.availablePermits()).to.be.rejectedWith(DistributedObjectDestroyedError);
     });
 
     for (const type of testTypes) {

--- a/test/unit/proxy/cpsubsystem/CPSessionManagerTest.js
+++ b/test/unit/proxy/cpsubsystem/CPSessionManagerTest.js
@@ -167,7 +167,7 @@ describe('CPSessionManagerTest', function () {
         it('acquireSession: should reject when shut down', async function () {
             await sessionManager.shutdown();
 
-            expect(sessionManager.acquireSession(prepareGroupId(42))).to.be.rejectedWith(IllegalStateError);
+            await expect(sessionManager.acquireSession(prepareGroupId(42))).to.be.rejectedWith(IllegalStateError);
         });
 
         it('acquireSession: should create new session for unknown group id', async function () {
@@ -248,7 +248,7 @@ describe('CPSessionManagerTest', function () {
         it('createUniqueThreadId: should reject when shut down', async function () {
             await sessionManager.shutdown();
 
-            expect(sessionManager.createUniqueThreadId(prepareGroupId(42))).to.be.rejectedWith(IllegalStateError);
+            await expect(sessionManager.createUniqueThreadId(prepareGroupId(42))).to.be.rejectedWith(IllegalStateError);
         });
 
         it('createUniqueThreadId: should generate new thread id', async function () {


### PR DESCRIPTION
* Implements the following behavior for pending invocations:
  - Reject written pending invocations on connection close
  - Reject pending invocations on client shutdown
* Add handling for missing registrations when processing response
* Also adds missing `await`s for `rejectedWith` asserts