### PR TITLE
Improve listener deregistration

### DIFF
--- a/test/ListenerServiceTest.js
+++ b/test/ListenerServiceTest.js
@@ -22,15 +22,21 @@ const Util = require('./Util');
 
 [true, false].forEach(function (isSmartService) {
     describe('ListenerServiceTest[smart=' + isSmartService + ']', function () {
-        let cluster, client;
 
-        before(function () {
-            return RC.createCluster(null, null).then(function (res) {
-                cluster = res;
-                return Promise.resolve(cluster.id);
-            }).then(function (clusterId) {
-                return RC.startMember(clusterId);
-            });
+        let cluster;
+        let client;
+
+        function detectListenerLeakScript(instanceVar, listenerId) {
+            return 'var clientEngine = ' + instanceVar +'.getOriginal().node.clientEngine;\n'
+                + 'var endpoints = clientEngine.getEndpointManager().getEndpoints();\n'
+                + 'var endpoint = endpoints.iterator().next();\n'
+                + 'var registrationUuid = java.util.UUID.fromString("' + listenerId + '");\n'
+                + 'result = "" + endpoint.removeDestroyAction(registrationUuid);\n';
+        }
+
+        before(async function () {
+            cluster = await RC.createCluster(null, null);
+            await RC.startMember(cluster.id);
         });
 
         beforeEach(async function () {
@@ -50,54 +56,97 @@ const Util = require('./Util');
             return RC.terminateCluster(cluster.id);
         });
 
-        it('listener is invoked when a new object is created', function (done) {
+        it('listener is invoked when new object is created[smart=' + isSmartService + ']', function (done) {
             let listenerId;
             client.addDistributedObjectListener(function (distributedObjectEvent) {
                 expect(distributedObjectEvent.objectName).to.eq('mapToListen');
                 expect(distributedObjectEvent.serviceName).to.eq('hz:impl:mapService');
                 expect(distributedObjectEvent.eventType).to.eq('created');
-                client.removeDistributedObjectListener(listenerId).then(function () {
-                    done();
-                });
+                client.removeDistributedObjectListener(listenerId).then(() => done());
             }).then(function (id) {
                 listenerId = id;
-                client.getMap('mapToListen');
-            });
+                client.getMap('mapToListen').catch(() => {
+                    // the event may come earlier than the getMap response,
+                    // so we ignore errors here
+                });
+            }).catch(done);
         });
 
-        it('listener is invoked when an object is removed[smart=' + isSmartService + ']', function (done) {
+        it('listener is invoked when object is removed[smart=' + isSmartService + ']', function (done) {
             let map, listenerId;
             client.addDistributedObjectListener(function (distributedObjectEvent) {
-                if (distributedObjectEvent.eventType === 'destroyed' && distributedObjectEvent.objectName === 'mapToRemove') {
+                if (distributedObjectEvent.eventType === 'destroyed'
+                        && distributedObjectEvent.objectName === 'mapToRemove') {
                     expect(distributedObjectEvent.objectName).to.eq('mapToRemove');
                     expect(distributedObjectEvent.serviceName).to.eq('hz:impl:mapService');
                     expect(distributedObjectEvent.eventType).to.eq('destroyed');
-                    client.removeDistributedObjectListener(listenerId).then(function () {
-                        done();
-                    });
-                } else if (distributedObjectEvent.eventType === 'created' && distributedObjectEvent.objectName === 'mapToRemove') {
+                    client.removeDistributedObjectListener(listenerId).then(() => done());
+                } else if (distributedObjectEvent.eventType === 'created'
+                        && distributedObjectEvent.objectName === 'mapToRemove') {
                     Util.promiseWaitMilliseconds(1000).then(function () {
-                        map.destroy();
+                        map.destroy().catch(() => {
+                            // no-op
+                        });
                     });
                 }
             }).then(function (id) {
                 listenerId = id;
-                client.getMap('mapToRemove').then(function (mp) {
+                return client.getMap('mapToRemove').then(function (mp) {
                     map = mp;
                 });
-            });
+            }).catch(done);
         });
 
-        it('listener is not invoked when listener was already removed by user', function (done) {
-            client.addDistributedObjectListener(function () {
+        it('listener is not invoked when it is removed[smart=' + isSmartService + ']', function (done) {
+            this.timeout(10000);
+
+            let listenerId;
+            client.addDistributedObjectListener(() => {
                 done(new Error('Should not have run!'));
-            }).then(function (listenerId) {
+            }).then((id) => {
+                listenerId = id;
                 return client.removeDistributedObjectListener(listenerId);
-            }).then(function () {
-                return client.getMap('testMap');
-            }).then(function () {
-                setTimeout(done, 1000);
-            });
+            }).then(() => {
+                return client.getMap('newMap');
+            }).then(() => {
+                setTimeout(() => {
+                    const script = detectListenerLeakScript('instance_0', listenerId);
+                    RC.executeOnController(cluster.id, script, 1).then((res) => {
+                        expect(res.result).to.not.be.null;
+                        expect(res.result.toString()).to.be.equal('false');
+                        done();
+                    }).catch(done);
+                }, 1000);
+            }).catch(done);
+        });
+
+        it('listener is not invoked when it is removed and new member starts[smart=' + isSmartService + ']', function (done) {
+            this.timeout(20000);
+
+            let listenerId;
+            let member2Promise;
+            client.addDistributedObjectListener(() => {
+                done(new Error('Should not have run!'));
+            }).then((id) => {
+                listenerId = id;
+                member2Promise = RC.startMember(cluster.id);
+                return client.removeDistributedObjectListener(listenerId);
+            }).then(() => {
+                return client.getMap('anotherNewMap');
+            }).then(() => {
+                member2Promise.then((member2) => {
+                    setTimeout(() => {
+                        // we're interested in the second member here
+                        const script = detectListenerLeakScript('instance_1', listenerId);
+                        RC.executeOnController(cluster.id, script, 1).then((res) => {
+                            expect(res.result).to.not.be.null;
+                            expect(res.result.toString()).to.be.equal('false');
+                            // need to clean up the second member before finishing the test
+                            RC.shutdownMember(cluster.id, member2.uuid).then(() => done());
+                        }).catch(done);
+                    }, 3000);
+                }).catch(done);
+            }).catch(done);
         });
     });
 });


### PR DESCRIPTION
* Closes #613 
* Also implements changes from the following Java client PR: https://github.com/hazelcast/hazelcast/pull/17646. As the result, `ListenerService#deregisterListener` immediately returns (i.e. returns a resolved promise) and the remote de-registrations are implicitly re-tried
* Also fixes unhandled promise rejections in `ListenerServiceTest`