### PR TITLE
[BACKPORT] Remove ad-hoc timeouts in tests

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
-    "timeout": 8000,
+    "timeout": 120000,
     "exit": true,
     "exclude": [
         "test/soak_test/**",

--- a/test/AutoPipeliningDisabledTest.js
+++ b/test/AutoPipeliningDisabledTest.js
@@ -26,7 +26,6 @@ describe('AutoPipeliningDisabledTest', function () {
     let map;
 
     before(async function () {
-        this.timeout(32000);
         cluster = await RC.createCluster(null, null);
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({

--- a/test/ClientHotRestartEventTest.js
+++ b/test/ClientHotRestartEventTest.js
@@ -31,7 +31,6 @@ const {
  */
 describe('ClientHotRestartEventTest', function () {
 
-    this.timeout(60000);
     let client;
     let cluster;
 

--- a/test/ClientReconnectTest.js
+++ b/test/ClientReconnectTest.js
@@ -21,8 +21,6 @@ const { Client } = require('../.');
 
 describe('ClientReconnectTest', function () {
 
-    this.timeout(10000);
-
     let cluster;
     let client;
 

--- a/test/ClientRedoEnabledTest.js
+++ b/test/ClientRedoEnabledTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('ClientRedoEnabledTest', function () {
 
-    this.timeout(10000);
-
     let cluster;
     let client;
 

--- a/test/ClusterServiceTest.js
+++ b/test/ClusterServiceTest.js
@@ -21,8 +21,9 @@ const { Client } = require('../.');
 
 describe('ClusterServiceTest', function () {
 
-    this.timeout(25000);
-    let cluster, member1, client;
+    let cluster;
+    let member1;
+    let client;
 
     beforeEach(function () {
         return RC.createCluster(null, null).then(function (res) {

--- a/test/ConnectionManagerTest.js
+++ b/test/ConnectionManagerTest.js
@@ -82,8 +82,6 @@ describe('ConnectionManagerTest', function () {
     });
 
     it('does not give up when timeout=0', function (done) {
-        this.timeout(8000);
-
         const timeoutTime = 0;
         startUnresponsiveServer(9999);
         const scheduled = setTimeout(function () {

--- a/test/ListenerServiceTest.js
+++ b/test/ListenerServiceTest.js
@@ -98,8 +98,6 @@ const Util = require('./Util');
         });
 
         it('listener is not invoked when it is removed[smart=' + isSmartService + ']', function (done) {
-            this.timeout(10000);
-
             let listenerId;
             client.addDistributedObjectListener(() => {
                 done(new Error('Should not have run!'));
@@ -121,8 +119,6 @@ const Util = require('./Util');
         });
 
         it('listener is not invoked when it is removed and new member starts[smart=' + isSmartService + ']', function (done) {
-            this.timeout(20000);
-
             let listenerId;
             let member2Promise;
             client.addDistributedObjectListener(() => {

--- a/test/ListenersOnReconnectTest.js
+++ b/test/ListenersOnReconnectTest.js
@@ -22,7 +22,6 @@ const Util = require('./Util');
 
 describe('ListenersOnReconnectTest', function () {
 
-    this.timeout(40000);
     let client;
     let cluster;
     let map;

--- a/test/LostConnectionTest.js
+++ b/test/LostConnectionTest.js
@@ -44,8 +44,6 @@ describe('LostConnectionTest', function () {
     });
 
     it('M2 starts, M1 goes down, client connects to M2', function (done) {
-        this.timeout(32000);
-
         let newMember;
         const membershipListener = {
             memberAdded: () => {

--- a/test/MembershipListenerTest.js
+++ b/test/MembershipListenerTest.js
@@ -23,8 +23,8 @@ const { MemberEvent } = require('../lib/core');
 
 describe('MembershipListenerTest', function () {
 
-    this.timeout(20000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     beforeEach(function () {
         return RC.createCluster(null, null).then(function (res) {

--- a/test/cpsubsystem/AtomicLongTest.js
+++ b/test/cpsubsystem/AtomicLongTest.js
@@ -30,8 +30,6 @@ const {
 
 describe('AtomicLongTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let long;

--- a/test/cpsubsystem/AtomicReferenceTest.js
+++ b/test/cpsubsystem/AtomicReferenceTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('AtomicReferenceTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let ref;

--- a/test/cpsubsystem/CountDownLatchTest.js
+++ b/test/cpsubsystem/CountDownLatchTest.js
@@ -29,11 +29,8 @@ const {
 
 describe('CountDownLatchTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
-
     let groupSeq = 0;
 
     // we use a separate latch (and group) per each test to enforce test isolation

--- a/test/cpsubsystem/FencedLockTest.js
+++ b/test/cpsubsystem/FencedLockTest.js
@@ -29,13 +29,11 @@ const {
 
 describe('FencedLockTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let lock;
-
     let anotherLockSeq = 0;
+
     async function getAnotherLock() {
         return client.getCPSubsystem().getLock('another-lock-' + anotherLockSeq++);
     }

--- a/test/cpsubsystem/SemaphoreCommonTest.js
+++ b/test/cpsubsystem/SemaphoreCommonTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('SemaphoreCommonTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     const testTypes = ['sessionless', 'sessionaware'];

--- a/test/cpsubsystem/SessionAwareSemaphoreTest.js
+++ b/test/cpsubsystem/SessionAwareSemaphoreTest.js
@@ -28,8 +28,6 @@ const {
 
 describe('SessionAwareSemaphoreTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let groupSeq = 0;

--- a/test/cpsubsystem/SessionlessSemaphoreTest.js
+++ b/test/cpsubsystem/SessionlessSemaphoreTest.js
@@ -25,8 +25,6 @@ const { Client } = require('../../');
 
 describe('SessionlessSemaphoreTest', function () {
 
-    this.timeout(30000);
-
     let cluster;
     let client;
     let groupSeq = 0;

--- a/test/flakeid/FlakeIdGeneratorOutOfRangeTest.js
+++ b/test/flakeid/FlakeIdGeneratorOutOfRangeTest.js
@@ -25,9 +25,8 @@ const Util = require('../Util');
 
 describe('FlakeIdGeneratorOutOfRangeTest', function () {
 
-    this.timeout(30000);
-
-    let cluster, client;
+    let cluster;
+    let client;
     let flakeIdGenerator;
 
     afterEach(async function () {

--- a/test/heartbeat/HeartbeatFromClientTest.js
+++ b/test/heartbeat/HeartbeatFromClientTest.js
@@ -23,7 +23,6 @@ const { Client } = require('../../');
 
 describe('HeartbeatFromClientTest', function () {
 
-    this.timeout(30000);
     let cluster;
 
     beforeEach(function () {

--- a/test/heartbeat/HeartbeatFromServerTest.js
+++ b/test/heartbeat/HeartbeatFromServerTest.js
@@ -23,7 +23,6 @@ const { AddressImpl, TargetDisconnectedError } = require('../../lib/core');
 
 describe('HeartbeatFromServerTest', function () {
 
-    this.timeout(50000);
     let cluster;
     let client;
 

--- a/test/integration/ClientBackupAcksTest.js
+++ b/test/integration/ClientBackupAcksTest.js
@@ -33,8 +33,6 @@ const { ClientLocalBackupListenerCodec } = require('../../lib/codec/ClientLocalB
  */
 describe('ClientBackupAcksTest', function () {
 
-    this.timeout(15000);
-
     let cluster;
     let client;
 

--- a/test/integration/ClientLabelTest.js
+++ b/test/integration/ClientLabelTest.js
@@ -22,8 +22,8 @@ const RC = require('../RC');
 
 describe('ClientLabelTest', function () {
 
-    this.timeout(32000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     before(async function () {
         cluster = await RC.createCluster(null, null);

--- a/test/integration/ConnectionStrategyTest.js
+++ b/test/integration/ConnectionStrategyTest.js
@@ -29,8 +29,8 @@ const { LifecycleState } = require('../../lib/LifecycleService');
 
 describe('ConnectionStrategyTest', function () {
 
-    this.timeout(32000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     beforeEach(function () {
         client = null;

--- a/test/integration/DistributedObjectsTest.js
+++ b/test/integration/DistributedObjectsTest.js
@@ -27,8 +27,8 @@ const Util = require('../Util');
 
 describe('DistributedObjectsTest', function () {
 
-    this.timeout(32000);
-    let cluster, client;
+    let cluster;
+    let client;
 
     const toNamespace = (distributedObjects) => {
         return distributedObjects.map((distObj) => distObj.getServiceName() + distObj.getName());

--- a/test/integration/InitialMembershipListenerTest.js
+++ b/test/integration/InitialMembershipListenerTest.js
@@ -27,8 +27,6 @@ const { deferredPromise } = require('../../lib/util/Util');
 
 describe('InitialMembershipListenerTest', function () {
 
-    this.timeout(32000);
-
     let cluster;
     let initialMember;
     let client;

--- a/test/list/ListProxyTest.js
+++ b/test/list/ListProxyTest.js
@@ -24,10 +24,9 @@ describe('ListProxyTest', function () {
 
     let cluster;
     let client;
-    let listInstance;
+    let list;
 
     before(function () {
-        this.timeout(10000);
         return RC.createCluster().then(function (response) {
             cluster = response;
             return RC.startMember(cluster.id);
@@ -40,13 +39,13 @@ describe('ListProxyTest', function () {
     });
 
     beforeEach(function () {
-        return client.getList('test').then(function (list) {
-            listInstance = list;
+        return client.getList('test').then(function (l) {
+            list = l;
         });
     });
 
     afterEach(function () {
-        return listInstance.destroy();
+        return list.destroy();
     });
 
     after(function () {
@@ -55,38 +54,38 @@ describe('ListProxyTest', function () {
     });
 
     it('appends one item', function () {
-        return listInstance.add(1).then(function () {
-            return listInstance.size();
+        return list.add(1).then(function () {
+            return list.size();
         }).then(function (size) {
             expect(size).to.equal(1);
         });
     });
 
     it('inserts one item at index', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.addAt(1, 5);
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.addAt(1, 5);
         }).then(function () {
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([1, 5, 2, 3]);
         });
     });
 
     it('clears', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.clear();
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.clear();
         }).then(function () {
-            return listInstance.size();
+            return list.size();
         }).then(function (size) {
             expect(size).to.equal(0);
         });
     });
 
     it('inserts all elements of array at index', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.addAllAt(1, [5, 6]);
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.addAllAt(1, [5, 6]);
         }).then(function () {
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([1, 5, 6, 2, 3])
         });
@@ -94,8 +93,8 @@ describe('ListProxyTest', function () {
 
     it('gets item at index', function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.get(1);
+        return list.addAll(input).then(function () {
+            return list.get(1);
         }).then(function (result) {
             expect(result).to.equal(2);
         });
@@ -103,11 +102,11 @@ describe('ListProxyTest', function () {
 
     it('removes item at index', function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.removeAt(1);
+        return list.addAll(input).then(function () {
+            return list.removeAt(1);
         }).then(function (removed) {
             expect(removed).to.equal(2);
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([1, 3]);
         });
@@ -115,11 +114,11 @@ describe('ListProxyTest', function () {
 
     it('replaces item at index', function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.set(1, 6);
+        return list.addAll(input).then(function () {
+            return list.set(1, 6);
         }).then(function (replaced) {
             expect(replaced).to.equal(2);
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([1, 6, 3]);
         });
@@ -127,8 +126,8 @@ describe('ListProxyTest', function () {
 
     it('contains', function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.contains(1);
+        return list.addAll(input).then(function () {
+            return list.contains(1);
         }).then(function (contains) {
             expect(contains).to.be.true;
         });
@@ -136,109 +135,108 @@ describe('ListProxyTest', function () {
 
     it('does not contain', function () {
         const input = [1, 2, 3];
-        return listInstance.addAll(input).then(function () {
-            return listInstance.contains(5);
+        return list.addAll(input).then(function () {
+            return list.contains(5);
         }).then(function (contains) {
             expect(contains).to.be.false;
         });
     });
 
     it('contains all', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.containsAll([1, 2]);
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.containsAll([1, 2]);
         }).then(function (contains) {
             expect(contains).to.be.true;
         });
     });
 
     it('does not contain all', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.containsAll([3, 4]);
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.containsAll([3, 4]);
         }).then(function (contains) {
             expect(contains).to.be.false;
         });
     });
 
     it('is empty', function () {
-        return listInstance.isEmpty().then(function (empty) {
+        return list.isEmpty().then(function (empty) {
             expect(empty).to.be.true;
         });
     });
 
     it('is not empty', function () {
-        return listInstance.add(1).then(function (empty) {
-            return listInstance.isEmpty();
+        return list.add(1).then(function (empty) {
+            return list.isEmpty();
         }).then(function (empty) {
             expect(empty).to.be.false;
         });
     });
 
     it('removes an entry', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.remove(1)
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.remove(1)
         }).then(function () {
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([2, 3]);
         });
     });
 
     it('removes an entry by index', function () {
-        return listInstance.addAll([1, 2, 3]).then(function () {
-            return listInstance.removeAt(1)
+        return list.addAll([1, 2, 3]).then(function () {
+            return list.removeAt(1)
         }).then(function () {
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([1, 3]);
         });
     });
 
     it('removes multiple entries', function () {
-        return listInstance.addAll([1, 2, 3, 4]).then(function () {
-            return listInstance.removeAll([1, 2]);
+        return list.addAll([1, 2, 3, 4]).then(function () {
+            return list.removeAll([1, 2]);
         }).then(function () {
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([3, 4]);
         });
     });
 
     it('retains multiple entries', function () {
-        return listInstance.addAll([1, 2, 3, 4]).then(function () {
-            return listInstance.retainAll([1, 2]);
+        return list.addAll([1, 2, 3, 4]).then(function () {
+            return list.retainAll([1, 2]);
         }).then(function () {
-            return listInstance.toArray();
+            return list.toArray();
         }).then(function (all) {
             expect(all).to.deep.equal([1, 2]);
         });
     });
 
     it('finds index of the element', function () {
-        return listInstance.addAll([1, 2, 4, 4]).then(function () {
-            return listInstance.indexOf(4);
+        return list.addAll([1, 2, 4, 4]).then(function () {
+            return list.indexOf(4);
         }).then(function (index) {
             expect(index).to.equal(2);
         });
     });
 
     it('finds last index of the element', function () {
-        return listInstance.addAll([1, 2, 4, 4]).then(function () {
-            return listInstance.lastIndexOf(4);
+        return list.addAll([1, 2, 4, 4]).then(function () {
+            return list.lastIndexOf(4);
         }).then(function (index) {
             expect(index).to.equal(3);
         });
     });
 
     it('returns a sub list', function () {
-        return listInstance.addAll([1, 2, 3, 4, 5, 6]).then(function () {
-            return listInstance.subList(1, 5);
+        return list.addAll([1, 2, 3, 4, 5, 6]).then(function () {
+            return list.subList(1, 5);
         }).then(function (subList) {
             expect(subList.toArray()).to.deep.equal([2, 3, 4, 5]);
         });
     });
 
     it('listens for added entry', function (done) {
-        this.timeout(5000);
         const listener = {
             itemAdded: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -248,15 +246,14 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, true).then(function () {
-            listInstance.add(1);
+        list.addItemListener(listener, true).then(function () {
+            list.add(1);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('listens for added and removed entry', function (done) {
-        this.timeout(5000);
         let added = false;
         const listener = {
             itemAdded: function (itemEvent) {
@@ -275,17 +272,16 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, true).then(function () {
-            return listInstance.add(2);
+        list.addItemListener(listener, true).then(function () {
+            return list.add(2);
         }).then(function () {
-            return listInstance.remove(2);
+            return list.remove(2);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('listens for removed entry with value included', function (done) {
-        this.timeout(5000);
         const listener = {
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -295,17 +291,16 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, true).then(function () {
-            return listInstance.add(1);
+        list.addItemListener(listener, true).then(function () {
+            return list.add(1);
         }).then(function () {
-            return listInstance.remove(1);
+            return list.remove(1);
         }).catch(function (e) {
             done(e);
         });
     });
 
     it('listens for removed entry with value not included', function (done) {
-        this.timeout(5000);
         const listener = {
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -315,28 +310,31 @@ describe('ListProxyTest', function () {
                 done();
             }
         };
-        listInstance.addItemListener(listener, false).then(function () {
-            return listInstance.add(1);
+        list.addItemListener(listener, false).then(function () {
+            return list.add(1);
         }).then(function () {
-            return listInstance.remove(1);
+            return list.remove(1);
         }).catch(function (e) {
             done(e);
         });
     });
 
-    it('remove entry listener', function () {
-        this.timeout(5000);
-        return listInstance.addItemListener({
-            itemRemoved: function (itemEvent) {
-                expect(itemEvent.name).to.be.equal('test');
-                expect(itemEvent.item).to.be.equal(1);
-                expect(itemEvent.eventType).to.be.equal(ItemEventType.REMOVED);
-                expect(itemEvent.member).to.not.be.equal(null);
+    it('remove entry listener', function (done) {
+        list.addItemListener({
+            itemRemoved: function () {
+                done(new Error('Listener should not be triggered'));
             }
         }).then(function (registrationId) {
-            return listInstance.removeItemListener(registrationId);
+            return list.removeItemListener(registrationId);
         }).then(function (removed) {
             expect(removed).to.be.true;
+            return list.add(1);
+        }).then(function () {
+            return list.remove(1);
+        }).then(function () {
+            setTimeout(done, 1000);
+        }).catch(function (e) {
+            done(e);
         });
     });
 });

--- a/test/map/MapEntryProcessorTest.js
+++ b/test/map/MapEntryProcessorTest.js
@@ -69,7 +69,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries should modify entries', function () {
-        this.timeout(4000);
         return map.executeOnEntries(new IdentifiedEntryProcessor('processed')).then(function () {
             return map.entrySet();
         }).then(function (entries) {
@@ -80,7 +79,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries should return modified entries', function () {
-        this.timeout(4000);
         return map.executeOnEntries(new IdentifiedEntryProcessor('processed')).then(function (entries) {
             expect(entries).to.have.lengthOf(MAP_SIZE);
             expect(entries.every(function (entry) {
@@ -90,7 +88,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries with predicate should modify entries', function () {
-        this.timeout(4000);
         return map.executeOnEntries(new IdentifiedEntryProcessor('processed'), Predicates.regex('this', '^[01]$'))
             .then(function () {
                 return map.getAll(["0", "1", "2"]);
@@ -101,7 +98,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnEntries with predicate should return modified entries', function () {
-        this.timeout(4000);
         return map.executeOnEntries(new IdentifiedEntryProcessor('processed'), Predicates.regex('this', '^[01]$'))
             .then(function (entries) {
                 expect(entries).to.have.lengthOf(2);
@@ -112,14 +108,12 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnKey should return modified value', function () {
-        this.timeout(4000);
         return map.executeOnKey('4', new IdentifiedEntryProcessor('processed')).then(function (retVal) {
             return expect(retVal).to.equal('processed');
         });
     });
 
     it('executeOnKey should modify the value', function () {
-        this.timeout(4000);
         return map.executeOnKey('4', new IdentifiedEntryProcessor('processed')).then(function () {
             return map.get('4');
         }).then(function (value) {
@@ -128,7 +122,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnKeys should return modified entries', function () {
-        this.timeout(4000);
         return map.executeOnKeys(['4', '5'], new IdentifiedEntryProcessor('processed'))
             .then(function (entries) {
                 return expect(entries).to.deep.have.members([['4', 'processed'], ['5', 'processed']]);
@@ -136,7 +129,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnKeys should modify the entries', function () {
-        this.timeout(4000);
         return map.executeOnKeys(['4', '5'], new IdentifiedEntryProcessor('processed')).then(function () {
             return map.getAll(['4', '5']);
         }).then(function (entries) {
@@ -145,7 +137,6 @@ describe('Entry Processor', function () {
     });
 
     it('executeOnKeys with empty array should return empty array', function () {
-        this.timeout(4000);
         return map.executeOnKeys([], new IdentifiedEntryProcessor('processed')).then(function (entries) {
             return expect(entries).to.have.lengthOf(0);
         });

--- a/test/map/MapLockTest.js
+++ b/test/map/MapLockTest.js
@@ -67,7 +67,6 @@ describe('MapLockTest', function () {
     });
 
     it('should acquire the lock when key owner terminates', function (done) {
-        this.timeout(30000);
         let clientTwo;
         let keyOwner;
         let key;
@@ -78,6 +77,7 @@ describe('MapLockTest', function () {
                 ['hazelcast.client.invocation.timeout.millis']: INVOCATION_TIMEOUT_FOR_TWO
             }
         };
+
         RC.startMember(cluster.id).then(function (m) {
                 keyOwner = m;
                 return Client.newHazelcastClient(clientTwoCfg);

--- a/test/map/MapPartitionAwareTest.js
+++ b/test/map/MapPartitionAwareTest.js
@@ -51,7 +51,6 @@ describe('MapPartitionAwareTest', function () {
 
     before(function () {
         expect(memberCount, 'This test should have at least 2 members.').to.be.at.least(2);
-        this.timeout(30000);
         return RC.createCluster(null, null).then(function (c) {
             cluster = c;
             for (let i = 0; i < memberCount; i++) {
@@ -82,7 +81,6 @@ describe('MapPartitionAwareTest', function () {
     });
 
     it('put', function () {
-        this.timeout(15000);
         return fillMap(map, numOfEntries).then(function (newVal) {
             const promises = members.map(function (member, index) {
                 return RC.executeOnController(cluster.id, getLocalMapStats(index), 1);

--- a/test/map/MapPredicateTest.js
+++ b/test/map/MapPredicateTest.js
@@ -35,7 +35,6 @@ describe('MapPredicateTest', function () {
     }
 
     before(function () {
-        this.timeout(32000);
         return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_identifiedfactory.xml', 'utf8'))
             .then(function (res) {
                 cluster = res;

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -50,7 +50,6 @@ describe('MapProxyTest', function () {
             let map;
 
             before(function () {
-                this.timeout(32000);
                 return createController(nearCacheEnabled).then(function (res) {
                     cluster = res;
                     return RC.startMember(cluster.id);

--- a/test/map/MapStoreTest.js
+++ b/test/map/MapStoreTest.js
@@ -30,7 +30,6 @@ describe('MapStoreTest', function () {
     let map;
 
     before(function () {
-        this.timeout(32000);
         return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_mapstore.xml', 'utf8'))
             .then(function (res) {
                 cluster = res;

--- a/test/map/NearCachedMapStressTest.js
+++ b/test/map/NearCachedMapStressTest.js
@@ -81,7 +81,6 @@ describe('NearCachedMapStress', function () {
     }
 
     it('stress test with put, get and remove', function (done) {
-        this.timeout(120000);
         let map;
         client1.getMap(mapName).then(function (mp) {
             map = mp;

--- a/test/map/NearCachedMapTest.js
+++ b/test/map/NearCachedMapTest.js
@@ -27,11 +27,13 @@ describe('NearCachedMapTest', function () {
     [true, false].forEach(function (invalidateOnChange) {
         describe('invalidate on change=' + invalidateOnChange, function () {
 
-            let cluster, client1, client2;
-            let map1, map2;
+            let cluster;
+            let client1;
+            let client2;
+            let map1;
+            let map2;
 
             before(function () {
-                this.timeout(32000);
                 const cfg = {
                     nearCaches: {
                         'ncc-map': {
@@ -59,7 +61,6 @@ describe('NearCachedMapTest', function () {
             });
 
             beforeEach(function () {
-                this.timeout(10000);
                 return client1.getMap('ncc-map').then(function (mp) {
                     map1 = mp
                     return client2.getMap('ncc-map');

--- a/test/multimap/MultiMapProxyListenersTest.js
+++ b/test/multimap/MultiMapProxyListenersTest.js
@@ -22,13 +22,11 @@ const Util = require('./../Util');
 
 describe("MultiMap Proxy Listener", function () {
 
-    this.timeout(10000);
     let cluster;
     let client;
     let map;
 
     before(function () {
-        this.timeout(10000);
         return RC.createCluster().then(function (response) {
             cluster = response;
             return RC.startMember(cluster.id);
@@ -167,7 +165,6 @@ describe("MultiMap Proxy Listener", function () {
     // Other
 
     it("listens for clear", function (done) {
-        this.timeout(10000);
         const listener = {
             mapCleared: function (mapEvent) {
                 try {
@@ -178,7 +175,6 @@ describe("MultiMap Proxy Listener", function () {
                 } catch (err) {
                     done(err);
                 }
-
             }
         };
 

--- a/test/multimap/MultiMapProxyLockTest.js
+++ b/test/multimap/MultiMapProxyLockTest.js
@@ -29,7 +29,6 @@ describe('MultiMapProxyLockTest', function () {
     let mapTwo;
 
     before(function () {
-        this.timeout(10000);
         return RC.createCluster().then(function (response) {
             cluster = response;
             return RC.startMember(cluster.id);
@@ -67,7 +66,6 @@ describe('MultiMapProxyLockTest', function () {
 
 
     it('locks and unlocks', function () {
-        this.timeout(10000);
         const startTime = Date.now();
         return mapOne.put(1, 2).then(function () {
             return mapOne.lock(1);
@@ -83,7 +81,6 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('unlocks after lease expired', function () {
-        this.timeout(10000);
         const startTime = Date.now();
         return mapOne.lock(1, 1000).then(function () {
             return mapTwo.lock(1);
@@ -94,7 +91,6 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('gives up attempt to lock after timeout is exceeded', function () {
-        this.timeout(10000);
         return mapOne.lock(1).then(function () {
             return mapTwo.tryLock(1, 1000);
         }).then(function (acquired) {
@@ -103,7 +99,6 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('acquires lock before timeout is exceeded', function () {
-        this.timeout(10000);
         const startTime = Date.now();
         return mapOne.lock(1, 1000).then(function () {
             return mapTwo.tryLock(1, 2000);
@@ -115,7 +110,6 @@ describe('MultiMapProxyLockTest', function () {
     });
 
     it('acquires the lock before timeout and unlocks after lease expired', function () {
-        this.timeout(10000);
         const startTime = Date.now();
         return mapOne.lock(1, 1000).then(function () {
             return mapTwo.tryLock(1, 2000, 1000);

--- a/test/multimap/MultiMapProxyTest.js
+++ b/test/multimap/MultiMapProxyTest.js
@@ -27,7 +27,6 @@ describe('MultiMapProxyTest', function () {
     let map;
 
     before(function () {
-        this.timeout(10000);
         return RC.createCluster().then(function (response) {
             cluster = response;
             return RC.startMember(cluster.id);

--- a/test/nearcache/InvalidationMetadataDistortionTest.js
+++ b/test/nearcache/InvalidationMetadataDistortionTest.js
@@ -76,7 +76,6 @@ describe('Invalidation metadata distortion', function () {
 
 
     it('lost invalidation', function (done) {
-        this.timeout(13000);
         let stopTest = false;
         let map;
         const populatePromises = [];

--- a/test/nearcache/LostInvalidationsTest.js
+++ b/test/nearcache/LostInvalidationsTest.js
@@ -23,7 +23,6 @@ const { deferredPromise } = require('../../lib/util/Util');
 const Util = require('../Util');
 
 describe('LostInvalidationTest', function () {
-    this.timeout(30000);
 
     let cluster;
     let client;

--- a/test/nearcache/MigratedDataTest.js
+++ b/test/nearcache/MigratedDataTest.js
@@ -24,10 +24,9 @@ const { deferredPromise } = require('../../lib/util/Util');
 
 describe('MigratedDataTest', function () {
 
-    this.timeout(20000);
-
     let cluster;
-    let member1, member2;
+    let member1;
+    let member2;
     let client;
 
     const mapName = 'ncmap';

--- a/test/nearcache/NearCacheSimpleInvalidationTest.js
+++ b/test/nearcache/NearCacheSimpleInvalidationTest.js
@@ -62,7 +62,6 @@ describe('NearCacheSimpleInvalidationTest', function () {
             });
 
             it('client observes outside invalidations', function () {
-                this.timeout(10000);
                 const entryCount = 1000;
                 let map;
                 return client.getMap(mapName).then(function (mp) {

--- a/test/nearcache/NearCacheTest.js
+++ b/test/nearcache/NearCacheTest.js
@@ -108,7 +108,6 @@ describe('NearCacheTest', function () {
         });
 
         it('expires after maxIdleSeconds', function (done) {
-            this.timeout(4000);
             const rec = new DataRecord(ds('key'), 'value', undefined, 100);
             setTimeout(function () {
                 if (rec.isExpired(1)) {

--- a/test/pncounter/PNCounterConsistencyTest.js
+++ b/test/pncounter/PNCounterConsistencyTest.js
@@ -26,8 +26,6 @@ const { Client, ConsistencyLostError } = require('../../');
 
 describe('PNCounterConsistencyTest', function () {
 
-    this.timeout(10000);
-
     let cluster;
     let client;
 

--- a/test/queue/QueueProxyTest.js
+++ b/test/queue/QueueProxyTest.js
@@ -32,7 +32,6 @@ describe('QueueProxyTest', function () {
     let queue;
 
     before(function () {
-        this.timeout(10000);
         return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_queue.xml', 'utf8'))
             .then(function (response) {
                 cluster = response;

--- a/test/replicatedmap/ReplicatedMapProxyTest.js
+++ b/test/replicatedmap/ReplicatedMapProxyTest.js
@@ -30,7 +30,6 @@ describe('ReplicatedMapProxyTest', function () {
     const ONE_HOUR = 3600000;
 
     before(function () {
-        this.timeout(10000);
         const config = fs.readFileSync(path.join(__dirname, 'hazelcast_replicatedmap.xml'), 'utf8');
         return RC.createCluster(null, config).then(function (response) {
             cluster = response;
@@ -92,7 +91,7 @@ describe('ReplicatedMapProxyTest', function () {
             .then(function (val) {
                 expect(val).to.be.null;
             });
-    }).timeout(5000);
+    });
 
     it('should contain the key', function () {
         return rm.put('key', 'value', ONE_HOUR)

--- a/test/rest_value/RestValueTest.js
+++ b/test/rest_value/RestValueTest.js
@@ -31,7 +31,6 @@ describe('RestValueTest', function () {
     let member;
 
     before(function () {
-        this.timeout(32000);
         return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_rest.xml', 'utf8'))
             .then(c => {
                 cluster = c;

--- a/test/ringbuffer/RingbufferProxyTest.js
+++ b/test/ringbuffer/RingbufferProxyTest.js
@@ -30,7 +30,6 @@ describe('RingbufferProxyTest', function () {
     let limitedCapacityRb;
 
     before(async function () {
-        this.timeout(10000);
         const config = fs.readFileSync(__dirname + '/hazelcast_ringbuffer.xml', 'utf8');
         cluster = await RC.createCluster(null, config);
         await RC.startMember(cluster.id);

--- a/test/serialization/BinaryCompatibilityTest.js
+++ b/test/serialization/BinaryCompatibilityTest.js
@@ -138,15 +138,14 @@ describe('BinaryCompatibilityTest', function () {
             versions.forEach(function (version) {
                 isBigEndianValues.forEach(function (isBigEndian) {
                     it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version, function () {
-                        this.timeout(10000);
                         const key = createObjectKey(varName, version, isBigEndian);
                         const service = createSerializationService(isBigEndian, 'integer');
                         const deserialized = service.toObject(dataMap[key]);
                         expectAlmostEqual(deserialized, object);
                     });
+
                     if (!ReferenceObjects.skipOnSerialize[varName]) {
                         it(varName + '-' + convertEndiannesToByteOrder(isBigEndian) + '-' + version + ' serialize deserialize', function () {
-                            this.timeout(10000);
                             const service = createSerializationService(isBigEndian, stripArticle(varName).toLowerCase());
                             const data = service.toData(object);
                             const deserialized = service.toObject(data);

--- a/test/set/SetProxyTest.js
+++ b/test/set/SetProxyTest.js
@@ -27,7 +27,6 @@ describe('SetProxyTest', function () {
     let setInstance;
 
     before(function () {
-        this.timeout(10000);
         return RC.createCluster().then(function (response) {
             cluster = response;
             return RC.startMember(cluster.id);
@@ -156,7 +155,6 @@ describe('SetProxyTest', function () {
     });
 
     it('listens for added entry', function (done) {
-        this.timeout(5000);
         setInstance.addItemListener({
             itemAdded: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -173,7 +171,6 @@ describe('SetProxyTest', function () {
     });
 
     it('listens for added and removed entry', function (done) {
-        this.timeout(5000);
         setInstance.addItemListener({
             itemAdded: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -198,7 +195,6 @@ describe('SetProxyTest', function () {
     });
 
     it('listens for removed entry', function (done) {
-        this.timeout(5000);
         setInstance.addItemListener({
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');
@@ -217,7 +213,6 @@ describe('SetProxyTest', function () {
     });
 
     it('remove entry listener', function () {
-        this.timeout(5000);
         return setInstance.addItemListener({
             itemRemoved: function (itemEvent) {
                 expect(itemEvent.name).to.be.equal('test');

--- a/test/ssl/ClientSSLAuthenticationTest.js
+++ b/test/ssl/ClientSSLAuthenticationTest.js
@@ -106,10 +106,6 @@ describe('ClientSSLAuthenticationTest', function () {
 
         describe(title, function () {
 
-            beforeEach(function () {
-                this.timeout(10000);
-            });
-
             afterEach(function () {
                 return RC.terminateCluster(cluster.id);
             });

--- a/test/ssl/ClientSSLTest.js
+++ b/test/ssl/ClientSSLTest.js
@@ -26,8 +26,6 @@ const { markEnterprise } = require('../Util');
 
 describe('ClientSSLTest', function () {
 
-    this.timeout(20000);
-
     let cluster;
     let client;
     let serverConfig;

--- a/test/topic/ReliableTopicTest.js
+++ b/test/topic/ReliableTopicTest.js
@@ -25,7 +25,6 @@ const { ReliableTopicMessage } = require('../../lib/proxy/topic/ReliableTopicMes
 
 describe('ReliableTopicTest', function () {
 
-    this.timeout(40000);
     let cluster;
     let clientOne;
     let clientTwo;
@@ -57,7 +56,6 @@ describe('ReliableTopicTest', function () {
     }
 
     before(async function () {
-        this.timeout(40000);
         const memberConfig = fs.readFileSync(__dirname + '/hazelcast_topic.xml', 'utf8');
         cluster = await RC.createCluster(null, memberConfig);
         await RC.startMember(cluster.id);


### PR DESCRIPTION
Backport of #719 (note: as `master` uses async/await syntax for tests, it's not a 1-to-1 backport)