### PR TITLE
Migrated List, Map, MultiMap, ReplicatedMap, Queue and Set tests to async/await

### DIFF
--- a/test/list/ListProxyTest.js
+++ b/test/list/ListProxyTest.js
@@ -26,215 +26,159 @@ describe('ListProxyTest', function () {
     let client;
     let listInstance;
 
-    before(function () {
+    before(async function () {
         this.timeout(10000);
-        return RC.createCluster().then(function (response) {
-            cluster = response;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return Client.newHazelcastClient({ clusterName: cluster.id })
-                .then(function (hazelcastClient) {
-                    client = hazelcastClient;
-                });
-        });
+        cluster = await RC.createCluster();
+        await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
     });
 
-    beforeEach(function () {
-        return client.getList('test').then(function (list) {
-            listInstance = list;
-        });
+    beforeEach(async function () {
+        listInstance = await client.getList('test');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return listInstance.destroy();
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    it('appends one item', function () {
-        return listInstance.add(1).then(function () {
-            return listInstance.size();
-        }).then(function (size) {
-            expect(size).to.equal(1);
-        });
+    it('appends one item', async function () {
+        await listInstance.add(1);
+        const size = await listInstance.size();
+        expect(size).to.equal(1);
     });
 
-    it('inserts one item at index', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.addAt(1, 5);
-        }).then(function () {
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([1, 5, 2, 3]);
-        });
+    it('inserts one item at index', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        await listInstance.addAt(1, 5);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([1, 5, 2, 3]);
     });
 
-    it('clears', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.clear();
-        }).then(function () {
-            return listInstance.size();
-        }).then(function (size) {
-            expect(size).to.equal(0);
-        });
+    it('clears', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        await listInstance.clear();
+        const size = await listInstance.size();
+        expect(size).to.equal(0);
     });
 
-    it('inserts all elements of array at index', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.addAllAt(1, [5, 6]);
-        }).then(function () {
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([1, 5, 6, 2, 3])
-        });
+    it('inserts all elements of array at index', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        await listInstance.addAllAt(1, [5, 6]);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([1, 5, 6, 2, 3]);
     });
 
-    it('gets item at index', function () {
+    it('gets item at index', async function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.get(1);
-        }).then(function (result) {
-            expect(result).to.equal(2);
-        });
+        await listInstance.addAll(input);
+        const result = await listInstance.get(1);
+        expect(result).to.equal(2);
     });
 
-    it('removes item at index', function () {
+    it('removes item at index', async function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.removeAt(1);
-        }).then(function (removed) {
-            expect(removed).to.equal(2);
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([1, 3]);
-        });
+        await listInstance.addAll(input);
+        const removed = await listInstance.removeAt(1);
+        expect(removed).to.equal(2);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([1, 3]);
     });
 
-    it('replaces item at index', function () {
+    it('replaces item at index', async function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.set(1, 6);
-        }).then(function (replaced) {
-            expect(replaced).to.equal(2);
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([1, 6, 3]);
-        });
+        await listInstance.addAll(input);
+        const replaced = await listInstance.set(1, 6);
+        expect(replaced).to.equal(2);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([1, 6, 3]);
     });
 
-    it('contains', function () {
+    it('contains', async function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.contains(1);
-        }).then(function (contains) {
-            expect(contains).to.be.true;
-        });
+        await listInstance.addAll(input);
+        const contains = await listInstance.contains(1);
+        expect(contains).to.be.true;
     });
 
-    it('does not contain', function () {
+    it('does not contain', async function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.contains(5);
-        }).then(function (contains) {
-            expect(contains).to.be.false;
-        });
+        await listInstance.addAll(input);
+        const contains = await listInstance.contains(5);
+        expect(contains).to.be.false;
     });
 
-    it('contains all', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.containsAll([1, 2]);
-        }).then(function (contains) {
-            expect(contains).to.be.true;
-        });
+    it('contains all', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        const contains = await listInstance.containsAll([1, 2]);
+        expect(contains).to.be.true;
     });
 
-    it('does not contain all', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.containsAll([3, 4]);
-        }).then(function (contains) {
-            expect(contains).to.be.false;
-        });
+    it('does not contain all', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        const contains = await listInstance.containsAll([3, 4]);
+        expect(contains).to.be.false;
     });
 
