### PR TITLE
[BACKPORT] Fix wrong reconnectToMembersTask initialization

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -451,7 +451,7 @@ export class HazelcastClient {
             .then(() => {
                 const connectionStrategyConfig = this.config.connectionStrategy;
                 if (!connectionStrategyConfig.asyncStart) {
-                    return this.clusterService.waitInitialMemberListFetched()
+                    return this.clusterService.waitForInitialMemberList()
                         .then(() => this.connectionManager.connectToAllClusterMembers());
                 }
             })

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -156,7 +156,7 @@ export class ClusterService implements Cluster {
         }
     }
 
-    waitInitialMemberListFetched(): Promise<void> {
+    waitForInitialMemberList(): Promise<void> {
         return timedPromise(this.initialListFetched.promise, INITIAL_MEMBERS_TIMEOUT_IN_MILLIS)
             .catch((error) => {
                 return Promise.reject(new IllegalStateError('Could not get initial member list from the cluster!', error));

--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -152,12 +152,7 @@ export class ClientConnectionManager extends EventEmitter {
         this.alive = true;
 
         this.heartbeatManager.start();
-        return this.connectToCluster()
-            .then(() => {
-                if (this.isSmartRoutingEnabled) {
-                    this.reconnectToMembersTask = scheduleWithRepetition(this.reconnectToMembers.bind(this), 1000, 1000);
-                }
-            });
+        return this.connectToCluster();
     }
 
     connectToAllClusterMembers(): Promise<void> {
@@ -166,7 +161,10 @@ export class ClientConnectionManager extends EventEmitter {
         }
 
         const members = this.client.getClusterService().getMembers();
-        return this.tryConnectToAllClusterMembers(members);
+        return this.tryConnectToAllClusterMembers(members)
+            .then(() => {
+                this.reconnectToMembersTask = scheduleWithRepetition(this.reconnectToMembers.bind(this), 1000, 1000);
+            });
     }
 
     shutdown(): void {


### PR DESCRIPTION
Partial backport of #703

* Fixes wrong reconnectToMembersTask initialization

`ClientConnectionManager` was initializing `reconnectToMembersTask` on initial member connection instead of when it connects to all members. As a result, the task could run before the initial member list was applied.