### PR TITLE
Add getAndDecrement operation for AtomicLong

### DIFF
--- a/src/proxy/IAtomicLong.ts
+++ b/src/proxy/IAtomicLong.ts
@@ -77,6 +77,13 @@ export interface IAtomicLong extends DistributedObject {
     getAndAdd(delta: Long | number): Promise<Long>;
 
     /**
+     * Atomically decrements the current value by one.
+     *
+     * @returns the old value
+     */
+    getAndDecrement(): Promise<Long>;
+
+    /**
      * Atomically sets the given value and returns the old value.
      *
      * @param newValue the new value

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -78,6 +78,10 @@ export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
             .then(AtomicLongGetAndAddCodec.decodeResponse);
     }
 
+    getAndDecrement(): Promise<Long> {
+        return this.getAndAdd(-1);
+    }
+
     getAndSet(newValue: Long | number): Promise<Long> {
         if (!Long.isLong(newValue)) {
             assertNumber(newValue);

--- a/test/cpsubsystem/AtomicLongTest.js
+++ b/test/cpsubsystem/AtomicLongTest.js
@@ -217,7 +217,7 @@ describe('AtomicLongTest', function () {
     });
 
     it('getAndDecrement: should decrement', async function () {
-        await long.getAndIncrement();
+        await long.getAndDecrement();
         const value = await long.get();
         expectLong(-1, value);
     });

--- a/test/cpsubsystem/AtomicLongTest.js
+++ b/test/cpsubsystem/AtomicLongTest.js
@@ -210,4 +210,15 @@ describe('AtomicLongTest', function () {
         const value = await long.get();
         expectLong(1, value);
     });
+
+    it('getAndDecrement: should return old value', async function () {
+        const value = await long.getAndDecrement();
+        expectLong(0, value);
+    });
+
+    it('getAndDecrement: should decrement', async function () {
+        await long.getAndIncrement();
+        const value = await long.get();
+        expectLong(-1, value);
+    });
 });


### PR DESCRIPTION
There were `getAndDoX` and `doXAndGet` method pairs for the `IAtomicLong` but there were just the `decrementAndGet`, `getAndDecrement` was missing. One may do `getAndAdd(-1)` to get the desired behavior, so there were no missing functionality but the `getAndDecrement` method is added to make the API more consistent.

Java client counterpart PR: https://github.com/hazelcast/hazelcast/pull/17699