### PR TITLE
Mark CannotReplicateError as retryable

### DIFF
--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -443,7 +443,7 @@ export class StaleAppendRequestError extends HazelcastError {
     }
 }
 
-export class CannotReplicateError extends HazelcastError {
+export class CannotReplicateError extends RetryableHazelcastError {
     constructor(msg: string, cause?: Error, serverStackTrace?: ServerErrorStackElement[]) {
         super(msg, cause, serverStackTrace);
         Object.setPrototypeOf(this, CannotReplicateError.prototype);


### PR DESCRIPTION
`CannotReplicateError` exception class introduced in 4.0 was extending `HazelcastError`, while it should be a `RetryableHazelcastError`