### PR TITLE
Workaround ClientBackupAcksTest flakiness

### DIFF
--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -63,6 +63,10 @@ describe('ClientBackupAcksTest', function () {
         });
         const map = await client.getMap('test-map');
 
+        // TODO(puzpuzpuz): remove the next line once
+        // https://github.com/hazelcast/hazelcast/issues/9398 is fixed
+        await map.get('foo');
+
         // it's enough for this operation to succeed
         await map.set('foo', 'bar');
     });


### PR DESCRIPTION
Closes #616

Adds a `map.get()` operation to help with avoiding race in partition table initialization on cluster side. See: https://github.com/hazelcast/hazelcast/issues/9398