### PR TITLE
Fix incorrect splice usage in NearCachedMapProxy#getAllInternal

### DIFF
--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -278,7 +278,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
         assertNotNull(keys);
         assertArray(keys);
         const partitionService = this.client.getPartitionService();
-        const partitionsToKeys: { [id: string]: any } = {};
+        const partitionsToKeys: { [id: string]: any[] } = {};
         let key: K;
         for (const i in keys) {
             key = keys[i];
@@ -291,7 +291,6 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
         }
         const result: Array<[any, any]> = [];
         return this.getAllInternal(partitionsToKeys, result).then(function (): Array<[any, any]> {
-
             return result;
         });
     }
@@ -493,7 +492,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
         }
     }
 
-    protected getAllInternal(partitionsToKeys: { [id: string]: any }, result: any[] = []): Promise<Array<[Data, Data]>> {
+    protected getAllInternal(partitionsToKeys: { [id: string]: Data[] }, result: any[] = []): Promise<Array<[Data, Data]>> {
         const partitionPromises: Array<Promise<Array<[Data, Data]>>> = [];
         for (const partition in partitionsToKeys) {
             partitionPromises.push(this.encodeInvokeOnPartition<Array<[Data, Data]>>(

--- a/src/proxy/NearCachedMapProxy.ts
+++ b/src/proxy/NearCachedMapProxy.ts
@@ -136,17 +136,17 @@ export class NearCachedMapProxy<K, V> extends MapProxy<K, V> {
         return super.removeInternal(keyData, value).then<V>(this.invalidateCacheEntryAndReturn.bind(this, keyData));
     }
 
-    protected getAllInternal(partitionsToKeys: { [id: string]: any }, result: any[] = []): Promise<any[]> {
+    protected getAllInternal(partitionsToKeys: { [id: string]: Data[] }, result: any[] = []): Promise<any[]> {
         const promises = [];
         try {
             for (const partition in partitionsToKeys) {
-                let partitionArray = partitionsToKeys[partition];
+                const partitionArray = partitionsToKeys[partition];
                 for (let i = partitionArray.length - 1; i >= 0; i--) {
                     const key = partitionArray[i];
                     promises.push(this.nearCache.get(key).then((cachedResult) => {
                         if (cachedResult !== undefined) {
                             result.push([this.toObject(partitionArray[i]), cachedResult]);
-                            partitionArray = partitionArray.splice(i, 1);
+                            partitionArray.splice(i, 1);
                         }
                     }));
                 }

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -23,7 +23,8 @@ var fs = require('fs');
 var _fillMap = require('../Util').fillMap;
 
 
-describe("NearCachedMap", function () {
+describe('NearCachedMapTest', function () {
+
     [true, false].forEach(function (invalidateOnChange) {
         describe('invalidate on change=' + invalidateOnChange, function () {
             var cluster;


### PR DESCRIPTION
Closes #671

`Array.splice` return was used instead of plain `.splice` invocation. As the result near cache warm-up logic in `NearCachedMapProxy.getAll` had a flaw.