### PR TITLE
Fix null request handling in listener deregistration

### DIFF
--- a/src/listener/ListenerService.ts
+++ b/src/listener/ListenerService.ts
@@ -196,6 +196,10 @@ export class ListenerService {
     private deregisterListenerOnTarget(userKey: string,
                                        eventRegistration: ClientEventRegistration): void {
         const clientMessage = eventRegistration.codec.encodeRemoveRequest(eventRegistration.serverRegistrationId);
+        // null message means no remote registration (e.g. for backup acks)
+        if (clientMessage === null) {
+            return;
+        }
         const invocation = new Invocation(this.client, clientMessage, Number.MAX_SAFE_INTEGER);
         invocation.connection = eventRegistration.subscriber;
         this.client.getInvocationService().invoke(invocation).catch((err) => {


### PR DESCRIPTION
Fixes `null` handling for `invocation.request` in `ListenerService#deregisterListenerOnTarget`. This case was introduced in #573