-    it('is empty', function () {
-        return listInstance.isEmpty().then(function (empty) {
-            expect(empty).to.be.true;
-        });
+    it('is empty', async function () {
+        const empty = await listInstance.isEmpty();
+        expect(empty).to.be.true;
     });
 
-    it('is not empty', function () {
-        return listInstance.add(1).then(function (empty) {
-            return listInstance.isEmpty();
-        }).then(function (empty) {
-            expect(empty).to.be.false;
-        });
+    it('is not empty', async function () {
+        await listInstance.add(1);
+        const empty = await listInstance.isEmpty();
+        expect(empty).to.be.false;
     });
 
-    it('removes an entry', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.remove(1)
-        }).then(function () {
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([2, 3]);
-        });
+    it('removes an entry', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        await listInstance.remove(1);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([2, 3]);
     });
 
-    it('removes an entry by index', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.removeAt(1)
-        }).then(function () {
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([1, 3]);
-        });
+    it('removes an entry by index', async function () {
+        await listInstance.addAll([1, 2, 3]);
+        await listInstance.removeAt(1);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([1, 3]);
     });
 
-    it('removes multiple entries', function () {
-        return listInstance.addAll([1, 2, 3, 4]).then(function () {
-            return listInstance.removeAll([1, 2]);
-        }).then(function () {
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([3, 4]);
-        });
+    it('removes multiple entries', async function () {
+        await listInstance.addAll([1, 2, 3, 4]);
+        await listInstance.removeAll([1, 2]);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([3, 4]);
     });
 
-    it('retains multiple entries', function () {
-        return listInstance.addAll([1, 2, 3, 4]).then(function () {
-            return listInstance.retainAll([1, 2]);
-        }).then(function () {
-            return listInstance.toArray();
-        }).then(function (all) {
-            expect(all).to.deep.equal([1, 2]);
-        });
+    it('retains multiple entries', async function () {
+        await listInstance.addAll([1, 2, 3, 4]);
+        await listInstance.retainAll([1, 2]);
+        const all = await listInstance.toArray();
+        expect(all).to.deep.equal([1, 2]);
     });
 
-    it('finds index of the element', function () {
-        return listInstance.addAll([1, 2, 4, 4]).then(function () {
-            return listInstance.indexOf(4);
-        }).then(function (index) {
-            expect(index).to.equal(2);
-        });
+    it('finds index of the element', async function () {
+        await listInstance.addAll([1, 2, 4, 4]);
+        const index = await listInstance.indexOf(4);
+        expect(index).to.equal(2);
     });
 
-    it('finds last index of the element', function () {
-        return listInstance.addAll([1, 2, 4, 4]).then(function () {
-            return listInstance.lastIndexOf(4);
-        }).then(function (index) {
-            expect(index).to.equal(3);
-        });
+    it('finds last index of the element', async function () {
+        await listInstance.addAll([1, 2, 4, 4]);
+        const index = await listInstance.lastIndexOf(4);
+        expect(index).to.equal(3);
     });
 
-    it('returns a sub list', function () {
-        return listInstance.addAll([1, 2, 3, 4, 5, 6]).then(function () {
-            return listInstance.subList(1, 5);
-        }).then(function (subList) {
-            expect(subList.toArray()).to.deep.equal([2, 3, 4, 5]);
-        });
+    it('returns a sub list', async function () {
+        await listInstance.addAll([1, 2, 3, 4, 5, 6]);
+        const subList = await listInstance.subList(1, 5);
+        expect(subList.toArray()).to.deep.equal([2, 3, 4, 5]);
     });
 
     it('listens for added entry', function (done) {
@@ -324,19 +268,17 @@ describe('ListProxyTest', function () {
         });
     });
 
-    it('remove entry listener', function () {
+    it('remove entry listener', async function () {
         this.timeout(5000);
-        return listInstance.addItemListener({
+        const registrationId = await listInstance.addItemListener({
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
                 expect(itemEvent.item).to.be.equal(1);
                 expect(itemEvent.eventType).to.be.equal(ItemEventType.REMOVED);
                 expect(itemEvent.member).to.not.be.equal(null);
             }
-        }).then(function (registrationId) {
-            return listInstance.removeItemListener(registrationId);
-        }).then(function (removed) {
-            expect(removed).to.be.true;
         });
+        const removed = await listInstance.removeItemListener(registrationId);
+        expect(removed).to.be.true;
     });
 });

--- a/test/map/MapAggregatorsDoubleTest.js
+++ b/test/map/MapAggregatorsDoubleTest.js
@@ -27,163 +27,128 @@ describe('MapAggregatorsDoubleTest', function () {
     let cluster, client;
     let map;
 
-    before(function () {
-        return RC.createCluster(null, null).then(function (cl) {
-            cluster = cl;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return Client.newHazelcastClient({ clusterName: cluster.id });
-        }).then(function (cl) {
-            client = cl;
-            return client.getMap('aggregatorsMap');
-        }).then(function (mp) {
-            map = mp;
-        });
+    before(async function () {
+        cluster = await RC.createCluster(null, null);
+        await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
+        map = await client.getMap('aggregatorsMap');
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
         return fillMap(map, 50, 'key', 0);
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return map.destroy();
     });
 
-    it('count', function () {
-        return map.aggregate(Aggregators.count()).then(function (count) {
-            return expect(count.toNumber()).to.equal(50);
-        });
+    it('count', async function () {
+        const count = await map.aggregate(Aggregators.count());
+        expect(count.toNumber()).to.equal(50);
     });
 
-    it('count with attribute path', function () {
-        return map.aggregate(Aggregators.count('this')).then(function (count) {
-            return expect(count.toNumber()).to.equal(50);
-        });
+    it('count with attribute path', async function () {
+        const count = await map.aggregate(Aggregators.count('this'));
+        expect(count.toNumber()).to.equal(50);
     });
 
-    it('count with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.count(), Predicates.greaterEqual('this', 1))
-            .then(function (count) {
-                return expect(count.toNumber()).to.equal(49);
-            });
+    it('count with predicate', async function () {
+        const count = await map.aggregateWithPredicate(Aggregators.count(), Predicates.greaterEqual('this', 1));
+        expect(count.toNumber()).to.equal(49);
     });
 
-    it('doubleAvg', function () {
-        return map.aggregate(Aggregators.doubleAvg()).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('doubleAvg', async function () {
+        const avg = await map.aggregate(Aggregators.doubleAvg());
+        expect(avg).to.equal(24.5);
     });
 
-    it('doubleAvg with attribute path', function () {
-        return map.aggregate(Aggregators.doubleAvg('this')).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('doubleAvg with attribute path', async function () {
+        const avg = await map.aggregate(Aggregators.doubleAvg('this'));
+        expect(avg).to.equal(24.5);
     });
 
-    it('doubleAvg with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.doubleAvg(), Predicates.greaterEqual('this', 47))
-            .then(function (avg) {
-                return expect(avg).to.equal(48);
-            });
+    it('doubleAvg with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.doubleAvg(), Predicates.greaterEqual('this', 47));
+        expect(avg).to.equal(48);
     });
 
-    it('doubleSum', function () {
-        return map.aggregate(Aggregators.doubleSum()).then(function (sum) {
-            return expect(sum).to.equal(1225);
-        });
+    it('doubleSum', async function () {
+        const sum = await map.aggregate(Aggregators.doubleSum());
+        expect(sum).to.equal(1225);
     });
 
-    it('doubleSum with attribute path', function () {
-        return map.aggregate(Aggregators.doubleSum('this')).then(function (sum) {
-            return expect(sum).to.equal(1225);
-        });
+    it('doubleSum with attribute path', async function () {
+        const sum = await map.aggregate(Aggregators.doubleSum('this'));
+        expect(sum).to.equal(1225);
     });
 
-    it('doubleSum with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.doubleSum(), Predicates.greaterEqual('this', 47))
-            .then(function (avg) {
-                return expect(avg).to.equal(144);
-            });
+    it('doubleSum with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.doubleSum(), Predicates.greaterEqual('this', 47));
+        expect(avg).to.equal(144);
     });
 
-    it('floatingPointSum', function () {
-        return map.aggregate(Aggregators.floatingPointSum()).then(function (sum) {
-            return expect(sum).to.equal(1225);
-        });
+    it('floatingPointSum', async function () {
+        const sum = await map.aggregate(Aggregators.floatingPointSum());
+        expect(sum).to.equal(1225);
     });
 
-    it('floatingPointSum with attribute path', function () {
-        return map.aggregate(Aggregators.floatingPointSum('this')).then(function (sum) {
-            return expect(sum).to.equal(1225);
-        });
+    it('floatingPointSum with attribute path', async function () {
+        const sum = await map.aggregate(Aggregators.floatingPointSum('this'));
+        expect(sum).to.equal(1225);
     });
 
-    it('floatingPointSum with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.floatingPointSum(), Predicates.greaterEqual('this', 47))
-            .then(function (sum) {
-                return expect(sum).to.equal(144);
-            });
+    it('floatingPointSum with predicate', async function () {
+        const sum = await map.aggregateWithPredicate(Aggregators.floatingPointSum(), Predicates.greaterEqual('this', 47));
+        expect(sum).to.equal(144);
     });
 
-    it('numberAvg', function () {
-        return map.aggregate(Aggregators.numberAvg()).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('numberAvg', async function () {
+        const avg = await map.aggregate(Aggregators.numberAvg());
+        expect(avg).to.equal(24.5);
     });
 
-    it('numberAvg with attribute path', function () {
-        return map.aggregate(Aggregators.numberAvg('this')).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('numberAvg with attribute path', async function () {
+        const avg = await map.aggregate(Aggregators.numberAvg('this'));
+        expect(avg).to.equal(24.5);
     });
 
-    it('numberAvg with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.numberAvg(), Predicates.greaterEqual('this', 47))
-            .then(function (avg) {
-                return expect(avg).to.equal(48);
-            });
+    it('numberAvg with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.numberAvg(), Predicates.greaterEqual('this', 47));
+        expect(avg).to.equal(48);
     });
 
-    it('max', function () {
-        return map.aggregate(Aggregators.max()).then(function (avg) {
-            return expect(avg).to.equal(49);
-        });
+    it('max', async function () {
+        const avg = await map.aggregate(Aggregators.max());
+        expect(avg).to.equal(49);
     });
 
-    it('max with attribute path', function () {
-        return map.aggregate(Aggregators.max('this')).then(function (avg) {
-            return expect(avg).to.equal(49);
-        });
+    it('max with attribute path', async function () {
+        const avg = await map.aggregate(Aggregators.max('this'));
+        expect(avg).to.equal(49);
     });
 
-    it('max with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.max(), Predicates.lessEqual('this', 3))
-            .then(function (avg) {
-                return expect(avg).to.equal(3);
-            });
+    it('max with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.max(), Predicates.lessEqual('this', 3));
+        expect(avg).to.equal(3);
     });
 
-    it('min', function () {
-        return map.aggregate(Aggregators.min()).then(function (avg) {
-            return expect(avg).to.equal(0);
-        });
+    it('min', async function () {
+        const avg = await map.aggregate(Aggregators.min());
+        expect(avg).to.equal(0);
     });
 
-    it('min with attribute path', function () {
-        return map.aggregate(Aggregators.min('this')).then(function (avg) {
-            return expect(avg).to.equal(0);
-        });
+    it('min with attribute path', async function () {
+        const avg = await map.aggregate(Aggregators.min('this'));
+        expect(avg).to.equal(0);
     });
 
-    it('min with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.min(), Predicates.greaterEqual('this', 3))
-            .then(function (avg) {
-                return expect(avg).to.equal(3);
-            });
+    it('min with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.min(), Predicates.greaterEqual('this', 3));
+        expect(avg).to.equal(3);
     });
 });

--- a/test/map/MapAggregatorsIntTest.js
+++ b/test/map/MapAggregatorsIntTest.js
@@ -27,93 +27,73 @@ describe('MapAggregatorsIntTest', function () {
     let cluster, client;
     let map;
 
-    before(function () {
-        return RC.createCluster(null, null).then(function (cl) {
-            cluster = cl;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return Client.newHazelcastClient({
-                clusterName: cluster.id,
-                serialization: {
-                    defaultNumberType: 'integer'
-                }
-            });
-        }).then(function (cl) {
-            client = cl;
-            return client.getMap('aggregatorsMap');
-        }).then(function (mp) {
-            map = mp;
+    before(async function () {
+        cluster = await RC.createCluster(null, null);
+        await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            serialization: {
+                defaultNumberType: 'integer'
+            }
         });
+        map = await client.getMap('aggregatorsMap');
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
         return fillMap(map, 50, 'key', 0);
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return map.destroy();
     });
 
-    it('intAvg', function () {
-        return map.aggregate(Aggregators.integerAvg()).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('intAvg', async function () {
+        const avg = await map.aggregate(Aggregators.integerAvg());
+        expect(avg).to.equal(24.5);
     });
 
-    it('intAvg with attribute path', function () {
-        return map.aggregate(Aggregators.integerAvg('this')).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('intAvg with attribute path', async function () {
+        const avg = await map.aggregate(Aggregators.integerAvg('this'));
+        expect(avg).to.equal(24.5);
     });
 
-    it('intAvg with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.integerAvg(), Predicates.greaterEqual('this', 47))
-            .then(function (avg) {
-                return expect(avg).to.equal(48);
-            });
+    it('intAvg with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.integerAvg(), Predicates.greaterEqual('this', 47));
+        expect(avg).to.equal(48);
     });
 
-    it('intSum', function () {
-        return map.aggregate(Aggregators.integerSum()).then(function (sum) {
-            return expect(sum.toNumber()).to.equal(1225);
-        });
+    it('intSum', async function () {
+        const sum = await map.aggregate(Aggregators.integerSum());
+        expect(sum.toNumber()).to.equal(1225);
     });
 
-    it('intSum with attribute path', function () {
-        return map.aggregate(Aggregators.integerSum('this')).then(function (sum) {
-            return expect(sum.toNumber()).to.equal(1225);
-        });
+    it('intSum with attribute path', async function () {
+        const sum = await map.aggregate(Aggregators.integerSum('this'));
+        expect(sum.toNumber()).to.equal(1225);
     });
 
-    it('intSum with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.integerSum(), Predicates.greaterEqual('this', 47))
-            .then(function (sum) {
-                return expect(sum.toNumber()).to.equal(144);
-            });
+    it('intSum with predicate', async function () {
+        const sum = await map.aggregateWithPredicate(Aggregators.integerSum(), Predicates.greaterEqual('this', 47));
+        expect(sum.toNumber()).to.equal(144);
     });
 
-
-    it('fixedPointSum', function () {
-        return map.aggregate(Aggregators.fixedPointSum()).then(function (sum) {
-            return expect(sum.toNumber()).to.equal(1225);
-        });
+    it('fixedPointSum', async function () {
+        const sum = await map.aggregate(Aggregators.fixedPointSum());
+        expect(sum.toNumber()).to.equal(1225);
     });
 
-    it('fixedPointSum with attribute path', function () {
-        return map.aggregate(Aggregators.fixedPointSum('this')).then(function (sum) {
-            return expect(sum.toNumber()).to.equal(1225);
-        });
+    it('fixedPointSum with attribute path', async function () {
+        const sum = await map.aggregate(Aggregators.fixedPointSum('this'));
+        expect(sum.toNumber()).to.equal(1225);
     });
 
-    it('fixedPointSum with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.fixedPointSum(), Predicates.greaterEqual('this', 47))
-            .then(function (sum) {
-                return expect(sum.toNumber()).to.equal(144);
-            });
+    it('fixedPointSum with predicate', async function () {
+        const sum = await map.aggregateWithPredicate(Aggregators.fixedPointSum(), Predicates.greaterEqual('this', 47));
+        expect(sum.toNumber()).to.equal(144);
     });
 });

--- a/test/map/MapAggregatorsLongTest.js
+++ b/test/map/MapAggregatorsLongTest.js
@@ -28,31 +28,24 @@ describe('MapAggregatorsLongTest', function () {
     let map;
     const entryCount = 50;
 
-    before(function () {
-        return RC.createCluster(null, null).then(function (cl) {
-            cluster = cl;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return Client.newHazelcastClient({
-                clusterName: cluster.id,
-                serialization: {
-                    defaultNumberType: 'long'
-                }
-            });
-        }).then(function (cl) {
-            client = cl;
-            return client.getMap('aggregatorsMap');
-        }).then(function (mp) {
-            map = mp;
+    before(async function () {
+        cluster = await RC.createCluster(null, null);
+        await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            serialization: {
+                defaultNumberType: 'long'
+            }
         });
+        map = await client.getMap('aggregatorsMap');
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    beforeEach(function () {
+    beforeEach(async function () {
         const entries = [];
         for (let i = 0; i < entryCount; i++) {
             entries.push(['key' + i, Long.fromNumber(i)]);
@@ -60,45 +53,37 @@ describe('MapAggregatorsLongTest', function () {
         return map.putAll(entries);
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return map.destroy();
     });
 
-    it('longAvg', function () {
-        return map.aggregate(Aggregators.longAvg()).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('longAvg', async function () {
+        const avg = await map.aggregate(Aggregators.longAvg());
+        expect(avg).to.equal(24.5);
     });
 
-    it('longAvg with attribute path', function () {
-        return map.aggregate(Aggregators.longAvg('this')).then(function (avg) {
-            return expect(avg).to.equal(24.5);
-        });
+    it('longAvg with attribute path', async function () {
+        const avg = await map.aggregate(Aggregators.longAvg('this'));
+        expect(avg).to.equal(24.5);
     });
 
-    it('longAvg with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.longAvg(), Predicates.greaterEqual('this', Long.fromNumber(47)))
-            .then(function (avg) {
-                return expect(avg).to.equal(48);
-            });
+    it('longAvg with predicate', async function () {
+        const avg = await map.aggregateWithPredicate(Aggregators.longAvg(), Predicates.greaterEqual('this', Long.fromNumber(47)));
+        expect(avg).to.equal(48);
     });
 
-    it('longSum', function () {
-        return map.aggregate(Aggregators.longSum()).then(function (sum) {
-            return expect(sum.toNumber()).to.equal(1225);
-        });
+    it('longSum', async function () {
+        const sum = await map.aggregate(Aggregators.longSum());
+        expect(sum.toNumber()).to.equal(1225);
     });
 
-    it('longSum with attribute path', function () {
-        return map.aggregate(Aggregators.longSum('this')).then(function (sum) {
-            return expect(sum.toNumber()).to.equal(1225);
-        });
+    it('longSum with attribute path', async function () {
+        const sum = await map.aggregate(Aggregators.longSum('this'));
+        expect(sum.toNumber()).to.equal(1225);
     });
 
-    it('longSum with predicate', function () {
-        return map.aggregateWithPredicate(Aggregators.longSum(), Predicates.greaterEqual('this', Long.fromNumber(47)))
-            .then(function (sum) {
-                return expect(sum.toNumber()).to.equal(144);
-            });
+    it('longSum with predicate', async function () {
+        const sum = await map.aggregateWithPredicate(Aggregators.longSum(), Predicates.greaterEqual('this', Long.fromNumber(47)));
+        expect(sum.toNumber()).to.equal(144);
     });
 });

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -238,9 +238,9 @@ describe('MapProxyTest', function () {
 
                 const entryMap = await client.getMap('entry-map');
                 await Promise.all([
-                        entryMap.put(samples[0][0], samples[0][1]),
-                        entryMap.put(samples[1][0], samples[1][1]),
-                        entryMap.put(samples[2][0], samples[2][1])
+                    entryMap.put(samples[0][0], samples[0][1]),
+                    entryMap.put(samples[1][0], samples[1][1]),
+                    entryMap.put(samples[2][0], samples[2][1])
                 ]);
                 const entrySet = await entryMap.entrySet();
                 expect(entrySet).to.deep.have.members(samples);
@@ -287,8 +287,8 @@ describe('MapProxyTest', function () {
             it('keySet', async function () {
                 const keySet = await map.keySet();
                 expect(keySet).to.deep.have.members([
-                        'key0', 'key1', 'key2', 'key3', 'key4',
-                        'key5', 'key6', 'key7', 'key8', 'key9'
+                    'key0', 'key1', 'key2', 'key3', 'key4',
+                    'key5', 'key6', 'key7', 'key8', 'key9'
                 ]);
             });
 
@@ -434,9 +434,14 @@ describe('MapProxyTest', function () {
 
             it('tryLock_success with timeout', async function () {
                 await RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
-                await RC.executeOnController(cluster.id, generateUnlockScript(map.getName(), '"key0"'), 1);
-                const success = await map.tryLock('key0', 1000);
+                const startTime = Date.now();
+                setTimeout(async function () {
+                    await RC.executeOnController(cluster.id, generateUnlockScript(map.getName(), '"key0"'), 1);
+                }, 1000);
+                const success = await map.tryLock('key0', 2000);
+                const elapsed = Date.now() - startTime;
                 expect(success).to.be.true;
+                expect(elapsed).to.be.greaterThan(995);
             });
 
             it('tryLock_fail with timeout', async function () {
@@ -462,7 +467,7 @@ describe('MapProxyTest', function () {
             });
 
             it('tryRemove fail', async function () {
-                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
+                await RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
                 const success = await map.tryRemove('key0', 200);
                 expect(success).to.be.false;
             });

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -23,7 +23,7 @@ const { Client, Predicates } = require('../../');
 const Util = require('./../Util');
 const { fillMap } = require('../Util');
 
-function createController(nearCacheEnabled) {
+async function createController(nearCacheEnabled) {
     if (nearCacheEnabled) {
         return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'));
     } else {
@@ -31,7 +31,7 @@ function createController(nearCacheEnabled) {
     }
 }
 
-function createClient(nearCacheEnabled, clusterName) {
+async function createClient(nearCacheEnabled, clusterName) {
     const cfg = {
         clusterName,
         nearCaches: {}
@@ -49,32 +49,25 @@ describe('MapProxyTest', function () {
             let cluster, client;
             let map;
 
-            before(function () {
+            before(async function () {
                 this.timeout(32000);
-                return createController(nearCacheEnabled).then(function (res) {
-                    cluster = res;
-                    return RC.startMember(cluster.id);
-                }).then(function (m) {
-                    return createClient(nearCacheEnabled, cluster.id).then(function (hazelcastClient) {
-                        client = hazelcastClient;
-                    });
-                });
+                cluster = await createController(nearCacheEnabled);
+                await RC.startMember(cluster.id);
+                client = await createClient(nearCacheEnabled, cluster.id);
             });
 
-            beforeEach(function () {
-                return client.getMap('test').then(function (mp) {
-                    map = mp;
-                    return fillMap(map);
-                });
+            beforeEach(async function () {
+                map = await client.getMap('test');
+                return fillMap(map);
             });
 
-            afterEach(function () {
+            afterEach(async function () {
                 return map.destroy();
             });
 
-            after(function () {
-                return client.shutdown()
-                    .then(() => RC.terminateCluster(cluster.id));
+            after(async function () {
+                await client.shutdown();
+                return RC.terminateCluster(cluster.id);
             });
 
             function generateLockScript(mapName, keyName) {
@@ -95,106 +88,85 @@ describe('MapProxyTest', function () {
                     'result=""+lockByServer();';
             }
 
-            it('get_basic', function () {
-                return map.get('key0').then(function (v) {
-                    return expect(v).to.equal('val0');
-                })
+            it('get_basic', async function () {
+                const val = await map.get('key0');
+                expect(val).to.equal('val0');
             });
 
-            it('get_return_null_on_non_existent', function () {
-                return map.get('non-existent').then(function (val) {
-                    return expect(val).to.be.null;
-                });
+            it('get_return_null_on_non_existent', async function () {
+                const val = await map.get('non-existent');
+                expect(val).to.be.null;
             });
 
-            it('put_return_value_not_null', function () {
-                return map.put('key0', 'new-val').then(function (val) {
-                    return expect(val).to.equal('val0');
-                });
+            it('put_return_value_not_null', async function () {
+                const val = await map.put('key0', 'new-val');
+                expect(val).to.equal('val0');
             });
 
-            it('put with ttl puts value to map', function () {
-                return map.put('key-with-ttl', 'val-with-ttl', 3000).then(function () {
-                    return map.get('key-with-ttl').then(function (val) {
-                        return expect(val).to.equal('val-with-ttl');
-                    });
-                });
+            it('put with ttl puts value to map', async function () {
+                await map.put('key-with-ttl', 'val-with-ttl', 3000);
+                const val = await map.get('key-with-ttl');
+                expect(val).to.equal('val-with-ttl');
             });
 
-            it('put with ttl removes value after ttl', function () {
-                return map.put('key10', 'val10', 1000).then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('val10');
-                }).then(function () {
-                    return Util.promiseLater(1100, map.get.bind(map, 'key10'));
-                }).then(function (val) {
-                    return expect(val).to.be.null;
-                });
+            it('put with ttl removes value after ttl', async function () {
+                await map.put('key10', 'val10', 1000);
+                let val = await map.get('key10');
+                expect(val).to.equal('val10');
+                val = await Util.promiseLater(1100, map.get.bind(map, 'key10'));
+                expect(val).to.be.null;
             });
 
-            it('clear', function () {
-                return map.clear().then(function () {
-                    return map.isEmpty();
-                }).then(function (val) {
-                    return expect(val).to.be.true;
-                });
+            it('clear', async function () {
+                await map.clear();
+                const val = await map.isEmpty();
+                expect(val).to.be.true;
             });
 
-            it('size', function () {
-                return map.size().then(function (size) {
-                    expect(size).to.equal(10);
-                })
+            it('size', async function () {
+                const size = await map.size();
+                expect(size).to.equal(10);
             });
 
-            it('basic_remove_return_value', function () {
-                return map.remove('key9').then(function (val) {
-                    return expect(val).to.equal('val9');
-                });
+            it('basic_remove_return_value', async function () {
+                const val = await map.remove('key9');
+                expect(val).to.equal('val9');
             });
 
-            it('basic_remove', function () {
-                return map.remove('key1').then(function () {
-                    return map.get('key1');
-                }).then(function (val) {
-                    return expect(val).to.be.null;
-                });
+            it('basic_remove', async function () {
+                await map.remove('key1');
+                const val = await map.get('key1');
+                expect(val).to.be.null;
             });
 
-            it('remove_if_equal_false', function () {
-                return map.remove('key1', 'wrong').then(function (val) {
-                    return expect(val).to.be.false;
-                });
+            it('remove_if_equal_false', async function () {
+                const val = await map.remove('key1', 'wrong');
+                expect(val).to.be.false;
             });
 
-            it('remove_if_equal_true', function () {
-                return map.remove('key1', 'val1').then(function (val) {
-                    return expect(val).to.be.true;
-                });
+            it('remove_if_equal_true', async function () {
+                const val = await map.remove('key1', 'val1');
+                expect(val).to.be.true;
             });
 
-            it('containsKey_true', function () {
-                return map.containsKey('key1').then(function (val) {
-                    return expect(val).to.be.true;
-                });
+            it('containsKey_true', async function () {
+                const val = await map.containsKey('key1');
+                expect(val).to.be.true;
             });
 
-            it('containsKey_false', function () {
-                return map.containsKey('non-existent').then(function (val) {
-                    return expect(val).to.be.false;
-                });
+            it('containsKey_false', async function () {
+                const val = await map.containsKey('non-existent');
+                expect(val).to.be.false;
             });
 
-            it('containsValue_true', function () {
-                return map.containsValue('val1').then(function (val) {
-                    return expect(val).to.be.true;
-                });
+            it('containsValue_true', async function () {
+                const val = await map.containsValue('val1');
+                expect(val).to.be.true;
             });
 
-            it('containsValue_false', function () {
-                return map.containsValue('non-existent').then(function (val) {
-                    return expect(val).to.be.false;
-                });
+            it('containsValue_false', async function () {
+                const val = await map.containsValue('non-existent');
+                expect(val).to.be.false;
             });
 
             [true, false].forEach(function (shouldUsePutAll) {
@@ -232,92 +204,73 @@ describe('MapProxyTest', function () {
                         map.get(arr[2][0]).then(verify(arr[2][1]));
                         map.get(arr[3][0]).then(verify(arr[3][1]));
                         map.get(arr[4][0]).then(verify(arr[4][1]));
-                    })
+                    });
                 });
             });
 
-            it('getAll', function () {
-                return map.getAll([
+            it('getAll', async function () {
+                const values = await map.getAll([
                     'key0', 'key1', 'key2', 'key3', 'key4',
                     'key5', 'key6', 'key7', 'key8', 'key9'
-                ]).then(function (values) {
-                    return expect(values).to.deep.have.members([
-                        ['key0', 'val0'], ['key1', 'val1'],
-                        ['key2', 'val2'], ['key3', 'val3'],
-                        ['key4', 'val4'], ['key5', 'val5'],
-                        ['key6', 'val6'], ['key7', 'val7'],
-                        ['key8', 'val8'], ['key9', 'val9']
-                    ]);
-                })
+                ]);
+                expect(values).to.deep.have.members([
+                    ['key0', 'val0'], ['key1', 'val1'],
+                    ['key2', 'val2'], ['key3', 'val3'],
+                    ['key4', 'val4'], ['key5', 'val5'],
+                    ['key6', 'val6'], ['key7', 'val7'],
+                    ['key8', 'val8'], ['key9', 'val9']
+                ]);
             });
 
-            it('delete', function () {
-                return map.put('key-to-delete', 'value').then(function () {
-                    return map.delete('key-to-delete');
-                }).then(function () {
-                    return map.get('key-to-delete');
-                }).then(function (val) {
-                    return expect(val).to.be.null;
-                })
+            it('delete', async function () {
+                await map.put('key-to-delete', 'value');
+                await map.delete('key-to-delete');
+                const val = await map.get('key-to-delete');
+                expect(val).to.be.null;
             });
 
-            it('entrySet_notNull', function () {
-                let entryMap;
+            it('entrySet_notNull', async function () {
                 const samples = [
                     ['k1', 'v1'],
                     ['k2', 'v2'],
                     ['k3', 'v3']
                 ];
 
-                return client.getMap('entry-map').then(function (mp) {
-                    entryMap = mp;
-                    return Promise.all([
+                const entryMap = await client.getMap('entry-map');
+                await Promise.all([
                         entryMap.put(samples[0][0], samples[0][1]),
                         entryMap.put(samples[1][0], samples[1][1]),
                         entryMap.put(samples[2][0], samples[2][1])
-                    ]);
-                }).then(function () {
-                    return entryMap.entrySet();
-                }).then(function (entrySet) {
-                    return expect(entrySet).to.deep.have.members(samples);
-                });
+                ]);
+                const entrySet = await entryMap.entrySet();
+                expect(entrySet).to.deep.have.members(samples);
             });
 
-            it('entrySet_null', function () {
-                let entryMap;
-                return client.getMap('null-entry-map').then(function (mp) {
-                    entryMap = mp;
-                    return entryMap.entrySet();
-                }).then(function (entrySet) {
-                    return expect(entrySet).to.be.empty;
-                });
+            it('entrySet_null', async function () {
+                const entryMap = await client.getMap('null-entry-map');
+                const entrySet = await entryMap.entrySet();
+                expect(entrySet).to.be.empty;
             });
 
-            it('flush', function () {
+            it('flush', async function () {
                 return map.flush();
             });
 
-            it('lock', function () {
-                return map.lock('key0').then(function () {
-                    return map.isLocked('key0');
-                }).then(function (isLocked) {
-                    return expect(isLocked).to.be.true;
-                }).finally(function () {
-                    return map.unlock('key0');
-                });
+            it('lock', async function () {
+                await map.lock('key0');
+                const isLocked = await map.isLocked('key0');
+                expect(isLocked).to.be.true;
+                return map.unlock('key0');
             });
 
-            it('unlock', function () {
-                return map.lock('key0').then(function () {
-                    return map.unlock('key0');
-                }).then(function () {
-                    return map.isLocked('key0');
-                }).then(function (isLocked) {
-                    return expect(isLocked).to.be.false;
-                });
+            it('unlock', async function () {
+                await map.lock('key0');
+                await map.unlock('key0');
+                const isLocked = await map.isLocked('key0');
+                expect(isLocked).to.be.false;
             });
 
-            it('forceUnlock', function () {
+            it('forceUnlock', async function () {
                 const script =
                     'function lockByServer() {' +
                     '   var map = instance_0.getMap("' + map.getName() + '");' +
@@ -325,140 +278,102 @@ describe('MapProxyTest', function () {
                     '   return map.isLocked("key0")' +
                     '}' +
                     'result=""+lockByServer();';
-                return RC.executeOnController(cluster.id, script, 1).then(function (s) {
-                    return map.forceUnlock('key0');
-                }).then(function () {
-                    return map.isLocked('key0');
-                }).then(function (isLocked) {
-                    return expect(isLocked).to.be.false;
-                });
+                await RC.executeOnController(cluster.id, script, 1);
+                await map.forceUnlock('key0');
+                const isLocked = await map.isLocked('key0');
+                expect(isLocked).to.be.false;
             });
 
-            it('keySet', function () {
-                return map.keySet().then(function (keySet) {
-                    return expect(keySet).to.deep.have.members([
+            it('keySet', async function () {
+                const keySet = await map.keySet();
+                expect(keySet).to.deep.have.members([
                         'key0', 'key1', 'key2', 'key3', 'key4',
                         'key5', 'key6', 'key7', 'key8', 'key9'
-                    ]);
-                });
+                ]);
             });
 
-            it('putIfAbsent_success', function () {
-                return map.putIfAbsent('key10', 'new-val').then(function (oldVal) {
-                    return expect(oldVal).to.be.null;
-                }).then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('new-val');
-                });
+            it('putIfAbsent_success', async function () {
+                const oldVal = await map.putIfAbsent('key10', 'new-val');
+                expect(oldVal).to.be.null;
+                const val = await map.get('key10');
+                expect(val).to.equal('new-val');
             });
 
-            it('putIfAbsent_fail', function () {
-                return map.putIfAbsent('key9', 'new-val').then(function () {
-                    return map.get('key9');
-                }).then(function (val) {
-                    return expect(val).to.equal('val9');
-                });
+            it('putIfAbsent_fail', async function () {
+                await map.putIfAbsent('key9', 'new-val');
+                const val = await map.get('key9');
+                expect(val).to.equal('val9');
             });
 
-            it('putIfAbsent_with_ttl', function () {
-                return map.putIfAbsent('key10', 'new-val', 1000).then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('new-val');
-                }).then(function () {
-                    return Util.promiseLater(1050, map.get.bind(map, 'key10'));
-                }).then(function (val) {
-                    return expect(val).to.be.null;
-                });
-
+            it('putIfAbsent_with_ttl', async function () {
+                await map.putIfAbsent('key10', 'new-val', 1000);
+                let val = await map.get('key10');
+                expect(val).to.equal('new-val');
+                val = await Util.promiseLater(1050, map.get.bind(map, 'key10'));
+                expect(val).to.be.null;
             });
 
-            it('putTransient', function () {
-                return map.putTransient('key10', 'val10').then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('val10');
-                });
+            it('putTransient', async function () {
+                await map.putTransient('key10', 'val10');
+                const val = await map.get('key10');
+                expect(val).to.equal('val10');
             });
 
-            it('putTransient_withTTL', function () {
-                return map.putTransient('key10', 'val10', 1000).then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('val10');
-                }).then(function () {
-                    return Util.promiseLater(1050, map.get.bind(map, 'key10'));
-                }).then(function (val) {
-                    return expect(val).to.be.null;
-                });
+            it('putTransient_withTTL', async function () {
+                await map.putTransient('key10', 'val10', 1000);
+                let val = await map.get('key10');
+                expect(val).to.equal('val10');
+                val = await Util.promiseLater(1050, map.get.bind(map, 'key10'));
+                expect(val).to.be.null;
             });
 
-            it('replace', function () {
-                return map.replace('key9', 'new-val').then(function (oldVal) {
-                    return expect(oldVal).to.equal('val9');
-                }).then(function () {
-                    return map.get('key9');
-                }).then(function (val) {
-                    return expect(val).to.equal('new-val');
-                });
+            it('replace', async function () {
+                const oldVal = await map.replace('key9', 'new-val');
+                expect(oldVal).to.equal('val9');
+                const val = await map.get('key9');
+                expect(val).to.equal('new-val');
             });
 
-            it('replaceIfSame_success', function () {
-                return map.replaceIfSame('key9', 'val9', 'new-val').then(function (success) {
-                    return expect(success).to.be.true;
-                }).then(function () {
-                    return map.get('key9');
-                }).then(function (val) {
-                    return expect(val).to.equal('new-val');
-                });
+            it('replaceIfSame_success', async function () {
+                const success = await map.replaceIfSame('key9', 'val9', 'new-val');
+                expect(success).to.be.true;
+                const val = await map.get('key9');
+                expect(val).to.equal('new-val');
             });
 
-            it('replaceIfSame_fail', function () {
-                return map.replaceIfSame('key9', 'wrong', 'new-val', function (success) {
-                    return expect(success).to.be.false;
-                }).then(function () {
-                    return map.get('key9');
-                }).then(function (val) {
-                    return expect(val).to.equal('val9');
-                });
+            it('replaceIfSame_fail', async function () {
+                const success = await map.replaceIfSame('key9', 'wrong', 'new-val');
+                expect(success).to.be.false;
+                const val = await map.get('key9');
+                expect(val).to.equal('val9');
             });
 
-            it('set', function () {
-                return map.set('key10', 'val10').then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('val10');
-                })
+            it('set', async function () {
+                await map.set('key10', 'val10');
+                const val = await map.get('key10');
+                expect(val).to.equal('val10');
             });
 
-            it('set_withTTL', function () {
-                return map.set('key10', 'val10', 1000).then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('val10');
-                }).then(function () {
-                    return Util.promiseLater(1050, map.get.bind(map, 'key10'));
-                }).then(function (val) {
-                    return expect(val).to.be.null;
-                })
+            it('set_withTTL', async function () {
+                await map.set('key10', 'val10', 1000);
+                let val = await map.get('key10');
+                expect(val).to.equal('val10');
+                val = await Util.promiseLater(1050, map.get.bind(map, 'key10'));
+                expect(val).to.be.null;
             });
 
-            it('values', function () {
-                return map.values().then(function (vals) {
-                    return expect(vals.toArray()).to.deep.have.members([
-                        'val0', 'val1', 'val2', 'val3', 'val4',
-                        'val5', 'val6', 'val7', 'val8', 'val9'
-                    ]);
-                });
+            it('values', async function () {
+                const vals = await map.values();
+                expect(vals.toArray()).to.deep.have.members([
+                    'val0', 'val1', 'val2', 'val3', 'val4',
+                    'val5', 'val6', 'val7', 'val8', 'val9'
+                ]);
             });
 
-            it('values_null', function () {
-                return map.clear().then(function () {
-                    return map.values();
-                }).then(function (vals) {
-                    return expect(vals.toArray()).to.have.lengthOf(0);
-                })
+            it('values_null', async function () {
+                await map.clear();
+                const vals = await map.values();
+                expect(vals.toArray()).to.have.lengthOf(0);
             });
 
             it('getEntryView', function (done) {
@@ -484,13 +399,12 @@ describe('MapProxyTest', function () {
                 });
             });
 
-            it('getEntryView_null', function () {
-                return map.getEntryView('non-exist').then(function (entry) {
-                    return expect(entry).to.be.null;
-                });
+            it('getEntryView_null', async function () {
+                const entry = await map.getEntryView('non-exist');
+                expect(entry).to.be.null;
             });
 
-            it('addIndex', function () {
+            it('addIndex', async function () {
                 const orderedIndexCfg = {
                     name: 'length',
                     attributes: ['this']
@@ -507,74 +421,50 @@ describe('MapProxyTest', function () {
                 ]);
             });
 
-            it('tryLock_success', function () {
-                return map.tryLock('key0').then(function (success) {
-                    return expect(success).to.be.true;
-                });
+            it('tryLock_success', async function () {
+                const success = await map.tryLock('key0');
+                expect(success).to.be.true;
             });
 
-            it('tryLock_fail', function () {
-                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1)
-                    .then(function (s) {
-                        return map.tryLock('key0');
-                    })
-                    .then(function (success) {
-                        return expect(success).to.be.false;
-                    });
+            it('tryLock_fail', async function () {
+                await RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
+                const success = await map.tryLock('key0');
+                expect(success).to.be.false;
             });
 
-            it('tryLock_success with timeout', function () {
-                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1)
-                    .then(function () {
-                        const promise = map.tryLock('key0', 1000);
-                        RC.executeOnController(cluster.id, generateUnlockScript(map.getName(), '"key0"'), 1);
-                        return promise;
-                    })
-                    .then(function (success) {
-                        return expect(success).to.be.true;
-                    });
+            it('tryLock_success with timeout', async function () {
+                await RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
+                await RC.executeOnController(cluster.id, generateUnlockScript(map.getName(), '"key0"'), 1);
+                const success = await map.tryLock('key0', 1000);
+                expect(success).to.be.true;
             });
 
-            it('tryLock_fail with timeout', function () {
-                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1)
-                    .then(function () {
-                        return map.tryLock('key0', 1000);
-                    })
-                    .then(function (success) {
-                        return expect(success).to.be.false;
-                    });
+            it('tryLock_fail with timeout', async function () {
+                await RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
+                const success = await map.tryLock('key0', 1000);
+                expect(success).to.be.false;
             });
 
-            it('tryPut success', function () {
-                return map.tryPut('key0', 'val0', 1000).then(function (success) {
-                    return expect(success).to.be.true;
-                })
+            it('tryPut success', async function () {
+                const success = await map.tryPut('key0', 'val0', 1000);
+                expect(success).to.be.true;
             });
 
-            it('tryPut fail', function () {
-                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1)
-                    .then(function () {
-                        return map.tryPut('key0', 'val0', 200);
-                    })
-                    .then(function (success) {
-                        return expect(success).to.be.false;
-                    });
+            it('tryPut fail', async function () {
+                await RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
+                const success = await map.tryPut('key0', 'val0', 200);
+                expect(success).to.be.false;
             });
 
-            it('tryRemove success', function () {
-                return map.tryRemove('key0', 1000).then(function (success) {
-                    return expect(success).to.be.true;
-                });
+            it('tryRemove success', async function () {
+                const success = await map.tryRemove('key0', 1000);
+                expect(success).to.be.true;
             });
 
-            it('tryRemove fail', function () {
-                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1)
-                    .then(function () {
-                        return map.tryRemove('key0', 200);
-                    })
-                    .then(function (success) {
-                        return expect(success).to.be.false;
-                    });
+            it('tryRemove fail', async function () {
+                return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1);
+                const success = await map.tryRemove('key0', 200);
+                expect(success).to.be.false;
             });
 
             it('addEntryListener on map, entryAdded fires because predicate returns true for that entry', function (done) {
@@ -765,7 +655,7 @@ describe('MapProxyTest', function () {
                     }
                 };
                 map.addEntryListener(listenerObject, 'key1', true).then(function () {
-                    map.evict('key1')
+                    map.evict('key1');
                 });
             });
 
@@ -807,19 +697,19 @@ describe('MapProxyTest', function () {
 
             it('addEntryListener on map entryExpired includeValue=true', function (done) {
                 const listenerObj = {
-                  expired: function (entryEvent) {
-                      try {
-                          expect(entryEvent.name).to.equal('test');
-                          expect(entryEvent.key).to.equal('expiringKey');
-                          expect(entryEvent.value).to.be.equal(null);
-                          expect(entryEvent.oldValue).to.equal('expiringValue');
-                          expect(entryEvent.mergingValue).to.be.equal(null);
-                          expect(entryEvent.member).to.not.be.equal(null);
-                          done();
-                      } catch (err) {
-                          done(err);
-                      }
-                  }
+                    expired: function (entryEvent) {
+                        try {
+                            expect(entryEvent.name).to.equal('test');
+                            expect(entryEvent.key).to.equal('expiringKey');
+                            expect(entryEvent.value).to.be.equal(null);
+                            expect(entryEvent.oldValue).to.equal('expiringValue');
+                            expect(entryEvent.mergingValue).to.be.equal(null);
+                            expect(entryEvent.member).to.not.be.equal(null);
+                            done();
+                        } catch (err) {
+                            done(err);
+                        }
+                    }
                 };
                 map.addEntryListener(listenerObj, undefined, true)
                     .then(function () {
@@ -827,88 +717,66 @@ describe('MapProxyTest', function () {
                     });
             });
 
-            it('removeEntryListener with correct id', function () {
-                return map.addEntryListener({}).then(function (listenerId) {
-                    return map.removeEntryListener(listenerId);
-                }).then(function (success) {
-                    return expect(success).to.be.true;
-                });
+            it('removeEntryListener with correct id', async function () {
+                const listenerId = await map.addEntryListener({});
+                const success = await map.removeEntryListener(listenerId);
+                expect(success).to.be.true;
             });
 
-            it('removeEntryListener with wrong id', function () {
-                return map.removeEntryListener('aaa').then(function (success) {
-                    return expect(success).to.be.false;
-                });
+            it('removeEntryListener with wrong id', async function () {
+                const success = await map.removeEntryListener('aaa');
+                expect(success).to.be.false;
             });
 
-            it('entrySetWithPredicate', function () {
-                return map.entrySetWithPredicate(Predicates.sql('this == val3')).then(function (entrySet) {
-                    expect(entrySet.length).to.equal(1);
-                    expect(entrySet[0][0]).to.equal('key3');
-                    expect(entrySet[0][1]).to.equal('val3');
-                });
+            it('entrySetWithPredicate', async function () {
+                const entrySet = await map.entrySetWithPredicate(Predicates.sql('this == val3'));
+                expect(entrySet.length).to.equal(1);
+                expect(entrySet[0][0]).to.equal('key3');
+                expect(entrySet[0][1]).to.equal('val3');
             });
 
-            it('keySetWithPredicate', function () {
-                return map.keySetWithPredicate(Predicates.sql('this == val3')).then(function (keySet) {
-                    expect(keySet.length).to.equal(1);
-                    expect(keySet[0]).to.equal('key3');
-                });
+            it('keySetWithPredicate', async function () {
+                const keySet = await map.keySetWithPredicate(Predicates.sql('this == val3'));
+                expect(keySet.length).to.equal(1);
+                expect(keySet[0]).to.equal('key3');
             });
 
-            it('keySetWithPredicate null response', function () {
-                return map.keySetWithPredicate(Predicates.sql('this == nonexisting')).then(function (keySet) {
-                    expect(keySet.length).to.equal(0);
-                });
+            it('keySetWithPredicate null response', async function () {
+                const keySet = await map.keySetWithPredicate(Predicates.sql('this == nonexisting'));
+                expect(keySet.length).to.equal(0);
             });
 
-            it('valuesWithPredicate', function () {
-                return map.valuesWithPredicate(Predicates.sql('this == val3')).then(function (valueList) {
-                    expect(valueList.toArray().length).to.equal(1);
-                    expect(valueList.toArray()[0]).to.equal('val3');
-                });
+            it('valuesWithPredicate', async function () {
+                const valueList = await map.valuesWithPredicate(Predicates.sql('this == val3'));
+                expect(valueList.toArray().length).to.equal(1);
+                expect(valueList.toArray()[0]).to.equal('val3');
             });
 
-            it('entrySetWithPredicate paging', function () {
-                return map.entrySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1))
-                    .then(function (entrySet) {
-                        expect(entrySet.length).to.equal(1);
-                        expect(entrySet[0]).to.deep.equal(['key3', 'val3']);
-                    });
+            it('entrySetWithPredicate paging', async function () {
+                const entrySet = await map.entrySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1));
+                expect(entrySet.length).to.equal(1);
+                expect(entrySet[0]).to.deep.equal(['key3', 'val3']);
             });
 
-            it('keySetWithPredicate paging', function () {
-                return map.keySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1))
-                    .then(function (keySet) {
-                        expect(keySet.length).to.equal(1);
-                        expect(keySet[0]).to.equal('key3');
-                    });
+            it('keySetWithPredicate paging', async function () {
+                const keySet = await map.keySetWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1));
+                expect(keySet.length).to.equal(1);
+                expect(keySet[0]).to.equal('key3');
             });
 
-            it('valuesWithPredicate paging', function () {
-                return map.valuesWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1))
-                    .then(function (values) {
-                        expect(values.toArray().length).to.equal(1);
-                        expect(values.toArray()[0]).to.equal('val3');
-                    });
+            it('valuesWithPredicate paging', async function () {
+                const values = await map.valuesWithPredicate(Predicates.paging(Predicates.greaterEqual('this', 'val3'), 1));
+                expect(values.toArray().length).to.equal(1);
+                expect(values.toArray()[0]).to.equal('val3');
             });
 
-            it('destroy', function () {
-                let dmap;
-                let newMap;
-                return client.getMap('map-to-be-destroyed').then(function (mp) {
-                    dmap = mp;
-                    return dmap.put('key', 'val');
-                }).then(function () {
-                    return dmap.destroy();
-                }).then(function () {
-                    return client.getMap('map-to-be-destroyed');
-                }).then(function (mp) {
-                    newMap = mp;
-                    return newMap.size();
-                }).then(function (s) {
-                    expect(s).to.equal(0);
-                });
+            it('destroy', async function () {
+                const dmap = await client.getMap('map-to-be-destroyed');
+                await dmap.put('key', 'val');
+                await dmap.destroy();
+                const newMap = await client.getMap('map-to-be-destroyed');
+                const s = await newMap.size();
+                expect(s).to.equal(0);
             });
         });
     });

--- a/test/map/NearCachedMapStressTest.js
+++ b/test/map/NearCachedMapStressTest.js
@@ -39,7 +39,7 @@ describe('NearCachedMapStress', function () {
     const removePercent = 20;
     const getPercent = 100 - putPercent - removePercent;
 
-    before(function () {
+    before(async function () {
         const cfg = {
             nearCaches: {
                 [mapName]: {
@@ -47,32 +47,20 @@ describe('NearCachedMapStress', function () {
                 }
             }
         };
-
-        return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'))
-            .then(function (res) {
-                cluster = res;
-                return RC.startMember(cluster.id);
-            })
-            .then(function (member) {
-                cfg.clusterName = cluster.id;
-                return Client.newHazelcastClient(cfg);
-            })
-            .then(function (cl) {
-                client1 = cl;
-                return Client.newHazelcastClient({ clusterName: cluster.id });
-            })
-            .then(function (cl) {
-                validatingClient = cl;
-            });
+        cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'));
+        await RC.startMember(cluster.id);
+        cfg.clusterName = cluster.id;
+        client1 = await Client.newHazelcastClient(cfg);
+        validatingClient = await Client.newHazelcastClient({ clusterName: cluster.id });
     });
 
-    after(function () {
-        return client1.shutdown()
-            .then(() => validatingClient.shutdown())
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client1.shutdown();
+        await validatingClient.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    function completeOperation() {
+    async function completeOperation() {
         runningOperations--;
         completedOperations++;
         if (completedOperations >= totalNumOperations && runningOperations === 0) {
@@ -120,7 +108,7 @@ describe('NearCachedMapStress', function () {
                             return mp.get(key);
                         }).then(function (actual) {
                             return expect(actual).to.be.equal(expected);
-                        })
+                        });
                     });
                     p.push(promise);
                 })();
@@ -140,5 +128,5 @@ describe('NearCachedMapStress', function () {
                 done(e);
             });
         });
-    })
+    });
 });

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -78,7 +78,7 @@ describe('NearCachedMapTest', function () {
                 await map1.get('key0');
                 const val = await map1.get('key0');
                 expect(val).to.equal('val0');
-                expectStats(map, 1, 1, 1);
+                expectStats(map1, 1, 1, 1);
             });
 
             it('remove operation removes entry from near cache', async function () {

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -30,7 +30,7 @@ describe('NearCachedMapTest', function () {
             let cluster, client1, client2;
             let map1, map2;
 
-            before(function () {
+            before(async function () {
                 this.timeout(32000);
                 const cfg = {
                     nearCaches: {
@@ -39,195 +39,152 @@ describe('NearCachedMapTest', function () {
                         }
                     }
                 };
-                return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'))
-                    .then(function (res) {
-                        cluster = res;
-                        return RC.startMember(cluster.id);
-                    })
-                    .then(function (member) {
-                        cfg.clusterName = cluster.id;
-                        return Client.newHazelcastClient(cfg).then(function (hazelcastClient) {
-                            client1 = hazelcastClient;
-                        });
-                    })
-                    .then(function () {
-                        return Client.newHazelcastClient(cfg).then(function (hazelcastClient) {
-                            client2 = hazelcastClient;
-                        });
-                    });
+                cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'));
+                await RC.startMember(cluster.id);
+                cfg.clusterName = cluster.id;
+                client1 = await Client.newHazelcastClient(cfg);
+                client2 = await Client.newHazelcastClient(cfg);
             });
 
-            beforeEach(function () {
+            beforeEach(async function () {
                 this.timeout(10000);
-                return client1.getMap('ncc-map').then(function (mp) {
-                    map1 = mp
-                    return client2.getMap('ncc-map');
-                }).then(function (mp) {
-                    map2 = mp;
-                    return fillMap(map1);
-                });
+                map1 = await client1.getMap('ncc-map');
+                map2 = await client2.getMap('ncc-map');
+                return fillMap(map1);
             });
 
-            afterEach(function () {
+            afterEach(async function () {
                 return map1.destroy();
             });
 
-            after(function () {
-                return client1.shutdown()
-                    .then(() => client2.shutdown())
-                    .then(() => RC.terminateCluster(cluster.id));
+            after(async function () {
+                await client1.shutdown();
+                await client2.shutdown();
+                return RC.terminateCluster(cluster.id);
             });
 
-            function getNearCacheStats(map) {
+            async function getNearCacheStats(map) {
                 return map.nearCache.getStatistics();
             }
 
-            function expectStats(map, hit, miss, entryCount) {
-                const stats = getNearCacheStats(map);
+            async function expectStats(map, hit, miss, entryCount) {
+                const stats = await getNearCacheStats(map);
                 expect(stats.hitCount).to.equal(hit);
                 expect(stats.missCount).to.equal(miss);
-                return expect(stats.entryCount).to.equal(entryCount);
+                expect(stats.entryCount).to.equal(entryCount);
             }
 
-            it('second get should hit', function () {
-                return map1.get('key0').then(function () {
-                    return map1.get('key0');
-                }).then(function (val) {
-                    const stats = getNearCacheStats(map1);
-                    expect(val).to.equal('val0');
-                    expect(stats.missCount).to.equal(1);
-                    expect(stats.entryCount).to.equal(1);
-                    expect(stats.hitCount).to.equal(1);
-                })
+            it('second get should hit', async function () {
+                await map1.get('key0');
+                const val = await map1.get('key0');
+                const stats = await getNearCacheStats(map1);
+                expect(val).to.equal('val0');
+                expect(stats.missCount).to.equal(1);
+                expect(stats.entryCount).to.equal(1);
+                expect(stats.hitCount).to.equal(1);
             });
 
-            it('remove operation removes entry from near cache', function () {
-                return map1.get('key1').then(function () {
-                    return map1.remove('key1');
-                }).then(function () {
-                    return map1.get('key1');
-                }).then(function (val) {
-                    const stats = getNearCacheStats(map1);
-                    expect(val).to.be.null;
-                    expect(stats.hitCount).to.equal(0);
-                    expect(stats.missCount).to.equal(2);
-                    expect(stats.entryCount).to.equal(1);
-                });
+            it('remove operation removes entry from near cache', async function () {
+                await map1.get('key1');
+                await map1.remove('key1');
+                const val = await map1.get('key1');
+                const stats = await getNearCacheStats(map1);
+                expect(val).to.be.null;
+                expect(stats.hitCount).to.equal(0);
+                expect(stats.missCount).to.equal(2);
+                expect(stats.entryCount).to.equal(1);
             });
 
-            it('update invalidates the near cache', function () {
-                return map1.get('key1').then(function () {
-                    return map1.put('key1', 'something else');
-                }).then(function () {
-                    return map1.get('key1');
-                }).then(function (val) {
-                    const stats = getNearCacheStats(map1);
-                    expect(val).to.be.equal('something else');
-                    expect(stats.hitCount).to.equal(0);
-                    expect(stats.missCount).to.equal(2);
-                    expect(stats.entryCount).to.equal(1);
-                });
+            it('update invalidates the near cache', async function () {
+                await map1.get('key1');
+                await map1.put('key1', 'something else');
+                const val = await map1.get('key1');
+                const stats = await getNearCacheStats(map1);
+                expect(val).to.be.equal('something else');
+                expect(stats.hitCount).to.equal(0);
+                expect(stats.missCount).to.equal(2);
+                expect(stats.entryCount).to.equal(1);
             });
 
-            it('get returns null if the entry was removed by another client', function () {
+            it('get returns null if the entry was removed by another client', async function () {
                 if (!invalidateOnChange) {
                     this.skip();
                 }
-                return map1.get('key1').then(function () {
-                    return map2.remove('key1');
-                }).then(function () {
-                    return Util.promiseLater(1000, map1.get.bind(map1, 'key1'));
-                }).then(function (val) {
-                    expectStats(map1, 0, 2, 1);
-                    return expect(val).to.be.null;
-                });
+                await map1.get('key1');
+                await map2.remove('key1');
+                const val = await Util.promiseLater(1000, map1.get.bind(map1, 'key1'));
+                await expectStats(map1, 0, 2, 1);
+                expect(val).to.be.null;
             });
 
-            it('clear clears nearcache', function () {
-                return map1.get('key1').then(function () {
-                    return map1.clear();
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('clear clears nearcache', async function () {
+                await map1.get('key1');
+                await map1.clear();
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('containsKey true(in near cache)', function () {
-                return map1.get('key1').then(function () {
-                    return map1.containsKey('key1');
-                }).then(function (c) {
-                    expectStats(map1, 1, 1, 1);
-                    return expect(c).to.be.true;
-                });
+            it('containsKey true(in near cache)', async function () {
+                await map1.get('key1');
+                const c = await map1.containsKey('key1');
+                await expectStats(map1, 1, 1, 1);
+                expect(c).to.be.true;
             });
 
-            it('containsKey false(in near cache)', function () {
-                return map1.get('exx').then(function () {
-                    return map1.containsKey('exx');
-                }).then(function (c) {
-                    expectStats(map1, 1, 1, 1);
-                    return expect(c).to.be.false;
-                });
+            it('containsKey false(in near cache)', async function () {
+                await map1.get('exx');
+                const c = await map1.containsKey('exx');
+                await expectStats(map1, 1, 1, 1);
+                expect(c).to.be.false;
             });
 
-            it('containsKey true', function () {
-                return map1.containsKey('key1').then(function (c) {
-                    expectStats(map1, 0, 1, 0);
-                    return expect(c).to.be.true;
-                });
+            it('containsKey true', async function () {
+                const c = await map1.containsKey('key1');
+                await expectStats(map1, 0, 1, 0);
+                expect(c).to.be.true;
             });
 
-            it('containsKey false', function () {
-                return map1.containsKey('exx').then(function (c) {
-                    expectStats(map1, 0, 1, 0);
-                    return expect(c).to.be.false;
-                });
+            it('containsKey false', async function () {
+                const c = await map1.containsKey('exx');
+                await expectStats(map1, 0, 1, 0);
+                expect(c).to.be.false;
             });
 
-            it('delete invalidates the cache', function () {
-                return map1.get('key1').then(function () {
-                    return map1.delete('key1');
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('delete invalidates the cache', async function () {
+                await map1.get('key1');
+                await map1.delete('key1');
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('evictAll evicts near cache', function () {
-                return map1.get('key1').then(function () {
-                    return map1.evictAll();
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('evictAll evicts near cache', async function () {
+                await map1.get('key1');
+                await map1.evictAll();
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('evict evicts the entry', function () {
-                return map1.getAll(['key1', 'key2']).then(function () {
-                    return map1.evict('key1');
-                }).then(function () {
-                    return expectStats(map1, 0, 2, 1);
-                });
+            it('evict evicts the entry', async function () {
+                await map1.getAll(['key1', 'key2']);
+                await map1.evict('key1');
+                return expectStats(map1, 0, 2, 1);
             });
 
-            it('getAll', function () {
-                return map1.getAll(['key1', 'key2']).then(function (vals) {
-                    expect(vals).to.deep.have.members([
-                        ['key1', 'val1'],
-                        ['key2', 'val2']
-                    ]);
-                    return expectStats(map1, 0, 2, 2);
-                });
+            it('getAll', async function () {
+                const vals = await map1.getAll(['key1', 'key2']);
+                expect(vals).to.deep.have.members([
+                    ['key1', 'val1'],
+                    ['key2', 'val2']
+                ]);
+                return expectStats(map1, 0, 2, 2);
             });
 
-            it('getAll second call should hit', function () {
-                return map1.getAll(['key1', 'key2']).then(function (vals) {
-                    return map1.getAll(['key1', 'key2', 'key3']);
-                }).then(function (vals) {
-                    expect(vals).to.deep.have.members([
-                        ['key1', 'val1'],
-                        ['key2', 'val2'],
-                        ['key3', 'val3']
-                    ]);
-                    return expectStats(map1, 2, 3, 3);
-                });
+            it('getAll second call should hit', async function () {
+                await map1.getAll(['key1', 'key2']);
+                const vals = await map1.getAll(['key1', 'key2', 'key3']);
+                expect(vals).to.deep.have.members([
+                    ['key1', 'val1'],
+                    ['key2', 'val2'],
+                    ['key3', 'val3']
+                ]);
+                return expectStats(map1, 2, 3, 3);
             });
 
             it('executeOnKey invalidates the entry');
@@ -237,77 +194,61 @@ describe('NearCachedMapTest', function () {
             it('loadAll invalidates the cache');
 
             [true, false].forEach(function (shouldUsePutAll) {
-                it((shouldUsePutAll ? 'putAll' : 'setAll') + ' invalidates entries', function () {
-                    return map1.getAll(['key1', 'key2'])
-                        .then(() => {
-                            const entries = [
-                                ['key1', 'newVal1'],
-                                ['key2', 'newVal2']
-                            ];
-                            if (shouldUsePutAll) {
-                                return map1.putAll(entries);
-                            } else {
-                                return map1.setAll(entries);
-                            }
-                        })
-                        .then(() => expectStats(map1, 0, 2, 0));
+                it((shouldUsePutAll ? 'putAll' : 'setAll') + ' invalidates entries', async function () {
+                    await map1.getAll(['key1', 'key2']);
+                    const entries = [
+                        ['key1', 'newVal1'],
+                        ['key2', 'newVal2']
+                    ];
+                    if (shouldUsePutAll) {
+                        await map1.putAll(entries);
+                    } else {
+                        await map1.setAll(entries);
+                    }
+                    expectStats(map1, 0, 2, 0);
                 });
             });
 
-            it('putIfAbsent (existing key) invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.putIfAbsent('key1', 'valnew');
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('putIfAbsent (existing key) invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.putIfAbsent('key1', 'valnew');
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('putTransient invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.putTransient('key1', 'vald');
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('putTransient invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.putTransient('key1', 'vald');
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('replace invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.replace('key1', 'newVal');
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('replace invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.replace('key1', 'newVal');
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('replaceIfSame invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.replaceIfSame('key1', 'val1', 'newVal');
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('replaceIfSame invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.replaceIfSame('key1', 'val1', 'newVal');
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('set invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.set('key1', 'newVal');
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('set invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.set('key1', 'newVal');
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('tryPut invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.tryPut('key1', 'newVal', 1000);
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('tryPut invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.tryPut('key1', 'newVal', 1000);
+                return expectStats(map1, 0, 1, 0);
             });
 
-            it('tryRemove invalidates the entry', function () {
-                return map1.get('key1').then(function () {
-                    return map1.tryRemove('key1', 1000);
-                }).then(function () {
-                    return expectStats(map1, 0, 1, 0);
-                });
+            it('tryRemove invalidates the entry', async function () {
+                await map1.get('key1');
+                await map1.tryRemove('key1', 1000);
+                return expectStats(map1, 0, 1, 0);
             });
         });
     });

--- a/test/multimap/MultiMapProxyListenersTest.js
+++ b/test/multimap/MultiMapProxyListenersTest.js
@@ -27,35 +27,28 @@ describe("MultiMap Proxy Listener", function () {
     let client;
     let map;
 
-    before(function () {
+    before(async function () {
         this.timeout(10000);
-        return RC.createCluster().then(function (response) {
-            cluster = response;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return HazelcastClient.newHazelcastClient({ clusterName: cluster.id });
-        }).then(function (hazelcastClient) {
-            client = hazelcastClient;
-        });
+        cluster = await RC.createCluster();
+        await RC.startMember(cluster.id);
+        client = await HazelcastClient.newHazelcastClient({ clusterName: cluster.id });
     });
 
-    beforeEach(function () {
-        return client.getMultiMap('test').then(function (mp) {
-            map = mp;
-        });
+    beforeEach(async function () {
+        map = await client.getMultiMap('test');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return map.destroy();
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
     function Listener(eventName, doneCallback, expectedName, expectedKey, expectedValue, expectedOldValue,
-                      expectedMergingValue) {
+        expectedMergingValue) {
         this[eventName] = function (entryEvent) {
             try {
                 expect(entryEvent.name).to.equal(expectedName);
@@ -68,7 +61,7 @@ describe("MultiMap Proxy Listener", function () {
             } catch (err) {
                 doneCallback(err);
             }
-        }
+        };
     }
 
     // Add tests
@@ -189,18 +182,15 @@ describe("MultiMap Proxy Listener", function () {
         });
     });
 
-    it("removes present listener", function () {
-        return map.addEntryListener({}, null, true).then(function (registrationId) {
-            return map.removeEntryListener(registrationId);
-        }).then(function (removed) {
-            expect(removed).to.be.true;
-        });
+    it("removes present listener", async function () {
+        const registrationId = await map.addEntryListener({}, null, true);
+        const removed = await map.removeEntryListener(registrationId);
+        expect(removed).to.be.true;
     });
 
-    it("removes present listener", function () {
-        return map.removeEntryListener("foo").then(function (removed) {
-            expect(removed).to.be.false;
-        });
+    it("removes present listener", async function () {
+        const removed = await map.removeEntryListener("foo");
+        expect(removed).to.be.false;
     });
 
     it('fires event for each pair of putAll', function (done) {
@@ -218,7 +208,7 @@ describe("MultiMap Proxy Listener", function () {
                         done(new Error('Received too many events'));
                     }
                 }
-            }
+            };
         };
 
         map.addEntryListener(listener('a', [1]), 'a')

--- a/test/queue/QueueProxyTest.js
+++ b/test/queue/QueueProxyTest.js
@@ -86,7 +86,7 @@ describe('QueueProxyTest', function () {
 
     it('add throws if queue is full', async function () {
         await offerToQueue(5, 'new');
-        expect(queue.add('excess_item')).to.eventually.rejected;
+        return expect(queue.add('excess_item')).to.eventually.rejected;
     });
 
     it('poll decreases queue size', async function () {

--- a/test/queue/QueueProxyTest.js
+++ b/test/queue/QueueProxyTest.js
@@ -31,32 +31,23 @@ describe('QueueProxyTest', function () {
     let client;
     let queue;
 
-    before(function () {
+    before(async function () {
         this.timeout(10000);
-        return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_queue.xml', 'utf8'))
-            .then(function (response) {
-                cluster = response;
-                return RC.startMember(cluster.id);
-            })
-            .then(function () {
-                return Client.newHazelcastClient({ clusterName: cluster.id });
-            }).then(function (hazelcastClient) {
-                client = hazelcastClient;
-            });
+        cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_queue.xml', 'utf8'));
+        await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
     });
 
-    beforeEach(function () {
-        return client.getQueue('ClientQueueTest').then(function (q) {
-            queue = q;
-            return offerToQueue(10);
-        });
+    beforeEach(async function () {
+        queue = await client.getQueue('ClientQueueTest');
+        return offerToQueue(10);
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return queue.destroy();
     });
 
-    function offerToQueue(size, prefix) {
+    async function offerToQueue(size, prefix) {
         if (prefix == null) {
             prefix = '';
         }
@@ -67,161 +58,132 @@ describe('QueueProxyTest', function () {
         return Promise.all(promises);
     }
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    it('size', function () {
-        return queue.size().then(function (s) {
-            return expect(s).to.equal(10);
-        })
+    it('size', async function () {
+        const s = await queue.size();
+        expect(s).to.equal(10);
     });
 
-    it('peek', function () {
-        return queue.peek().then(function (head) {
-            return expect(head).to.equal('item0');
-        })
+    it('peek', async function () {
+        const head = await queue.peek();
+        expect(head).to.equal('item0');
     });
 
-    it('add return true', function () {
-        return queue.add('item_new').then(function (retVal) {
-            return expect(retVal).to.be.true;
-        });
+    it('add return true', async function () {
+        const retVal = await queue.add('item_new');
+        expect(retVal).to.be.true;
     });
 
-    it('add increases queue size', function () {
-        return queue.add('item_new').then(function () {
-            return queue.size();
-        }).then(function (s) {
-            return expect(s).to.equal(11);
-        });
+    it('add increases queue size', async function () {
+        await queue.add('item_new');
+        const s = await queue.size();
+        expect(s).to.equal(11);
     });
 
-    it('add throws if queue is full', function () {
-        return offerToQueue(5, 'new').then(function () {
-            return expect(queue.add('excess_item')).to.eventually.rejected;
-        });
+    it('add throws if queue is full', async function () {
+        await offerToQueue(5, 'new');
+        expect(queue.add('excess_item')).to.eventually.rejected;
     });
 
-    it('poll decreases queue size', function () {
-        return queue.poll().then(function () {
-            return queue.size();
-        }).then(function (s) {
-            return expect(s).to.equal(9);
-        });
+    it('poll decreases queue size', async function () {
+        await queue.poll();
+        const s = await queue.size();
+        expect(s).to.equal(9);
     });
 
-    it('poll returns the head of the queue', function () {
-        return queue.poll().then(function (ret) {
-            return expect(ret).to.equal('item0');
-        });
+    it('poll returns the head of the queue', async function () {
+        const ret = await queue.poll();
+        expect(ret).to.equal('item0');
     });
 
-    it('poll returns null after timeout', function () {
-        return queue.clear().then(function () {
-            return queue.poll(1000);
-        }).then(function (ret) {
-            return expect(ret).to.be.null;
-        });
+    it('poll returns null after timeout', async function () {
+        await queue.clear();
+        const ret = await queue.poll(1000);
+        expect(ret).to.be.null;
     });
 
-    it('poll returns head after a new element added', function () {
-        return queue.clear().then(function () {
-            setTimeout(function () {
-                queue.offer('new_item');
-            }, 500);
-            return queue.poll(1000);
-        }).then(function (ret) {
-            return expect(ret).to.equal('new_item');
-        });
+    it('poll returns head after a new element added', async function () {
+        await queue.clear();
+        setTimeout(async function () {
+            await queue.offer('new_item');
+        }, 500);
+        const ret = await queue.poll(1000);
+        expect(ret).to.equal('new_item');
     });
 
-    it('offer with timeout', function () {
-        return queue.offer('new_item', 1000).then(function () {
-            return queue.size();
-        }).then(function (s) {
-            return expect(s).to.equal(11);
-        });
+    it('offer with timeout', async function () {
+        await queue.offer('new_item', 1000);
+        const s = await queue.size();
+        expect(s).to.equal(11);
     });
 
-    it('remaining capacity', function () {
-        return queue.remainingCapacity().then(function (c) {
-            return expect(c).to.equal(5);
-        });
+    it('remaining capacity', async function () {
+        const c = await queue.remainingCapacity();
+        expect(c).to.equal(5);
     });
 
-    it('contains returns false for absent', function () {
-        return queue.contains('item_absent').then(function (ret) {
-            return expect(ret).to.be.false;
-        });
+    it('contains returns false for absent', async function () {
+        const ret = await queue.contains('item_absent');
+        expect(ret).to.be.false;
     });
 
-    it('contains returns true for present', function () {
-        return queue.contains('item0').then(function (ret) {
-            return expect(ret).to.be.true;
-        });
+    it('contains returns true for present', async function () {
+        const ret = await queue.contains('item0');
+        expect(ret).to.be.true;
     });
 
-    it('remove', function () {
-        return queue.remove('item5').then(function (ret) {
-            return expect(ret).to.be.true;
-        });
+    it('remove', async function () {
+        const ret = await queue.remove('item5');
+        expect(ret).to.be.true;
     });
 
-    it('remove decreases size', function () {
-        return queue.remove('item5').then(function () {
-            return queue.size();
-        }).then(function (s) {
-            return expect(s).to.equal(9);
-        });
+    it('remove decreases size', async function () {
+        await queue.remove('item5');
+        const s = await queue.size();
+        expect(s).to.equal(9);
     });
 
-    it('toArray', function () {
-        return queue.toArray().then(function (arr) {
-            expect(arr).to.be.instanceof(Array);
-            expect(arr).to.have.lengthOf(10);
-            expect(arr).to.include.members(['item0', 'item2', 'item9']);
-        });
+    it('toArray', async function () {
+        const arr = await queue.toArray();
+        expect(arr).to.be.instanceof(Array);
+        expect(arr).to.have.lengthOf(10);
+        expect(arr).to.include.members(['item0', 'item2', 'item9']);
     });
 
-    it('clear', function () {
-        return queue.clear().then(function () {
-            return queue.size();
-        }).then(function (s) {
-            return expect(s).to.equal(0);
-        });
+    it('clear', async function () {
+        await queue.clear();
+        const s = await queue.size();
+        expect(s).to.equal(0);
     });
 
-    it('drainTo', function () {
+    it('drainTo', async function () {
         const dummyArr = ['dummy_item'];
-        return queue.drainTo(dummyArr).then(function () {
-            expect(dummyArr).to.have.lengthOf(11);
-            expect(dummyArr).to.include.members(['item0', 'dummy_item', 'item3', 'item9']);
-        });
+        await queue.drainTo(dummyArr);
+        expect(dummyArr).to.have.lengthOf(11);
+        expect(dummyArr).to.include.members(['item0', 'dummy_item', 'item3', 'item9']);
     });
 
-    it('drainTo with max elements', function () {
+    it('drainTo with max elements', async function () {
         const dummyArr = ['dummy_item'];
-        return queue.drainTo(dummyArr, 2).then(function () {
-            expect(dummyArr).to.have.lengthOf(3);
-            expect(dummyArr).to.include.members(['item0', 'dummy_item', 'item1']);
-            expect(dummyArr).to.not.include.members(['item2', 'item9']);
-        });
+        await queue.drainTo(dummyArr, 2);
+        expect(dummyArr).to.have.lengthOf(3);
+        expect(dummyArr).to.include.members(['item0', 'dummy_item', 'item1']);
+        expect(dummyArr).to.not.include.members(['item2', 'item9']);
     });
 
-    it('isEmpty false', function () {
-        return queue.isEmpty().then(function (ret) {
-            return expect(ret).to.be.false;
-        });
+    it('isEmpty false', async function () {
+        const ret = await queue.isEmpty();
+        expect(ret).to.be.false;
     });
 
-    it('isEmpty true', function () {
-        return queue.clear().then(function (ret) {
-            return queue.isEmpty();
-        }).then(function (ret) {
-            return expect(ret).to.be.true;
-        })
+    it('isEmpty true', async function () {
+        await queue.clear();
+        const ret = await queue.isEmpty();
+        expect(ret).to.be.true;
     });
 
     it('take waits', function (done) {
@@ -234,86 +196,66 @@ describe('QueueProxyTest', function () {
         }).catch(done);
     });
 
-    it('take immediately returns', function () {
-        return queue.take().then(function (ret) {
-            return expect(ret).to.equal('item0');
-        });
+    it('take immediately returns', async function () {
+        const ret = await queue.take();
+        expect(ret).to.equal('item0');
     });
 
-    it('addAll', function () {
+    it('addAll', async function () {
         const values = ['a', 'b', 'c'];
-        return queue.addAll(values).then(function (retVal) {
-            expect(retVal).to.be.true;
-            return queue.toArray();
-        }).then(function (vals) {
-            return expect(vals).to.include.members(values);
-        })
+        const retVal = await queue.addAll(values);
+        expect(retVal).to.be.true;
+        const vals = await queue.toArray();
+        expect(vals).to.include.members(values);
     });
 
-    it('containsAll true', function () {
+    it('containsAll true', async function () {
         const values = ['item0', 'item1'];
-        return queue.containsAll(values).then(function (ret) {
-            return expect(ret).to.be.true;
-        });
+        const ret = await queue.containsAll(values);
+        expect(ret).to.be.true;
     });
 
-    it('containsAll true', function () {
+    it('containsAll true', async function () {
         const values = ['item0', 'item_absent'];
-        return queue.containsAll(values).then(function (ret) {
-            return expect(ret).to.be.false;
-        });
+        const ret = await queue.containsAll(values);
+        expect(ret).to.be.false;
     });
 
-    it('containsAll true', function () {
+    it('containsAll true', async function () {
         const values = [];
-        return queue.containsAll(values).then(function (ret) {
-            return expect(ret).to.be.true;
-        });
+        const ret = await queue.containsAll(values);
+        expect(ret).to.be.true;
     });
 
-    it('put', function () {
-        return queue.put('item_new').then(function () {
-            return queue.size();
-        }).then(function (s) {
-            return expect(s).to.equal(11);
-        });
+    it('put', async function () {
+        await queue.put('item_new');
+        const s = await queue.size();
+        expect(s).to.equal(11);
     });
 
-    it('removeAll', function () {
+    it('removeAll', async function () {
         const cand = ['item1', 'item2'];
-        return queue.removeAll(cand).then(function (retVal) {
-            return expect(retVal).to.be.true;
-        }).then(function () {
-            return queue.toArray();
-        }).then(function (arr) {
-            return expect(arr).to.not.include.members(cand);
-        });
+        const retVal = await queue.removeAll(cand);
+        expect(retVal).to.be.true;
+        const arr = await queue.toArray();
+        expect(arr).to.not.include.members(cand);
     });
 
-    it('retainAll changes queue', function () {
+    it('retainAll changes queue', async function () {
         const retains = ['item1', 'item2'];
-        return queue.retainAll(retains).then(function (r) {
-            return expect(r).to.be.true;
-        }).then(function () {
-            return queue.toArray();
-        }).then(function (arr) {
-            return expect(arr).to.deep.equal(retains);
-        });
+        const r = await queue.retainAll(retains);
+        expect(r).to.be.true;
+        const arr = await queue.toArray();
+        expect(arr).to.deep.equal(retains);
     });
 
 
-    it('retainAll does not change queue', function () {
-        let retains;
-        return queue.toArray().then(function (r) {
-            retains = r;
-            return queue.retainAll(r);
-        }).then(function (r) {
-            return expect(r).to.be.false;
-        }).then(function () {
-            return queue.toArray();
-        }).then(function (arr) {
-            return expect(arr).to.deep.equal(retains);
-        });
+    it('retainAll does not change queue', async function () {
+        const retains = await queue.toArray();
+        const r = await queue.retainAll(retains);
+        expect(r).to.be.false;
+        const arr = await queue.toArray();
+        expect(arr).to.deep.equal(retains);
     });
 
     it('addItemListener itemAdded', function (done) {
@@ -327,7 +269,7 @@ describe('QueueProxyTest', function () {
             }
         }, true).then(function () {
             queue.add('item_new');
-        })
+        });
     });
 
     it('addItemListener itemAdded with includeValue=false', function (done) {
@@ -355,19 +297,15 @@ describe('QueueProxyTest', function () {
         });
     });
 
-    it('removeItemListener', function () {
-        return queue.addItemListener({}, false).then(function (regId) {
-            return queue.removeItemListener(regId);
-        }).then(function (ret) {
-            return expect(ret).to.be.true;
-        });
+    it('removeItemListener', async function () {
+        const regId = await queue.addItemListener({}, false);
+        const ret = await queue.removeItemListener(regId);
+        expect(ret).to.be.true;
     });
 
-    it('removeItemListener with wrong id returns null', function () {
-        return queue.addItemListener({}, false).then(function () {
-            return queue.removeItemListener('wrongId');
-        }).then(function (ret) {
-            return expect(ret).to.be.false;
-        });
+    it('removeItemListener with wrong id returns null', async function () {
+        await queue.addItemListener({}, false);
+        const ret = await queue.removeItemListener('wrongId');
+        expect(ret).to.be.false;
     });
 });

--- a/test/replicatedmap/ReplicatedMapProxyTest.js
+++ b/test/replicatedmap/ReplicatedMapProxyTest.js
@@ -21,6 +21,7 @@ const path = require('path');
 const RC = require('./../RC');
 const { Client } = require('../..');
 const { Predicates } = require('../..');
+const TestUtil = require('./../Util');
 
 describe('ReplicatedMapProxyTest', function () {
 
@@ -64,11 +65,7 @@ describe('ReplicatedMapProxyTest', function () {
 
     it('puts entry with 1000 ttl', async function () {
         await rm.put('1000ttl', 'value', 1000);
-        await new Promise(function (resolve) {
-            setTimeout(function () {
-                resolve();
-            }, 2000);
-        });
+        await TestUtil.promiseWaitMilliseconds(2000);
         const val = await rm.get('1000ttl');
         expect(val).to.be.null;
     }).timeout(5000);

--- a/test/replicatedmap/ReplicatedMapProxyTest.js
+++ b/test/replicatedmap/ReplicatedMapProxyTest.js
@@ -29,245 +29,168 @@ describe('ReplicatedMapProxyTest', function () {
     let rm;
     const ONE_HOUR = 3600000;
 
-    before(function () {
+    before(async function () {
         this.timeout(10000);
         const config = fs.readFileSync(path.join(__dirname, 'hazelcast_replicatedmap.xml'), 'utf8');
-        return RC.createCluster(null, config).then(function (response) {
-            cluster = response;
-            return RC.startMember(cluster.id);
-        }).then(function () {
-            return Client.newHazelcastClient({ clusterName: cluster.id });
-        }).then(function (hazelcastClient) {
-            client = hazelcastClient;
-        });
+        cluster = await RC.createCluster(null, config);
+        await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({ clusterName: cluster.id });
     });
 
-    beforeEach(function () {
-        return client.getReplicatedMap('test').then(function (mp) {
-            rm = mp;
-        });
+    beforeEach(async function () {
+        rm = await client.getReplicatedMap('test');
     });
 
-    afterEach(function () {
+    afterEach(async function () {
         return rm.destroy();
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        return RC.terminateCluster(cluster.id);
     });
 
-    it('puts one entry and gets one entry', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function () {
-                return rm.get('key')
-            })
-            .then(function (val) {
-                expect(val).to.equal('value');
-            });
+    it('puts one entry and gets one entry', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        const val = await rm.get('key');
+        expect(val).to.equal('value');
     });
 
-    it('puts entry with 0 ttl', function () {
-        return rm.put('zerottl', 'value')
-            .then(function () {
-                return rm.get('zerottl');
-            })
-            .then(function (val) {
-                expect(val).to.equal('value');
-            });
+    it('puts entry with 0 ttl', async function () {
+        await rm.put('zerottl', 'value');
+        const val = await rm.get('zerottl');
+        expect(val).to.equal('value');
     });
 
-    it('puts entry with 1000 ttl', function () {
-        return rm.put('1000ttl', 'value', 1000)
-            .then(function () {
-                return new Promise(function (resolve) {
-                    setTimeout(function () {
-                        resolve();
-                    }, 2000)
-                });
-            })
-            .then(function () {
-                return rm.get('1000ttl');
-            })
-            .then(function (val) {
-                expect(val).to.be.null;
-            });
+    it('puts entry with 1000 ttl', async function () {
+        await rm.put('1000ttl', 'value', 1000);
+        await new Promise(function (resolve) {
+            setTimeout(function () {
+                resolve();
+            }, 2000);
+        });
+        const val = await rm.get('1000ttl');
+        expect(val).to.be.null;
     }).timeout(5000);
 
-    it('should contain the key', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function (val) {
-                return rm.containsKey('key')
-            })
-            .then(function (res) {
-                expect(res).to.equal(true);
-            });
+    it('should contain the key', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        const res = await rm.containsKey('key');
+        expect(res).to.equal(true);
     });
 
-    it('should not contain the key', function () {
-        return rm.containsKey('key')
-            .then(function (res) {
-                expect(res).to.equal(false);
-            });
+    it('should not contain the key', async function () {
+        const res = await rm.containsKey('key');
+        expect(res).to.equal(false);
     });
 
-    it('should contain the value', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function () {
-                return rm.containsValue('value')
-            })
-            .then(function (res) {
-                expect(res).to.equal(true);
-            });
+    it('should contain the value', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        const res = await rm.containsValue('value');
+        expect(res).to.equal(true);
     });
 
-    it('should not contain the value', function () {
-        return rm.containsValue('value')
-            .then(function (res) {
-                expect(res).to.equal(false);
-            });
+    it('should not contain the value', async function () {
+        const res = await rm.containsValue('value');
+        expect(res).to.equal(false);
     });
 
-    it('putting items into the map should increase it\'s size', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function () {
-                return rm.size()
-            })
-            .then(function (size) {
-                expect(size).to.equal(1);
-            });
+    it('putting items into the map should increase it\'s size', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        const size = await rm.size();
+        expect(size).to.equal(1);
     });
 
-    it('returns isEmpty true if map is empty', function () {
-        return rm.isEmpty()
-            .then(function (res) {
-                expect(res).to.equal(true);
-            });
+    it('returns isEmpty true if map is empty', async function () {
+        const res = await rm.isEmpty();
+        expect(res).to.equal(true);
     });
 
-    it('returns isEmpty false if map is not empty', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function () {
-                return rm.isEmpty()
-            })
-            .then(function (res) {
-                expect(res).to.equal(false);
-            });
+    it('returns isEmpty false if map is not empty', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        const res = await rm.isEmpty();
+        expect(res).to.equal(false);
     });
 
-    it('removes entry from map', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function () {
-                return rm.containsKey('key');
-            })
-            .then(function (contains) {
-                expect(contains).to.equal(true);
-                return rm.remove('key')
-            })
-            .then(function () {
-                return rm.containsKey('key')
-            })
-            .then(function (contains) {
-                expect(contains).to.equal(false);
-            });
+    it('removes entry from map', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        let contains = await rm.containsKey('key');
+        expect(contains).to.equal(true);
+        await rm.remove('key');
+        contains = await rm.containsKey('key');
+        expect(contains).to.equal(false);
     });
 
-    it('clears map', function () {
-        return rm.put('key', 'value', ONE_HOUR)
-            .then(function () {
-                return rm.size();
-            })
-            .then(function (size) {
-                expect(size).to.equal(1);
-                return rm.clear();
-            })
-            .then(function () {
-                return rm.size();
-            })
-            .then(function (size) {
-                expect(size).to.equal(0);
-            });
+    it('clears map', async function () {
+        await rm.put('key', 'value', ONE_HOUR);
+        let size = await rm.size();
+        expect(size).to.equal(1);
+        await rm.clear();
+        size = await rm.size();
+        expect(size).to.equal(0);
     });
 
-    it('returns entry set', function () {
-        return Promise.all([
+    it('returns entry set', async function () {
+        await Promise.all([
             rm.put('key1', 'value1', ONE_HOUR),
             rm.put('key2', 'value2', ONE_HOUR),
             rm.put('key3', 'value3', ONE_HOUR)
-        ])
-            .then(function () {
-                return rm.entrySet();
-            })
-            .then(function (entrySet) {
-                expect(entrySet).to.eql([
-                    ['key1', 'value1'],
-                    ['key2', 'value2'],
-                    ['key3', 'value3']
-                ]);
-            });
-    });
-
-    it('batch put entries with putAll', function () {
-        return rm.putAll([
+        ]);
+        const entrySet = await rm.entrySet();
+        expect(entrySet).to.eql([
             ['key1', 'value1'],
             ['key2', 'value2'],
             ['key3', 'value3']
-        ])
-            .then(function () {
-                return rm.entrySet();
-            })
-            .then(function (entrySet) {
-                expect(entrySet).to.eql([
-                    ['key1', 'value1'],
-                    ['key2', 'value2'],
-                    ['key3', 'value3']
-                ]);
-            });
+        ]);
     });
 
-    it('returns values array', function () {
-        return rm.putAll([
+    it('batch put entries with putAll', async function () {
+        await rm.putAll([
             ['key1', 'value1'],
             ['key2', 'value2'],
             ['key3', 'value3']
-        ])
-            .then(function () {
-                return rm.values();
-            })
-            .then(function (values) {
-                expect(values.toArray()).to.eql(['value1', 'value2', 'value3']);
-            });
+        ]);
+        const entrySet = await rm.entrySet();
+        expect(entrySet).to.eql([
+            ['key1', 'value1'],
+            ['key2', 'value2'],
+            ['key3', 'value3']
+        ]);
     });
 
-    it('returns values array sorted with custom comparator', function () {
+    it('returns values array', async function () {
+        await rm.putAll([
+            ['key1', 'value1'],
+            ['key2', 'value2'],
+            ['key3', 'value3']
+        ]);
+        const values = await rm.values();
+        expect(values.toArray()).to.eql(['value1', 'value2', 'value3']);
+    });
+
+    it('returns values array sorted with custom comparator', async function () {
         const expectedArray = ['value3', 'value2', 'value1'];
-        return rm.putAll([
+        await rm.putAll([
             ['key2', 'value2'],
             ['key3', 'value3'],
             ['key1', 'value1']
-        ]).then(function () {
-            return rm.values(function (a, b) {
-                return b[b.length - 1] - a[a.length - 1];
-            });
-        }).then(function (values) {
-            values.toArray().forEach(function (value, index) {
-                expect(value).to.equal(expectedArray[index]);
-            });
+        ]);
+        const values = await rm.values(function (a, b) {
+            return b[b.length - 1] - a[a.length - 1];
+        });
+        values.toArray().forEach(function (value, index) {
+            expect(value).to.equal(expectedArray[index]);
         });
     });
 
-    it('returns keySet', function () {
-        return rm.putAll([
+    it('returns keySet', async function () {
+        await rm.putAll([
             ['key1', 'value1'],
             ['key2', 'value2'],
             ['key3', 'value3']
-        ])
-            .then(function () {
-                return rm.keySet();
-            })
-            .then(function (values) {
-                expect(values).to.eql(['key1', 'key2', 'key3']);
-            });
+        ]);
+        const values = await rm.keySet();
+        expect(values).to.eql(['key1', 'key2', 'key3']);
     });
 
     it('addEntryListener should be fired on adding new key-value pair', function (done) {
@@ -391,7 +314,7 @@ describe('ReplicatedMapProxyTest', function () {
                     rm.put('key-to-clear2', 'value2', ONE_HOUR),
                     rm.put('key-to-clear3', 'value2', ONE_HOUR),
                     rm.put('key-to-clear4', 'value2', ONE_HOUR)
-                ])
+                ]);
             })
             .then(function () {
                 return rm.clear();


### PR DESCRIPTION
Migrated tests in `test/{List,Map,MultiMap,ReplicatedMap,Queue,Set}` to use the `async/await` syntax.

Related to #569.