### PR TITLE
Reject/retry pending invocations on connection close

### DIFF
--- a/src/ClientMessage.ts
+++ b/src/ClientMessage.ts
@@ -46,7 +46,7 @@ class ClientMessage {
 
     private buffer: Buffer;
     private cursor: number = BitsUtil.HEADER_SIZE;
-    private isRetryable: boolean;
+    private retryable: boolean;
 
     constructor(buffer: Buffer) {
         this.buffer = buffer;
@@ -66,7 +66,7 @@ class ClientMessage {
 
     clone(): ClientMessage {
         const message = new ClientMessage(Buffer.from(this.buffer));
-        message.isRetryable = this.isRetryable;
+        message.retryable = this.retryable;
         return message;
     }
 
@@ -132,7 +132,11 @@ class ClientMessage {
     }
 
     setRetryable(value: boolean): void {
-        this.isRetryable = value;
+        this.retryable = value;
+    }
+
+    isRetryable(): boolean {
+        return this.retryable;
     }
 
     appendByte(value: number): void {

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -397,6 +397,7 @@ export default class HazelcastClient {
         }).then(() => {
             this.proxyManager.init();
             this.listenerService.start();
+            this.invocationService.start();
             this.statistics.start();
             return this;
         }).catch((e) => {

--- a/src/config/ClientNetworkConfig.ts
+++ b/src/config/ClientNetworkConfig.ts
@@ -46,7 +46,7 @@ export class ClientNetworkConfig {
      */
     connectionTimeout: number = 5000;
     /**
-     * true if redo operations are enabled (not implemented yet)
+     * true if redo operations are enabled.
      */
     redoOperation: boolean = false;
     /**

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -44,6 +44,7 @@ export class ClientConfig {
         'hazelcast.client.heartbeat.timeout': 60000,
         'hazelcast.client.invocation.retry.pause.millis': 1000,
         'hazelcast.client.invocation.timeout.millis': 120000,
+        'hazelcast.client.internal.clean.resources.millis': 100,
         'hazelcast.client.cloud.url': 'https://coordinator.hazelcast.cloud',
         'hazelcast.client.statistics.enabled': false,
         'hazelcast.client.statistics.period.seconds': Statistics.PERIOD_SECONDS_DEFAULT_VALUE,

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -269,8 +269,9 @@ export class InvocationService {
 
         if (clientMessage.hasFlags(BitsUtil.LISTENER_FLAG)) {
             setImmediate(() => {
-                if (this.eventHandlers.has(correlationId)) {
-                    this.eventHandlers.get(correlationId).handler(clientMessage);
+                const invocation = this.eventHandlers.get(correlationId);
+                if (invocation !== undefined) {
+                    invocation.handler(clientMessage);
                 }
             });
             return;

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -277,6 +277,13 @@ export class InvocationService {
         }
 
         const pendingInvocation = this.pending.get(correlationId);
+        if (pendingInvocation === undefined) {
+            if (!this.isShutdown) {
+                this.logger.warn('InvocationService',
+                    'Found no registration for invocation id ' + correlationId);
+            }
+            return;
+        }
         const deferred = pendingInvocation.deferred;
         if (messageType === EXCEPTION_MESSAGE_TYPE) {
             const remoteError = this.client.getErrorFactory().createErrorFromClientMessage(clientMessage);

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -19,11 +19,10 @@ var HazelcastClient = require('../../').Client;
 var expect = require('chai').expect;
 var Config = require('../../').Config;
 var fs = require('fs');
-var Long = require('long');
 var Util = require('../Util');
 var DeferredPromise = require('../../lib/Util').DeferredPromise;
 
-describe('LostInvalidation', function () {
+describe('LostInvalidationsTest', function () {
     this.timeout(30000);
 
     var cluster;
@@ -157,10 +156,10 @@ describe('LostInvalidation', function () {
         var listenerId = nearCachedMap.invalidationListenerId;
         var clientRegistrationKey = client.getListenerService().activeRegistrations.get(listenerId).get(client.clusterService.getOwnerConnection());
         var correlationId = clientRegistrationKey.correlationId;
-        var handler = client.getInvocationService().eventHandlers[correlationId].handler;
+        var handler = client.getInvocationService().eventHandlers.get(correlationId).handler;
         var numberOfBlockedInvalidations = 0;
         var deferred = DeferredPromise();
-        client.getInvocationService().eventHandlers[correlationId].handler = function () {
+        client.getInvocationService().eventHandlers.get(correlationId).handler = function () {
             numberOfBlockedInvalidations++;
             if (notifyAfterNumberOfEvents !== undefined && notifyAfterNumberOfEvents === numberOfBlockedInvalidations) {
                 deferred.resolve();
@@ -170,6 +169,6 @@ describe('LostInvalidation', function () {
     }
 
     function unblockInvalidationEvents(client, metadata) {
-        client.getInvocationService().eventHandlers[metadata.correlationId].handler = metadata.handler;
+        client.getInvocationService().eventHandlers.get(metadata.correlationId).handler = metadata.handler;
     }
 });


### PR DESCRIPTION
Closes #663
Refs: #562

* Adds clean task for invocations with closed connections
* Adds support for `redoOperation` option
* Also fixes `generateKeyOwnedBy` function in `LockProxyTest` to deal with string keys. Previously it was generating number keys which was wrong as they were later converted to strings