### PR TITLE
Fix client resource leak on failed start

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -424,7 +424,7 @@ export class HazelcastClient {
     /** @internal */
     onClusterRestart(): void {
         this.getLoggingService().getLogger()
-            .info('HazelcastClient', 'Clearing local state of the client, because of a cluster restart');
+            .info('HazelcastClient', 'Clearing local state of the client, because of a cluster restart.');
         this.nearCacheManager.clearAllNearCaches();
         this.clusterService.clearMemberListVersion();
     }
@@ -443,7 +443,7 @@ export class HazelcastClient {
             this.clusterService.start(configuredMembershipListeners);
             this.clusterViewListenerService.start();
         } catch (e) {
-            logger.error('HazelcastClient', 'Client failed to start', e);
+            logger.error('HazelcastClient', 'Client failed to start.', e);
             throw e;
         }
 
@@ -469,7 +469,11 @@ export class HazelcastClient {
                 return this;
             })
             .catch((e) => {
-                logger.error('HazelcastClient', 'Client failed to start', e);
+                this.shutdown()
+                    .catch((e) => {
+                        logger.debug('HazelcastClient', 'Could not shut down after start failure.', e);
+                    });
+                logger.error('HazelcastClient', 'Client failed to start.', e);
                 throw e;
             });
     }
@@ -499,7 +503,7 @@ export class HazelcastClient {
         if (addressListProvided && hazelcastCloudToken != null) {
             throw new IllegalStateError('Only one discovery method can be enabled at a time. '
                 + 'Cluster members given explicitly: ' + addressListProvided
-                + ', hazelcastCloud enabled');
+                + ', hazelcastCloud enabled.');
         }
 
         const cloudAddressProvider = this.initCloudAddressProvider();

