### PR TITLE
Fix test flakiness on Windows

### DIFF
--- a/src/PartitionService.ts
+++ b/src/PartitionService.ts
@@ -71,7 +71,7 @@ export class PartitionService {
                 this.partitionCount = Object.keys(this.partitionMap).length;
             }).catch((e) => {
                 if (this.client.getLifecycleService().isRunning()) {
-                    this.logger.warn('PartitionService', 'Error while fetching cluster partition table from'
+                    this.logger.warn('PartitionService', 'Error while fetching cluster partition table from '
                         + this.client.getClusterService().ownerUuid, e);
                 }
             });

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -300,7 +300,7 @@ export class ClusterService {
         const events: MembershipEvent[] = [];
         const eventMembers = Array.from(this.members);
         const addedMembers: Member[] = [];
-        let deletedMembers = Array.from(prevMembers);
+        const deletedMembers = Array.from(prevMembers);
 
         for (const member of this.members) {
             const idx = deletedMembers.findIndex(member.equals, member);

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -307,7 +307,7 @@ export class ClusterService {
             if (idx === -1) {
                 addedMembers.push(member);
             } else {
-                deletedMembers = deletedMembers.splice(idx, 1);
+                deletedMembers.splice(idx, 1);
             }
         }
 

--- a/test/ClientClusterRestartEventTest.js
+++ b/test/ClientClusterRestartEventTest.js
@@ -89,16 +89,14 @@ describe('ClientClusterRestartEventTest', function () {
 
         const membershipListener = {
             memberAdded: function (membershipEvent) {
-                addedCount++;
                 added.push(membershipEvent.member);
-                if (addedCount === 2) {
+                if (++addedCount === 2) {
                     addedPromise.resolve();
                 }
             },
             memberRemoved: function (membershipEvent) {
                 removed.push(membershipEvent.member);
-                removedCount++;
-                if (removedCount === 2) {
+                if (++removedCount === 2) {
                     removedPromise.resolve();
                 }
             }

--- a/test/ClientClusterRestartEventTest.js
+++ b/test/ClientClusterRestartEventTest.js
@@ -73,8 +73,8 @@ describe('ClientClusterRestartEventTest', function () {
                 const members = Array.from(client.clusterService.getMembers()).map(function (m) {
                     return m.uuid;
                 });
-                expect(members).to.includes(newMember.uuid);
-                expect(members.length).to.equal(1);
+                expect(members).to.have.lengthOf(1);
+                expect(members).to.include(newMember.uuid);
             });
     });
 
@@ -122,19 +122,28 @@ describe('ClientClusterRestartEventTest', function () {
             newMember2 = m;
             return removedPromise.promise;
         }).then(function () {
-            expect(removed[0].uuid).to.equal(member.uuid);
-            expect(removed[1].uuid).to.equal(member2.uuid);
+            const removedUuids = removed.map(function (m) {
+                return m.uuid;
+            });
+            expect(removedUuids).to.have.lengthOf(2);
+            expect(removedUuids).to.include(member.uuid);
+            expect(removedUuids).to.include(member2.uuid);
         }).then(function () {
             return addedPromise.promise;
         }).then(function () {
-            expect(added[0].uuid).to.equal(newMember1.uuid);
-            expect(added[1].uuid).to.equal(newMember2.uuid);
-            const members = Array.from(client.clusterService.getMembers()).map(function (m) {
+            const addedUuids = added.map(function (m) {
                 return m.uuid;
             });
-            expect(members).to.includes(newMember1.uuid);
-            expect(members).to.includes(newMember2.uuid);
-            expect(members.length).to.equal(2);
+            expect(addedUuids).to.have.lengthOf(2);
+            expect(addedUuids).to.include(newMember1.uuid);
+            expect(addedUuids).to.include(newMember2.uuid);
+
+            const localMemberUuids = Array.from(client.clusterService.getMembers()).map(function (m) {
+                return m.uuid;
+            });
+            expect(localMemberUuids).to.have.lengthOf(2);
+            expect(localMemberUuids).to.include(newMember1.uuid);
+            expect(localMemberUuids).to.include(newMember2.uuid);
         });
     });
 });

--- a/test/ClientClusterRestartEventTest.js
+++ b/test/ClientClusterRestartEventTest.js
@@ -23,7 +23,7 @@ const MemberEvent = require('../lib/invocation/ClusterService').MemberEvent;
 
 describe('ClientClusterRestartEventTest', function () {
 
-    this.timeout(20000);
+    this.timeout(40000);
 
     let cluster;
     let client;

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -18,11 +18,9 @@ var Controller = require('./RC');
 var expect = require('chai').expect;
 var HazelcastClient = require('../.').Client;
 var Config = require('../.').Config;
-var Address = require('../.').Address;
 var Promise = require('bluebird');
-var Address = require('../.').Address;
 
-describe('ClusterService', function () {
+describe('ClusterServiceTest', function () {
     this.timeout(25000);
     var cluster;
     var ownerMember;
@@ -89,7 +87,7 @@ describe('ClusterService', function () {
     });
 
     it('getMembers returns correct list after a member is removed', function (done) {
-        this.timeout(20000);
+        this.timeout(40000);
         var member2;
         var member3;
 

--- a/test/heartbeat/HeartbeatFromClientTest.js
+++ b/test/heartbeat/HeartbeatFromClientTest.js
@@ -21,7 +21,7 @@ var Config = require('../../').Config;
 var Util = require('../Util');
 var fs = require('fs');
 
-describe('Heartbeat', function () {
+describe('HeartbeatFromClientTest', function () {
     this.timeout(30000);
 
     var cluster;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---timeout 8000
+--timeout 15000

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---timeout 15000
+--timeout 10000

--- a/test/nearcache/NearCacheSimpleInvalidationTest.js
+++ b/test/nearcache/NearCacheSimpleInvalidationTest.js
@@ -23,7 +23,7 @@ var Config = require('../../.').Config;
 var Controller = require('../RC');
 var HazelcastClient = require('../../.').Client;
 
-describe('NearCacheSimpleInvalidation', function () {
+describe('NearCacheSimpleInvalidationTest', function () {
     var cluster;
     var client;
     var updaterClient;
@@ -65,7 +65,7 @@ describe('NearCacheSimpleInvalidation', function () {
             });
 
             it('client observes outside invalidations', function () {
-                this.timeout(4000);
+                this.timeout(10000);
                 var entryCount = 1000;
                 var map;
                 return client.getMap(mapName).then(function (mp) {


### PR DESCRIPTION
* Fixes deleted members detection in `ClusterService` (return of `Array.splice` was mistakenly used instead of the array itself)
* Fixes heartbeat lost simulation in `HeartbeatFromServerTest`
* Increases default timeout for mocha tests to 10s (was 8s)
* Increases timeouts for `ClientClusterRestartEventTest`, `ClusterServiceTest`, and `NearCacheSimpleInvalidationTest`

Examples of failures:
* http://jenkins.hazelcast.com/job/NodeJS-4-3.12.x-windows/190/testReport/(root)/should%20receive%20membership%20events%20when%20multiple%20member%20restarted/ClientClusterRestartEventTest_should_receive_membership_events_when_multiple_member_restarted/
* http://jenkins.hazelcast.com/job/NodeJS-4-3.12.x-windows/191/testReport/junit/(root)/getMembers%20returns%20correct%20list%20after%20a%20member%20is%20removed/ClusterService_getMembers_returns_correct_list_after_a_member_is_removed/
* http://jenkins.hazelcast.com/job/NodeJS-3.12.x-pr-builder/42/testReport/junit/(root)/client%20observes%20outside%20invalidations/NearCacheSimpleInvalidation_batch_invalidations_enabled_false_client_observes_outside_invalidations/