### PR TITLE
Remove ad-hoc timeouts in tests

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
-    "timeout": 8000,
+    "timeout": 120000,
     "exit": true,
     "exclude": [
         "test/soak_test/**",

--- a/test/AutoPipeliningDisabledTest.js
+++ b/test/AutoPipeliningDisabledTest.js
@@ -26,7 +26,6 @@ describe('AutoPipeliningDisabledTest', function () {
     let map;
 
     before(async function () {
-        this.timeout(32000);
         cluster = await RC.createCluster(null, null);
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({

--- a/test/ClientHotRestartEventTest.js
+++ b/test/ClientHotRestartEventTest.js
@@ -31,7 +31,6 @@ const {
  */
 describe('ClientHotRestartEventTest', function () {
 
-    this.timeout(60000);
     let client;
     let cluster;
 

--- a/test/ClientReconnectTest.js
+++ b/test/ClientReconnectTest.js
@@ -21,8 +21,6 @@ const { Client } = require('../.');
 
 describe('ClientReconnectTest', function () {
 
-    this.timeout(10000);
-
     let cluster;
     let client;
 

--- a/test/ClientRedoEnabledTest.js
+++ b/test/ClientRedoEnabledTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('ClientRedoEnabledTest', function () {
 
-    this.timeout(10000);
-
     let cluster;
     let client;
 

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -25,8 +25,6 @@ const { Client } = require('../.');
 
 describe('ClusterServiceTest', function () {
 
-    this.timeout(25000);
-
     let cluster;
     let member1;
     let client;

--- a/test/ConnectionManagerTest.js
+++ b/test/ConnectionManagerTest.js
@@ -87,8 +87,6 @@ describe('ConnectionManagerTest', function () {
     });
 
     it('should not give up when timeout set to 0', function (done) {
-        this.timeout(8000);
-
         const timeoutTime = 0;
         let scheduled;
 

--- a/test/ListenerServiceTest.js
+++ b/test/ListenerServiceTest.js
@@ -98,8 +98,6 @@ const Util = require('./Util');
         });
 
         it('listener is not invoked when it is removed[smart=' + isSmartService + ']', function (done) {
-            this.timeout(10000);
-
             let listenerId;
             client.addDistributedObjectListener(() => {
                 done(new Error('Should not have run!'));
@@ -121,8 +119,6 @@ const Util = require('./Util');
         });
 
         it('listener is not invoked when it is removed and new member starts[smart=' + isSmartService + ']', function (done) {
-            this.timeout(20000);
-
             let listenerId;
             let member2Promise;
             client.addDistributedObjectListener(() => {

--- a/test/ListenersOnReconnectTest.js
+++ b/test/ListenersOnReconnectTest.js
@@ -22,7 +22,6 @@ const Util = require('./Util');
 
 describe('ListenersOnReconnectTest', function () {
 
-    this.timeout(40000);
     let client;
     let cluster;
     let map;

--- a/test/LostConnectionTest.js
+++ b/test/LostConnectionTest.js
@@ -44,8 +44,6 @@ describe('LostConnectionTest', function () {
     });
 
     it('M2 starts, M1 goes down, client connects to M2', function (done) {
-        this.timeout(32000);
-
         let newMember;
         const membershipListener = {
             memberAdded: () => {

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -22,8 +22,9 @@ const { deferredPromise } = require('../lib/util/Util');
 const { MemberEvent } = require('../lib/core');
 
 describe('MembershipListenerTest', function () {
-    this.timeout(20000);
-    let cluster, client;
+
+    let cluster;
+    let client;
 
     beforeEach(async function () {
         cluster = await RC.createCluster(null, null);

--- a/test/cpsubsystem/AtomicLongTest.js
+++ b/test/cpsubsystem/AtomicLongTest.js
@@ -30,8 +30,6 @@ const {
 
 describe('AtomicLongTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let long;

--- a/test/cpsubsystem/AtomicReferenceTest.js
+++ b/test/cpsubsystem/AtomicReferenceTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('AtomicReferenceTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let ref;

--- a/test/cpsubsystem/CountDownLatchTest.js
+++ b/test/cpsubsystem/CountDownLatchTest.js
@@ -29,11 +29,8 @@ const {
 
 describe('CountDownLatchTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
-
     let groupSeq = 0;
 
     // we use a separate latch (and group) per each test to enforce test isolation

--- a/test/cpsubsystem/FencedLockTest.js
+++ b/test/cpsubsystem/FencedLockTest.js
@@ -29,8 +29,6 @@ const {
 
 describe('FencedLockTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let lock;

--- a/test/cpsubsystem/SemaphoreCommonTest.js
+++ b/test/cpsubsystem/SemaphoreCommonTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('SemaphoreCommonTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     const testTypes = ['sessionless', 'sessionaware'];

--- a/test/cpsubsystem/SessionAwareSemaphoreTest.js
+++ b/test/cpsubsystem/SessionAwareSemaphoreTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('SessionAwareSemaphoreTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let groupSeq = 0;

--- a/test/cpsubsystem/SessionlessSemaphoreTest.js
+++ b/test/cpsubsystem/SessionlessSemaphoreTest.js
@@ -25,8 +25,6 @@ const { Client } = require('../../');
 
 describe('SessionlessSemaphoreTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let groupSeq = 0;

--- a/test/flakeid/FlakeIdGeneratorOutOfRangeTest.js
+++ b/test/flakeid/FlakeIdGeneratorOutOfRangeTest.js
@@ -25,8 +25,6 @@ const Util = require('../Util');
 
 describe('FlakeIdGeneratorOutOfRangeTest', function () {
 
-    this.timeout(30000);
-
     let cluster, client;
     let flakeIdGenerator;
 

--- a/test/heartbeat/HeartbeatFromClientTest.js
+++ b/test/heartbeat/HeartbeatFromClientTest.js
@@ -23,7 +23,6 @@ const { Client } = require('../../');
 
 describe('HeartbeatFromClientTest', function () {
 
-    this.timeout(30000);
     let cluster;
 
     beforeEach(async function () {

--- a/test/heartbeat/HeartbeatFromServerTest.js
+++ b/test/heartbeat/HeartbeatFromServerTest.js
@@ -23,7 +23,6 @@ const { AddressImpl, TargetDisconnectedError } = require('../../lib/core');
 
 describe('HeartbeatFromServerTest', function () {
 
-    this.timeout(50000);
     let cluster;
     let client;
 

--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -33,8 +33,6 @@ const { ClientLocalBackupListenerCodec } = require('../../lib/codec/ClientLocalB
  */
 describe('ClientBackupAcksTest', function () {
 
-    this.timeout(15000);
-
     let cluster;
     let client;
 

--- a/test/integration/ClientLabelTest.js
+++ b/test/integration/ClientLabelTest.js
@@ -22,8 +22,8 @@ const RC = require('../RC');
 
 describe('ClientLabelTest', function () {
 
-    this.timeout(32000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     before(async function () {
         cluster = await RC.createCluster(null, null);

--- a/test/integration/ConnectionStrategyTest.js
+++ b/test/integration/ConnectionStrategyTest.js
@@ -29,8 +29,8 @@ const { LifecycleState } = require('../../lib/LifecycleService');
 
 describe('ConnectionStrategyTest', function () {
 
-    this.timeout(32000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     beforeEach(function () {
         client = null;

--- a/test/integration/DistributedObjectsTest.js
+++ b/test/integration/DistributedObjectsTest.js
@@ -26,8 +26,8 @@ const Util = require('../Util');
 
 describe('DistributedObjectsTest', function () {
 
-    this.timeout(32000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     const toNamespace = (distributedObjects) => {
         return distributedObjects.map((distObj) => distObj.getServiceName() + distObj.getName());

--- a/test/integration/InitialMembershipListenerTest.js
+++ b/test/integration/InitialMembershipListenerTest.js
@@ -27,8 +27,6 @@ const { deferredPromise } = require('../../lib/util/Util');
 
 describe('InitialMembershipListenerTest', function () {
 
-    this.timeout(32000);
-
     let cluster;
     let initialMember;
     let client;

--- a/test/list/ListProxyTest.js
+++ b/test/list/ListProxyTest.js
@@ -19,170 +19,169 @@ const expect = require('chai').expect;
 const RC = require('./../RC');
 const { Client } = require('../../');
 const { ItemEventType } = require('../../lib/proxy/ItemListener');
+const { deferredPromise } = require('../../lib/util/Util');
 
 describe('ListProxyTest', function () {
 
     let cluster;
     let client;
-    let listInstance;
+    let list;
 
     before(async function () {
-        this.timeout(10000);
         cluster = await RC.createCluster();
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({ clusterName: cluster.id });
     });
 
     beforeEach(async function () {
-        listInstance = await client.getList('test');
+        list = await client.getList('test');
     });
 
     afterEach(async function () {
-        return listInstance.destroy();
+        await list.destroy();
     });
 
     after(async function () {
         await client.shutdown();
-        return RC.terminateCluster(cluster.id);
+        await RC.terminateCluster(cluster.id);
     });
 
     it('appends one item', async function () {
-        await listInstance.add(1);
-        const size = await listInstance.size();
+        await list.add(1);
+        const size = await list.size();
         expect(size).to.equal(1);
     });
 
     it('inserts one item at index', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        await listInstance.addAt(1, 5);
-        const all = await listInstance.toArray();
+        await list.addAll([1, 2, 3]);
+        await list.addAt(1, 5);
+        const all = await list.toArray();
         expect(all).to.deep.equal([1, 5, 2, 3]);
     });
 
     it('clears', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        await listInstance.clear();
-        const size = await listInstance.size();
+        await list.addAll([1, 2, 3]);
+        await list.clear();
+        const size = await list.size();
         expect(size).to.equal(0);
     });
 
     it('inserts all elements of array at index', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        await listInstance.addAllAt(1, [5, 6]);
-        const all = await listInstance.toArray();
+        await list.addAll([1, 2, 3]);
+        await list.addAllAt(1, [5, 6]);
+        const all = await list.toArray();
         expect(all).to.deep.equal([1, 5, 6, 2, 3]);
     });
 
     it('gets item at index', async function () {
         const input = [1, 2, 3];
-        await listInstance.addAll(input);
-        const result = await listInstance.get(1);
+        await list.addAll(input);
+        const result = await list.get(1);
         expect(result).to.equal(2);
     });
 
     it('removes item at index', async function () {
         const input = [1, 2, 3];
-        await listInstance.addAll(input);
-        const removed = await listInstance.removeAt(1);
+        await list.addAll(input);
+        const removed = await list.removeAt(1);
         expect(removed).to.equal(2);
-        const all = await listInstance.toArray();
+        const all = await list.toArray();
         expect(all).to.deep.equal([1, 3]);
     });
 
     it('replaces item at index', async function () {
         const input = [1, 2, 3];
-        await listInstance.addAll(input);
-        const replaced = await listInstance.set(1, 6);
+        await list.addAll(input);
+        const replaced = await list.set(1, 6);
         expect(replaced).to.equal(2);
-        const all = await listInstance.toArray();
+        const all = await list.toArray();
         expect(all).to.deep.equal([1, 6, 3]);
     });
 
     it('contains', async function () {
         const input = [1, 2, 3];
-        await listInstance.addAll(input);
-        const contains = await listInstance.contains(1);
+        await list.addAll(input);
+        const contains = await list.contains(1);
         expect(contains).to.be.true;
     });
 
     it('does not contain', async function () {
         const input = [1, 2, 3];
-        await listInstance.addAll(input);
-        const contains = await listInstance.contains(5);
+        await list.addAll(input);
+        const contains = await list.contains(5);
         expect(contains).to.be.false;
     });
 
     it('contains all', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        const contains = await listInstance.containsAll([1, 2]);
+        await list.addAll([1, 2, 3]);
+        const contains = await list.containsAll([1, 2]);
         expect(contains).to.be.true;
     });
 
     it('does not contain all', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        const contains = await listInstance.containsAll([3, 4]);
+        await list.addAll([1, 2, 3]);
+        const contains = await list.containsAll([3, 4]);
         expect(contains).to.be.false;
     });
 
     it('is empty', async function () {
-        const empty = await listInstance.isEmpty();
+        const empty = await list.isEmpty();
         expect(empty).to.be.true;
     });
 
     it('is not empty', async function () {
-        await listInstance.add(1);
-        const empty = await listInstance.isEmpty();
+        await list.add(1);
+        const empty = await list.isEmpty();
         expect(empty).to.be.false;
     });
 
     it('removes an entry', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        await listInstance.remove(1);
-        const all = await listInstance.toArray();
+        await list.addAll([1, 2, 3]);
+        await list.remove(1);
+        const all = await list.toArray();
         expect(all).to.deep.equal([2, 3]);
     });
 
     it('removes an entry by index', async function () {
-        await listInstance.addAll([1, 2, 3]);
-        await listInstance.removeAt(1);
-        const all = await listInstance.toArray();
+        await list.addAll([1, 2, 3]);
+        await list.removeAt(1);
+        const all = await list.toArray();
         expect(all).to.deep.equal([1, 3]);
     });
 
     it('removes multiple entries', async function () {
-        await listInstance.addAll([1, 2, 3, 4]);
-        await listInstance.removeAll([1, 2]);
-        const all = await listInstance.toArray();
+        await list.addAll([1, 2, 3, 4]);
+        await list.removeAll([1, 2]);
+        const all = await list.toArray();
         expect(all).to.deep.equal([3, 4]);
     });
 
     it('retains multiple entries', async function () {
-        await listInstance.addAll([1, 2, 3, 4]);
-        await listInstance.retainAll([1, 2]);
-        const all = await listInstance.toArray();
+        await list.addAll([1, 2, 3, 4]);
+        await list.retainAll([1, 2]);
+        const all = await list.toArray();
         expect(all).to.deep.equal([1, 2]);
     });
 
     it('finds index of the element', async function () {
-        await listInstance.addAll([1, 2, 4, 4]);
-        const index = await listInstance.indexOf(4);
+        await list.addAll([1, 2, 4, 4]);
+        const index = await list.indexOf(4);
         expect(index).to.equal(2);
     });
 
     it('finds last index of the element', async function () {
-        await listInstance.addAll([1, 2, 4, 4]);
-        const index = await listInstance.lastIndexOf(4);
+        await list.addAll([1, 2, 4, 4]);
+        const index = await list.lastIndexOf(4);
         expect(index).to.equal(3);
     });
 
     it('returns a sub list', async function () {
-        await listInstance.addAll([1, 2, 3, 4, 5, 6]);
-        const subList = await listInstance.subList(1, 5);
+        await list.addAll([1, 2, 3, 4, 5, 6]);
+        const subList = await list.subList(1, 5);
         expect(subList.toArray()).to.deep.equal([2, 3, 4, 5]);
     });
 
     it('listens for added entry', function (done) {
-        this.timeout(5000);
         const listener = {
             itemAdded: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -192,15 +191,14 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, true).then(function () {
-            listInstance.add(1);
+        list.addItemListener(listener, true).then(function () {
+            list.add(1);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('listens for added and removed entry', function (done) {
-        this.timeout(5000);
         let added = false;
         const listener = {
             itemAdded: function (itemEvent) {
@@ -219,17 +217,16 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, true).then(function () {
-            return listInstance.add(2);
+        list.addItemListener(listener, true).then(function () {
+            return list.add(2);
         }).then(function () {
-            return listInstance.remove(2);
+            return list.remove(2);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('listens for removed entry with value included', function (done) {
-        this.timeout(5000);
         const listener = {
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -239,17 +236,16 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, true).then(function () {
-            return listInstance.add(1);
+        list.addItemListener(listener, true).then(function () {
+            return list.add(1);
         }).then(function () {
-            return listInstance.remove(1);
+            return list.remove(1);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('listens for removed entry with value not included', function (done) {
-        this.timeout(5000);
         const listener = {
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -259,26 +255,30 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, false).then(function () {
-            return listInstance.add(1);
+        list.addItemListener(listener, false).then(function () {
+            return list.add(1);
         }).then(function () {
-            return listInstance.remove(1);
+            return list.remove(1);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('remove entry listener', async function () {
-        this.timeout(5000);
-        const registrationId = await listInstance.addItemListener({
-            itemRemoved: function (itemEvent) {
-                expect(itemEvent.name).to.be.equal('test');
-                expect(itemEvent.item).to.be.equal(1);
-                expect(itemEvent.eventType).to.be.equal(ItemEventType.REMOVED);
-                expect(itemEvent.member).to.not.be.equal(null);
+        const itemRemovedNotTriggered = deferredPromise();
+        const registrationId = await list.addItemListener({
+            itemRemoved: () => {
+                itemRemovedNotTriggered.reject(new Error('Listener should not be triggered'));
             }
         });
-        const removed = await listInstance.removeItemListener(registrationId);
+
+        const removed = await list.removeItemListener(registrationId);
         expect(removed).to.be.true;
+
+        await list.add(1);
+        await list.remove(1);
+
+        setTimeout(itemRemovedNotTriggered.resolve, 1000);
+        await itemRemovedNotTriggered.promise;
     });
 });

--- a/test/map/MapEntryProcessorTest.js
+++ b/test/map/MapEntryProcessorTest.js
@@ -59,7 +59,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries should modify entries', async function () {
-        this.timeout(4000);
         await map.executeOnEntries(new IdentifiedEntryProcessor('processed'));
         const entries = await map.entrySet();
         expect(entries.every(function (entry) {
@@ -68,7 +67,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries should return modified entries', async function () {
-        this.timeout(4000);
         const entries = await map.executeOnEntries(new IdentifiedEntryProcessor('processed'));
         expect(entries).to.have.lengthOf(MAP_SIZE);
         expect(entries.every(function (entry) {
@@ -77,15 +75,14 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries with predicate should modify entries', async function () {
-        this.timeout(4000);
         await map.executeOnEntries(new IdentifiedEntryProcessor('processed'), Predicates.regex('this', '^[01]$'));
         const entries = await map.getAll(["0", "1", "2"]);
         expect(entries).to.deep.have.members([['0', 'processed'], ['1', 'processed'], ['2', '2']]);
     });
 
     it('executeOnEntries with predicate should return modified entries', async function () {
-        this.timeout(4000);
-        const entries = await map.executeOnEntries(new IdentifiedEntryProcessor('processed'), Predicates.regex('this', '^[01]$'));
+        const entries = await map.executeOnEntries(new IdentifiedEntryProcessor('processed'),
+            Predicates.regex('this', '^[01]$'));
         expect(entries).to.have.lengthOf(2);
         expect(entries.every(function (entry) {
             return entry[1] == 'processed';
@@ -93,35 +90,29 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnKey should return modified value', async function () {
-        this.timeout(4000);
         const retVal = await map.executeOnKey('4', new IdentifiedEntryProcessor('processed'));
         expect(retVal).to.equal('processed');
     });
 
     it('executeOnKey should modify the value', async function () {
-        this.timeout(4000);
         await map.executeOnKey('4', new IdentifiedEntryProcessor('processed'));
         const value = await map.get('4');
         expect(value).to.equal('processed');
     });
 
     it('executeOnKeys should return modified entries', async function () {
-        this.timeout(4000);
         const entries = await map.executeOnKeys(['4', '5'], new IdentifiedEntryProcessor('processed'));
         expect(entries).to.deep.have.members([['4', 'processed'], ['5', 'processed']]);
     });
 
     it('executeOnKeys should modify the entries', async function () {
-        this.timeout(4000);
         await map.executeOnKeys(['4', '5'], new IdentifiedEntryProcessor('processed'));
         const entries = await map.getAll(['4', '5']);
         expect(entries).to.deep.have.members([['4', 'processed'], ['5', 'processed']]);
     });
 
     it('executeOnKeys with empty array should return empty array', async function () {
-        this.timeout(4000);
         const entries = await map.executeOnKeys([], new IdentifiedEntryProcessor('processed'));
         expect(entries).to.have.lengthOf(0);
     });
-
 });

--- a/test/map/MapLockTest.js
+++ b/test/map/MapLockTest.js
@@ -67,7 +67,6 @@ describe('MapLockTest', function () {
     });
 
     it('should acquire the lock when key owner terminates', function (done) {
-        this.timeout(30000);
         let clientTwo;
         let keyOwner;
         let key;

--- a/test/map/MapPartitionAwareTest.js
+++ b/test/map/MapPartitionAwareTest.js
@@ -51,7 +51,6 @@ describe('MapPartitionAwareTest', function () {
 
     before(async function () {
         expect(memberCount, 'This test should have at least 2 members.').to.be.at.least(2);
-        this.timeout(30000);
         cluster = await RC.createCluster(null, null);
         for (let i = 0; i < memberCount; i++) {
             members.push(await RC.startMember(cluster.id));
@@ -74,7 +73,6 @@ describe('MapPartitionAwareTest', function () {
     });
 
     it('put', async function () {
-        this.timeout(15000);
         await fillMap(map, numOfEntries);
         const stats = await Promise.all(members.map(async function (member, index) {
             return RC.executeOnController(cluster.id, getLocalMapStats(index), 1);

--- a/test/map/MapPredicateTest.js
+++ b/test/map/MapPredicateTest.js
@@ -39,7 +39,6 @@ describe('MapPredicateTest', function () {
     }
 
     before(async function () {
-        this.timeout(32000);
         cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_identifiedfactory.xml', 'utf8'));
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -46,11 +46,11 @@ describe('MapProxyTest', function () {
     [false, true].forEach(function (nearCacheEnabled) {
         describe('Near Cache: ' + nearCacheEnabled, function () {
 
-            let cluster, client;
+            let cluster;
+            let client;
             let map;
 
             before(async function () {
-                this.timeout(32000);
                 cluster = await createController(nearCacheEnabled);
                 await RC.startMember(cluster.id);
                 client = await createClient(nearCacheEnabled, cluster.id);

--- a/test/map/MapStoreTest.js
+++ b/test/map/MapStoreTest.js
@@ -30,7 +30,6 @@ describe('MapStoreTest', function () {
     let map;
 
     before(async function () {
-        this.timeout(32000);
         cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_mapstore.xml', 'utf8'));
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({ clusterName: cluster.id });

--- a/test/map/NearCachedMapStressTest.js
+++ b/test/map/NearCachedMapStressTest.js
@@ -69,7 +69,6 @@ describe('NearCachedMapStress', function () {
     }
 
     it('stress test with put, get and remove', function (done) {
-        this.timeout(120000);
         let map;
         client1.getMap(mapName).then(function (mp) {
             map = mp;

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -27,11 +27,13 @@ describe('NearCachedMapTest', function () {
     [true, false].forEach(function (invalidateOnChange) {
         describe('invalidate on change=' + invalidateOnChange, function () {
 
-            let cluster, client1, client2;
-            let map1, map2;
+            let cluster;
+            let client1;
+            let client2;
+            let map1;
+            let map2;
 
             before(async function () {
-                this.timeout(32000);
                 const cfg = {
                     nearCaches: {
                         'ncc-map': {
@@ -48,7 +50,6 @@ describe('NearCachedMapTest', function () {
             });
 
             beforeEach(async function () {
-                this.timeout(10000);
                 map1 = await client1.getMap('ncc-map');
                 map2 = await client2.getMap('ncc-map');
                 return fillMap(map1);

--- a/test/multimap/MultiMapProxyListenersTest.js
+++ b/test/multimap/MultiMapProxyListenersTest.js
@@ -22,13 +22,11 @@ const Util = require('./../Util');
 
 describe("MultiMap Proxy Listener", function () {
 
-    this.timeout(10000);
     let cluster;
     let client;
     let map;
 
     before(async function () {
-        this.timeout(10000);
         cluster = await RC.createCluster();
         await RC.startMember(cluster.id);
         client = await HazelcastClient.newHazelcastClient({ clusterName: cluster.id });
@@ -160,7 +158,6 @@ describe("MultiMap Proxy Listener", function () {
     // Other
 
     it("listens for clear", function (done) {
-        this.timeout(10000);
         const listener = {
             mapCleared: function (mapEvent) {
                 try {
@@ -171,7 +168,6 @@ describe("MultiMap Proxy Listener", function () {
                 } catch (err) {
                     done(err);
                 }
-
             }
         };
 

--- a/test/multimap/MultiMapProxyLockTest.js
+++ b/test/multimap/MultiMapProxyLockTest.js
@@ -29,7 +29,6 @@ describe('MultiMapProxyLockTest', function () {
     let mapTwo;
 
     before(async function () {
-        this.timeout(10000);
         cluster = await RC.createCluster();
         await RC.startMember(cluster.id);
         const cfg = { clusterName: cluster.id };
@@ -54,7 +53,6 @@ describe('MultiMapProxyLockTest', function () {
 
 
     it('locks and unlocks', async function () {
-        this.timeout(10000);
         const startTime = Date.now();
         await mapOne.put(1, 2);
         await mapOne.lock(1);
@@ -67,7 +65,6 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('unlocks after lease expired', async function () {
-        this.timeout(10000);
         const startTime = Date.now();
         await mapOne.lock(1, 1000);
         await mapTwo.lock(1);
@@ -76,14 +73,12 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('gives up attempt to lock after timeout is exceeded', async function () {
-        this.timeout(10000);
         await mapOne.lock(1);
         const acquired = await mapTwo.tryLock(1, 1000);
         expect(acquired).to.be.false;
     });
 
     it('acquires lock before timeout is exceeded', async function () {
-        this.timeout(10000);
         const startTime = Date.now();
         await mapOne.lock(1, 1000);
         const acquired = await mapTwo.tryLock(1, 2000);
@@ -93,7 +88,6 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('acquires the lock before timeout and unlocks after lease expired', async function () {
-        this.timeout(10000);
         const startTime = Date.now();
         await mapOne.lock(1, 1000);
         await mapTwo.tryLock(1, 2000, 1000);

--- a/test/multimap/MultiMapProxyTest.js
+++ b/test/multimap/MultiMapProxyTest.js
@@ -27,7 +27,6 @@ describe('MultiMapProxyTest', function () {
     let map;
 
     before(async function () {
-        this.timeout(10000);
         cluster = await RC.createCluster();
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({

--- a/test/nearcache/InvalidationMetadataDistortionTest.js
+++ b/test/nearcache/InvalidationMetadataDistortionTest.js
@@ -68,7 +68,6 @@ describe('Invalidation metadata distortion', function () {
     });
 
     it('lost invalidation', function (done) {
-        this.timeout(13000);
         let stopTest = false;
         let map;
         const populatePromises = [];

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -23,7 +23,6 @@ const { deferredPromise } = require('../../lib/util/Util');
 const Util = require('../Util');
 
 describe('LostInvalidationTest', function () {
-    this.timeout(30000);
 
     let cluster;
     let client;

--- a/test/nearcache/MigratedDataTest.js
+++ b/test/nearcache/MigratedDataTest.js
@@ -24,10 +24,9 @@ const { deferredPromise } = require('../../lib/util/Util');
 
 describe('MigratedDataTest', function () {
 
-    this.timeout(20000);
-
     let cluster;
-    let member1, member2;
+    let member1;
+    let member2;
     let client;
 
     const mapName = 'ncmap';

--- a/test/nearcache/NearCacheSimpleInvalidationTest.js
+++ b/test/nearcache/NearCacheSimpleInvalidationTest.js
@@ -55,9 +55,8 @@ describe('NearCacheSimpleInvalidationTest', function () {
             });
 
             it('client observes outside invalidations', async function () {
-                this.timeout(10000);
                 const entryCount = 1000;
-                let map = await client.getMap(mapName);
+                const map = await client.getMap(mapName);
                 for (let i = 0; i < entryCount; i++) {
                     await map.get('' + i);
                 }

--- a/test/nearcache/NearCacheTest.js
+++ b/test/nearcache/NearCacheTest.js
@@ -108,7 +108,6 @@ describe('NearCacheTest', function () {
         });
 
         it('expires after maxIdleSeconds', function (done) {
-            this.timeout(4000);
             const rec = new DataRecord(ds('key'), 'value', undefined, 100);
             setTimeout(function () {
                 if (rec.isExpired(1)) {

--- a/test/pncounter/PNCounterConsistencyTest.js
+++ b/test/pncounter/PNCounterConsistencyTest.js
@@ -26,8 +26,6 @@ const { Client, ConsistencyLostError } = require('../../');
 
 describe('PNCounterConsistencyTest', function () {
 
-    this.timeout(10000);
-
     let cluster;
     let client;
 

--- a/test/queue/QueueProxyTest.js
+++ b/test/queue/QueueProxyTest.js
@@ -32,7 +32,6 @@ describe('QueueProxyTest', function () {
     let queue;
 
     before(async function () {
-        this.timeout(10000);
         cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_queue.xml', 'utf8'));
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({ clusterName: cluster.id });

--- a/test/replicatedmap/ReplicatedMapProxyTest.js
+++ b/test/replicatedmap/ReplicatedMapProxyTest.js
@@ -31,7 +31,6 @@ describe('ReplicatedMapProxyTest', function () {
     const ONE_HOUR = 3600000;
 
     before(async function () {
-        this.timeout(10000);
         const config = fs.readFileSync(path.join(__dirname, 'hazelcast_replicatedmap.xml'), 'utf8');
         cluster = await RC.createCluster(null, config);
         await RC.startMember(cluster.id);
@@ -68,7 +67,7 @@ describe('ReplicatedMapProxyTest', function () {
         await TestUtil.promiseWaitMilliseconds(2000);
         const val = await rm.get('1000ttl');
         expect(val).to.be.null;
-    }).timeout(5000);
+    });
 
     it('should contain the key', async function () {
         await rm.put('key', 'value', ONE_HOUR);

--- a/test/rest_value/RestValueTest.js
+++ b/test/rest_value/RestValueTest.js
@@ -31,7 +31,6 @@ describe('RestValueTest', function () {
     let member;
 
     before(async function () {
-        this.timeout(32000);
         cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_rest.xml', 'utf8'));
         member = await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({ clusterName: cluster.id });

--- a/test/ringbuffer/RingbufferProxyTest.js
+++ b/test/ringbuffer/RingbufferProxyTest.js
@@ -30,7 +30,6 @@ describe('RingbufferProxyTest', function () {
     let limitedCapacityRb;
 
     before(async function () {
-        this.timeout(10000);
         const config = fs.readFileSync(__dirname + '/hazelcast_ringbuffer.xml', 'utf8');
         cluster = await RC.createCluster(null, config);
         await RC.startMember(cluster.id);

--- a/test/serialization/BinaryCompatibilityTest.js
+++ b/test/serialization/BinaryCompatibilityTest.js
@@ -138,15 +138,14 @@ describe('BinaryCompatibilityTest', function () {
             versions.forEach(function (version) {
                 isBigEndianValues.forEach(function (isBigEndian) {
                     it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version, function () {
-                        this.timeout(10000);
                         const key = createObjectKey(varName, version, isBigEndian);
                         const service = createSerializationService(isBigEndian, 'integer');
                         const deserialized = service.toObject(dataMap[key]);
                         expectAlmostEqual(deserialized, object);
                     });
+
                     if (!ReferenceObjects.skipOnSerialize[varName]) {
                         it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version + ' serialize deserialize', function () {
-                            this.timeout(10000);
                             const service = createSerializationService(isBigEndian, stripArticle(varName).toLowerCase());
                             const data = service.toData(object);
                             const deserialized = service.toObject(data);

--- a/test/set/SetProxyTest.js
+++ b/test/set/SetProxyTest.js
@@ -27,7 +27,6 @@ describe('SetProxyTest', function () {
     let setInstance;
 
     before(async function () {
-        this.timeout(10000);
         cluster = await RC.createCluster();
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({ clusterName: cluster.id });
@@ -120,7 +119,6 @@ describe('SetProxyTest', function () {
     });
 
     it('listens for added entry', function (done) {
-        this.timeout(5000);
         setInstance.addItemListener({
             itemAdded: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -137,7 +135,6 @@ describe('SetProxyTest', function () {
     });
 
     it('listens for added and removed entry', function (done) {
-        this.timeout(5000);
         setInstance.addItemListener({
             itemAdded: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -162,7 +159,6 @@ describe('SetProxyTest', function () {
     });
 
     it('listens for removed entry', function (done) {
-        this.timeout(5000);
         setInstance.addItemListener({
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -181,7 +177,6 @@ describe('SetProxyTest', function () {
     });
 
     it('remove entry listener', async function () {
-        this.timeout(5000);
         const registrationId = await setInstance.addItemListener({
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');

--- a/test/ssl/ClientSSLAuthenticationTest.js
+++ b/test/ssl/ClientSSLAuthenticationTest.js
@@ -104,8 +104,6 @@ describe('ClientSSLAuthenticationTest', function () {
 
         describe(title, function () {
 
-            this.timeout(10000);
-
             afterEach(async function () {
                 await RC.terminateCluster(cluster.id);
             });

--- a/test/ssl/ClientSSLTest.js
+++ b/test/ssl/ClientSSLTest.js
@@ -26,8 +26,6 @@ const { markEnterprise } = require('../Util');
 
 describe('ClientSSLTest', function () {
 
-    this.timeout(20000);
-
     let cluster;
     let client;
     let serverConfig;

--- a/test/topic/ReliableTopicTest.js
+++ b/test/topic/ReliableTopicTest.js
@@ -25,7 +25,6 @@ const { ReliableTopicMessage } = require('../../lib/proxy/topic/ReliableTopicMes
 
 describe('ReliableTopicTest', function () {
 
-    this.timeout(40000);
     let cluster;
     let clientOne;
     let clientTwo;
@@ -57,7 +56,6 @@ describe('ReliableTopicTest', function () {
     }
 
     before(async function () {
-        this.timeout(40000);
         const memberConfig = fs.readFileSync(__dirname + '/hazelcast_topic.xml', 'utf8');
         cluster = await RC.createCluster(null, memberConfig);
         await RC.startMember(cluster.id);


### PR DESCRIPTION
Closes #452

* Removes ad-hoc timeouts in tests in favor of the global one
* Increases global test timeout to 2 mins
* Includes minor improvements for some tests

As a result, CI builds running on Windows should become more stable.