--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -471,7 +471,7 @@ export class HazelcastClient {
             .catch((e) => {
                 this.shutdown()
                     .catch((e) => {
-                        logger.debug('HazelcastClient', 'Could not shut down after start failure.', e);
+                        logger.warn('HazelcastClient', 'Could not shut down after start failure.', e);
                     });
                 logger.error('HazelcastClient', 'Client failed to start.', e);
                 throw e;

--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -175,7 +175,7 @@ export class ClientConnectionManager extends EventEmitter {
         }
 
         this.alive = false;
-        if (this.isSmartRoutingEnabled) {
+        if (this.reconnectToMembersTask !== undefined) {
             cancelRepetitionTask(this.reconnectToMembersTask);
         }
         this.pendingConnections.forEach((pending) => {

--- a/src/proxy/cpsubsystem/CPSessionManager.ts
+++ b/src/proxy/cpsubsystem/CPSessionManager.ts
@@ -128,7 +128,7 @@ export class CPSessionManager {
 
     shutdown(): Promise<void> {
         if (this.isShutdown) {
-            return;
+            return Promise.resolve();
         }
         this.isShutdown = true;
         this.cancelHeartbeatTask();

--- a/src/proxy/cpsubsystem/CPSessionManager.ts
+++ b/src/proxy/cpsubsystem/CPSessionManager.ts
@@ -30,6 +30,7 @@ import {
 import {CPSessionCloseSessionCodec} from '../../codec/CPSessionCloseSessionCodec';
 import {CPSessionHeartbeatSessionCodec} from '../../codec/CPSessionHeartbeatSessionCodec';
 import {CPSessionGenerateThreadIdCodec} from '../../codec/CPSessionGenerateThreadIdCodec';
+import {ILogger} from '../../logging/ILogger';
 import {
     scheduleWithRepetition,
     cancelRepetitionTask,
@@ -85,6 +86,7 @@ export const NO_SESSION_ID = Long.fromNumber(-1);
 export class CPSessionManager {
 
     private readonly client: HazelcastClient;
+    private readonly logger: ILogger;
     // <group_id, session_state> map
     private readonly sessions: Map<string, SessionState> = new Map();
     private heartbeatTask: Task;
@@ -92,6 +94,7 @@ export class CPSessionManager {
 
     constructor(client: HazelcastClient) {
         this.client = client;
+        this.logger = this.client.getLoggingService().getLogger();
     }
 
     getSessionId(groupId: RaftGroupId): Long {
@@ -137,8 +140,8 @@ export class CPSessionManager {
             closePromises.push(this.requestCloseSession(session.groupId, session.id));
         }
         return Promise.all(closePromises)
-            .catch(() => {
-                // no-op
+            .catch((e) => {
+                this.logger.debug('CPSessionManager', 'Could not close CP sessions.', e);
             })
             .then(() => this.sessions.clear());
     }

--- a/test/ClientProxyTest.js
+++ b/test/ClientProxyTest.js
@@ -42,7 +42,7 @@ describe('ClientProxyTest', function () {
         }
     });
 
-    it('Client without active connection should return unknown version', function () {
+    it('client without active connection should return unknown version', function () {
         const connectionManagerStub = sandbox.stub(ClientConnectionManager.prototype);
         connectionManagerStub.getActiveConnections.returns({});
         const clientStub = sandbox.stub(Client.prototype);
@@ -52,9 +52,9 @@ describe('ClientProxyTest', function () {
         assert.equal(mapProxy.getConnectedServerVersion(), -1);
     });
 
-    it('Client with a 3.7 server connection should return the version', function () {
+    it('client with a 4.1 server connection should return the version', function () {
         const connectionStub = sandbox.stub(ClientConnection.prototype);
-        connectionStub.getConnectedServerVersion.returns('30700');
+        connectionStub.getConnectedServerVersion.returns('40100');
         const connectionManagerStub = sandbox.stub(ClientConnectionManager.prototype);
         connectionManagerStub.getActiveConnections.returns({
             'localhost': connectionStub
@@ -63,10 +63,10 @@ describe('ClientProxyTest', function () {
         clientStub.getConnectionManager.returns(connectionManagerStub);
 
         const mapProxy = new MapProxy(clientStub, 'mockMapService', 'mockMap');
-        assert.equal(mapProxy.getConnectedServerVersion(), 30700);
+        assert.equal(mapProxy.getConnectedServerVersion(), 40100);
     });
 
-    it('Proxies with the same name should be different for different services', async function () {
+    it('proxies with the same name should be different for different services', async function () {
         cluster = await RC.createCluster();
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({ clusterName: cluster.id });

--- a/test/ClientShutdownTest.js
+++ b/test/ClientShutdownTest.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const { expect } = require('chai');
+const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
+
+const RC = require('./RC');
+const { Client } = require('../.');
+const { LifecycleServiceImpl } = require('../lib/LifecycleService');
+const { RepairingTask } = require('../lib/nearcache/RepairingTask');
+const { NearCacheManager } = require('../lib/nearcache/NearCacheManager');
+const { ProxyManager } = require('../lib/proxy/ProxyManager');
+const { Statistics } = require('../lib/statistics/Statistics');
+const { CPSubsystemImpl } = require('../lib/CPSubsystem');
+const { ClientConnectionManager } = require('../lib/network/ClientConnectionManager');
+const { InvocationService } = require('../lib/invocation/InvocationService');
+
+describe('ClientShutdownTest', function () {
+
+    let cluster;
+
+    afterEach(async function () {
+        sandbox.restore();
+        if (cluster != null) {
+            await RC.terminateCluster(cluster.id);
+            cluster = null;
+        }
+    });
+
+    it('client should call shutdown on failed start', async function () {
+        sandbox.spy(Client.prototype, 'shutdown');
+
+        await expect(Client.newHazelcastClient({
+            connectionStrategy: {
+                connectionRetry: {
+                    clusterConnectTimeoutMillis: 100,
+                    initialBackoffMillis: 100
+                }
+            }
+        })).to.be.rejected;
+
+        expect(Client.prototype.shutdown.calledOnce).to.be.true;
+    });
+
+    it('client should stop services and release resources on shutdown', async function () {
+        sandbox.spy(LifecycleServiceImpl.prototype, 'shutdown');
+        sandbox.spy(RepairingTask.prototype, 'shutdown');
+        sandbox.spy(NearCacheManager.prototype, 'destroyAllNearCaches');
+        sandbox.spy(ProxyManager.prototype, 'destroy');
+        sandbox.spy(Statistics.prototype, 'stop');
+        sandbox.spy(CPSubsystemImpl.prototype, 'shutdown');
+        sandbox.spy(ClientConnectionManager.prototype, 'shutdown');
+        sandbox.spy(InvocationService.prototype, 'shutdown');
+
+        cluster = await RC.createCluster(null, null);
+        await RC.startMember(cluster.id);
+
+        const client = await Client.newHazelcastClient({ clusterName: cluster.id });
+        // force ReparingTask initialization
+        client.getRepairingTask();
+        await client.shutdown();
+
+        expect(LifecycleServiceImpl.prototype.shutdown.calledOnce).to.be.true;
+        expect(RepairingTask.prototype.shutdown.calledOnce).to.be.true;
+        expect(NearCacheManager.prototype.destroyAllNearCaches.calledOnce).to.be.true;
+        expect(ProxyManager.prototype.destroy.calledOnce).to.be.true;
+        expect(Statistics.prototype.stop.calledOnce).to.be.true;
+        expect(CPSubsystemImpl.prototype.shutdown.calledOnce).to.be.true;
+        expect(ClientConnectionManager.prototype.shutdown.calledOnce).to.be.true;
+        expect(InvocationService.prototype.shutdown.calledOnce).to.be.true;
+    });
+});

--- a/test/unit/proxy/cpsubsystem/CPSessionManagerTest.js
+++ b/test/unit/proxy/cpsubsystem/CPSessionManagerTest.js
@@ -31,6 +31,7 @@ const {
     SessionState,
     CPSessionManager
 } = require('../../../../lib/proxy/cpsubsystem/CPSessionManager');
+const { DefaultLogger } = require('../../../../lib/logging/DefaultLogger');
 const { RaftGroupId } = require('../../../../lib/proxy/cpsubsystem/RaftGroupId');
 
 describe('CPSessionManagerTest', function () {
@@ -144,6 +145,8 @@ describe('CPSessionManagerTest', function () {
 
         beforeEach(function () {
             clientStub = sandbox.stub(Client.prototype);
+            const loggerStub = sandbox.stub(DefaultLogger.prototype);
+            clientStub.getLoggingService.returns({ getLogger: () => loggerStub });
             sessionManager = new CPSessionManager(clientStub);
         });
 


### PR DESCRIPTION
Closes #687

Client was not stopping internal periodical tasks on failed start. As a result, those tasks kept working and the whole client instance was leaking. At least three client instances were leaking in our test suite.