### PR TITLE
Fix flaky tests

### DIFF
--- a/src/nearcache/MetadataFetcher.ts
+++ b/src/nearcache/MetadataFetcher.ts
@@ -96,7 +96,7 @@ export class MetadataFetcher {
 
     private getObjectNames(handlers: Map<string, RepairingHandler>): string[] {
         const names: string[] = [];
-        handlers.forEach((handler: RepairingHandler) => {
+        handlers.forEach((handler) => {
             names.push(handler.getName());
         });
         return names;

--- a/src/nearcache/RepairingTask.ts
+++ b/src/nearcache/RepairingTask.ts
@@ -96,11 +96,15 @@ export class RepairingTask {
                     this.updateLastKnownStaleSequences(handler);
                 }
             });
-            this.metadataFetcher.fetchMetadata(this.handlers);
+            this.metadataFetcher.fetchMetadata(this.handlers)
+                .catch((err) => {
+                    this.logger.debug('RepairingTask', 'Anti entropy task could not fetch metadata. '
+                        + 'Going to retry later.', err);
+                });
         } else {
             this.shutdown();
-            this.logger.debug('RepairingTask', 'Anti entropy task was on although client was not running.' +
-                'Anti entropy task was shutdown forcibly.');
+            this.logger.debug('RepairingTask', 'Anti entropy task was on although client was not running. '
+                + 'Anti entropy task was shutdown forcibly.');
         }
     }
 
@@ -131,9 +135,9 @@ export class RepairingTask {
         if (seconds === 0 || seconds >= this.minAllowedReconciliationSeconds) {
             return seconds * 1000;
         } else {
-            const message = 'Reconciliation interval can be at least ' + this.minAllowedReconciliationSeconds + ' seconds ' +
-                'if not 0. Configured interval is ' + seconds + ' seconds. ' +
-                'Note: configuring a value of 0 seconds disables the reconciliation task.';
+            const message = 'Reconciliation interval can be at least ' + this.minAllowedReconciliationSeconds
+                + ' seconds if not 0. Configured interval is ' + seconds + ' seconds. '
+                + 'Note: configuring a value of 0 seconds disables the reconciliation task.';
             throw new RangeError(message);
         }
     }

--- a/test/config/SchemaValidationTest.js
+++ b/test/config/SchemaValidationTest.js
@@ -40,6 +40,8 @@ describe('SchemaValidationTest', function () {
 
     it('invalid configuration is caught by the validator', function () {
         const invalidJson = fs.readFileSync(path.resolve(__dirname, 'configurations/invalid.json'), 'utf8');
-        expect(validateCandidate(invalidJson).errors[0]).to.exist.with.property('message', 'must have a minimum value of 1000');
+        const result = validateCandidate(invalidJson);
+        expect(result.errors[0]).to.exist.with.property('message');
+        expect(result.errors[0].message).to.have.string('1000');
     });
 });


### PR DESCRIPTION
Closes: #646
Refs: #647

* Fixes `SchemaValidationTest` which started failing because of an error message change in a newer version of `jsonschema` library
* Also fixes unhandled project rejection in `RepairingTask` which led to #647

See http://jenkins.hazelcast.com/job/NodeJS-10-master/322/testReport/(root)/invalid%20configuration%20is%20caught%20by%20the%20validator/SchemaValidationTest_invalid_configuration_is_caught_by_the_validator/ as a failure example