### PR TITLE
Fix backup acks listener registration on client start

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -436,13 +436,14 @@ export class HazelcastClient {
 
     /** @internal */
     private init(): Promise<HazelcastClient> {
+        const logger = this.loggingService.getLogger();
         try {
             this.lifecycleService.start();
             const configuredMembershipListeners = this.config.membershipListeners;
             this.clusterService.start(configuredMembershipListeners);
             this.clusterViewListenerService.start();
         } catch (e) {
-            this.loggingService.getLogger().error('HazelcastClient', 'Client failed to start', e);
+            logger.error('HazelcastClient', 'Client failed to start', e);
             throw e;
         }
 
@@ -451,13 +452,18 @@ export class HazelcastClient {
                 const connectionStrategyConfig = this.config.connectionStrategy;
                 if (!connectionStrategyConfig.asyncStart) {
                     return this.clusterService.waitInitialMemberListFetched()
-                        .then(() => this.connectionManager.connectToAllClusterMembers());
+                        .then(() => this.connectionManager.connectToAllClusterMembers())
+                        .then(() => this.invocationService.start());
+                } else {
+                    this.invocationService.start()
+                        .catch((e) => {
+                            logger.warn('HazelcastClient', 'InvocationService failed to start', e);
+                        });
                 }
             })
             .then(() => {
                 this.listenerService.start();
                 this.proxyManager.init();
-                this.invocationService.start();
                 this.loadBalancer.initLoadBalancer(this.clusterService, this.config);
                 this.statistics.start();
                 return this.sendStateToCluster();
@@ -466,7 +472,7 @@ export class HazelcastClient {
                 return this;
             })
             .catch((e) => {
-                this.loggingService.getLogger().error('HazelcastClient', 'Client failed to start', e);
+                logger.error('HazelcastClient', 'Client failed to start', e);
                 throw e;
             });
     }

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -452,13 +452,7 @@ export class HazelcastClient {
                 const connectionStrategyConfig = this.config.connectionStrategy;
                 if (!connectionStrategyConfig.asyncStart) {
                     return this.clusterService.waitInitialMemberListFetched()
-                        .then(() => this.connectionManager.connectToAllClusterMembers())
-                        .then(() => this.invocationService.start());
-                } else {
-                    this.invocationService.start()
-                        .catch((e) => {
-                            logger.warn('HazelcastClient', 'InvocationService failed to start', e);
-                        });
+                        .then(() => this.connectionManager.connectToAllClusterMembers());
                 }
             })
             .then(() => {
@@ -466,6 +460,9 @@ export class HazelcastClient {
                 this.proxyManager.init();
                 this.loadBalancer.initLoadBalancer(this.clusterService, this.config);
                 this.statistics.start();
+                return this.invocationService.start();
+            })
+            .then(() => {
                 return this.sendStateToCluster();
             })
             .then(() => {

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -407,8 +407,8 @@ export class InvocationService {
         ClientLocalBackupListenerCodec.handle(clientMessage, (correlationId: Long) => {
             const invocation = this.pending.get(correlationId.toNumber());
             if (invocation === undefined) {
-                this.logger.trace('InvocationService', 'Invocation not found for backup event, '
-                    + 'invocation id ' + correlationId);
+                this.logger.trace('InvocationService', 'Invocation not found for backup event, invocation id '
+                    + correlationId);
                 return;
             }
             invocation.notifyBackupComplete();

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -289,12 +289,16 @@ export class InvocationService {
         this.isShutdown = false;
     }
 
-    start(): void {
+    start(): Promise<void> {
+        this.cleanResourcesTask = this.scheduleCleanResourcesTask(this.cleanResourcesMillis);
         if (this.backupAckToClientEnabled) {
             const listenerService = this.client.getListenerService();
-            listenerService.registerListener(backupListenerCodec, this.backupEventHandler.bind(this));
+            return listenerService.registerListener(
+                    backupListenerCodec,
+                    this.backupEventHandler.bind(this)
+                ).then(() => {});
         }
-        this.cleanResourcesTask = this.scheduleCleanResourcesTask(this.cleanResourcesMillis);
+        return Promise.resolve();
     }
 
     private scheduleCleanResourcesTask(periodMillis: number): Task {

--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -54,13 +54,11 @@ describe('ClientBackupAcksTest', function () {
     });
 
     it('should receive backup acks in smart mode', async function () {
-        this.timeout(15000);
-
         client = await Client.newHazelcastClient({
             clusterName: cluster.id,
             properties: {
                 'hazelcast.client.operation.fail.on.indeterminate.state': true,
-                'hazelcast.client.operation.backup.timeout.millis': 10000
+                'hazelcast.client.operation.backup.timeout.millis': 7000
             }
         });
         const map = await client.getMap('test-map');

--- a/test/invocation/InvocationServiceTest.js
+++ b/test/invocation/InvocationServiceTest.js
@@ -44,6 +44,7 @@ describe('InvocationServiceTest', function () {
         const clientStub = sandbox.stub(Client.prototype);
         clientStub.getConfig.returns(config);
         const listenerServiceStub = sandbox.stub(ListenerService.prototype);
+        listenerServiceStub.registerListener.returns(Promise.resolve('mock-uuid'));
         clientStub.getListenerService.returns(listenerServiceStub);
         const partitionServiceStub = sandbox.stub(PartitionServiceImpl.prototype);
         clientStub.getPartitionService.returns(partitionServiceStub);
@@ -55,12 +56,12 @@ describe('InvocationServiceTest', function () {
         return clientStub;
     }
 
-    function preparePendingInvocationWithClosedConn() {
+    async function preparePendingInvocationWithClosedConn() {
         const config = new ClientConfigImpl();
         const clientStub = mockClient(config);
         service = new InvocationService(clientStub);
         clientStub.getInvocationService.returns(service);
-        service.start();
+        await service.start();
 
         const messageStub = sandbox.stub(ClientMessage.prototype);
         messageStub.getCorrelationId.returns(0);
@@ -81,43 +82,43 @@ describe('InvocationServiceTest', function () {
         }
     });
 
-    it('should start clean resource task and register listener when client is smart and acks are enabled', function () {
+    it('should start clean resource task and register listener for smart client and enabled acks', async function () {
         const config = new ClientConfigImpl();
         const client = mockClient(config);
 
         service = new InvocationService(client);
-        service.start();
+        await service.start();
 
         expect(service.cleanResourcesTask).to.be.not.undefined;
         expect(client.getListenerService().registerListener.calledOnce).to.be.true;
     });
 
-    it('should start clean resource task without listener registration when client is unisocket', function () {
+    it('should start clean resource task without listener registration for unisocket client', async function () {
         const config = new ClientConfigImpl();
         config.network.smartRouting = false;
         const client = mockClient(config);
 
         service = new InvocationService(client);
-        service.start();
+        await service.start();
 
         expect(service.cleanResourcesTask).to.be.not.undefined;
         expect(client.getListenerService().registerListener.notCalled).to.be.true;
     });
 
-    it('should start clean resource task without listener registration when acks are disabled', function () {
+    it('should start clean resource task without listener registration for disabled acks', async function () {
         const config = new ClientConfigImpl();
         config.backupAckToClientEnabled = false;
         const client = mockClient(config);
 
         service = new InvocationService(client);
-        service.start();
+        await service.start();
 
         expect(service.cleanResourcesTask).to.be.not.undefined;
         expect(client.getListenerService().registerListener.notCalled).to.be.true;
     });
 
     it('should reject pending invocations on shut down', async function () {
-        const invocation = preparePendingInvocationWithClosedConn();
+        const invocation = await preparePendingInvocationWithClosedConn();
 
         invocation.invocationService.shutdown();
 
@@ -125,7 +126,7 @@ describe('InvocationServiceTest', function () {
     });
 
     it('should reject pending invocations with closed connections when clean resource task runs', async function () {
-        const invocation = preparePendingInvocationWithClosedConn();
+        const invocation = await preparePendingInvocationWithClosedConn();
 
         await expect(invocation.deferred.promise).to.be.rejectedWith(TargetDisconnectedError);
     });

--- a/test/invocation/InvocationServiceTest.js
+++ b/test/invocation/InvocationServiceTest.js
@@ -34,6 +34,7 @@ const { LifecycleServiceImpl } = require('../../lib/LifecycleService');
 const { LoggingService } = require('../../lib/logging/LoggingService');
 const { ClientMessage } = require('../../lib/protocol/ClientMessage');
 const { ClientConnection } = require('../../lib/network/ClientConnection');
+const { ClientConnectionManager } = require('../../lib/network/ClientConnectionManager');
 const { deferredPromise } = require('../../lib/util/Util');
 
 describe('InvocationServiceTest', function () {
@@ -43,6 +44,8 @@ describe('InvocationServiceTest', function () {
     function mockClient(config) {
         const clientStub = sandbox.stub(Client.prototype);
         clientStub.getConfig.returns(config);
+        const connectionManagerStub = sandbox.stub(ClientConnectionManager.prototype);
+        clientStub.getConnectionManager.returns(connectionManagerStub);
         const listenerServiceStub = sandbox.stub(ListenerService.prototype);
         listenerServiceStub.registerListener.returns(Promise.resolve('mock-uuid'));
         clientStub.getListenerService.returns(listenerServiceStub);


### PR DESCRIPTION
Closes #680
Closes #681
Refs: #616 (potentially closes, but that needs to be verified)

Fixes the following:
* Fixes backup acks listener registration on client start
  - Client did not wait for backup acks registration on start. This could lead to missed acks in scenarios when client starts and immediately executes operations.
* Fixes listener registration to wait for all connections
  - Listener registration did not wait for individual connections, but rather for the first one.