### PR TITLE
Remove source maps from npm artifact

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
             "es6"
         ],
         "removeComments": false,
-        "sourceMap": true
+        "sourceMap": false
     },
     "include": [
         "src/index.ts"


### PR DESCRIPTION
There is no point in having source maps in the npm artifact. Moreover, we already removed them in 4.0.