### PR TITLE
Release session on unexpected FencedLock error

### DIFF
--- a/test/unit/proxy/cpsubsystem/FencedLockProxyTest.js
+++ b/test/unit/proxy/cpsubsystem/FencedLockProxyTest.js
@@ -137,6 +137,7 @@ describe('FencedLockProxyTest', function () {
         stubRequestLock(2, new Error());
 
         await expect(proxy.lock()).to.be.rejectedWith(Error);
+        expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
     });
 
     it('tryLock: should not release session on successful acquire', async function () {
@@ -200,6 +201,7 @@ describe('FencedLockProxyTest', function () {
         stubRequestTryLock(2, new Error());
 
         await expect(proxy.tryLock()).to.be.rejectedWith(Error);
+        expect(cpSessionManagerStub.releaseSession.calledOnce).to.be.true;
     });
 
     it('tryLock: should throw when timeout is not a number', function () {


### PR DESCRIPTION
Even if the calls to the lock, `lock` or `tryLock` fail for some reason other than `SessionExpiredError` or `WaitKeyCancelledError`, we were not releasing the sessions we acquired in the beginning, before throwing the exception. This fix aims to solve this problem by catching all kinds of exceptions (other than the two mentioned above), releasing the session and then rethrowing the catched exception.

Java client counterpart PR: https://github.com/hazelcast/hazelcast/pull/17697