### PR TITLE
Document requirements for external client public address discovery

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1046,6 +1046,8 @@ backups, this property specifies how long (in milliseconds) the invocation waits
 
 ## 5.8. External Client Public Address Discovery
 
+> **NOTE: This feature requires Hazelcast IMDG 4.2 or higher version.**
+
 When you set up a Hazelcast cluster in the Cloud (AWS, Azure, GCP, Kubernetes) and would like to use it from outside the Cloud network, the client needs to communicate with all cluster members via their public IP addresses. Whenever Hazelcast cluster members are able to resolve their own public external IP addresses, they pass this information to the client. As a result, the client can use public addresses for communication, if it cannot access members via private IPs.
 
 Hazelcast Node.js client has a built-in mechanism to detect such situation. When the client starts, it executes the following steps:


### PR DESCRIPTION
Follow-up for #703

Context: the member-side part of this feature [won't be backported](https://github.com/hazelcast/hazelcast/pull/17895#issuecomment-745282885) to v4.0 and/or v4.1, so it's worth mentioning the required cluster version in the ref manual

cc @burakcelebi 