### PR TITLE
Increase automated pipelining threshold to 64KB

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2757,7 +2757,7 @@ You can configure automated operation pipelining with entries of the `properties
 
 - `hazelcast.client.autopipelining.enabled`: Default value is `true`. Turns automated pipelining feature on/off. If your application does only writes operations, like `IMap.set()`, you can try disabling automated pipelining to get a slightly better throughtput.
 
-- `hazelcast.client.autopipelining.threshold.bytes`: Default value is `8192` bytes. This is the coalescing threshold for the internal queue used by automated pipelining. Once the total size of operation payloads taken from the queue reaches this value during batch preparation, these operations are written to the socket. Notice that automated pipelining will still send operations if their total size is smaller than the threshold and there are no more operations in the internal queue.
+- `hazelcast.client.autopipelining.threshold.bytes`: Default value is `65536` bytes (64 KB). This is the coalescing threshold for the internal queue used by automated pipelining. Once the total size of operation payloads taken from the queue reaches this value during batch preparation, these operations are written to the socket. Notice that automated pipelining will still send operations if their total size is smaller than the threshold and there are no more operations in the internal queue.
 
 ## 8.9. Monitoring and Logging
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -171,7 +171,7 @@ export class ClientConfigImpl implements ClientConfig {
         'hazelcast.invalidation.min.reconciliation.interval.seconds': 30,
         'hazelcast.logging.level': 'INFO',
         'hazelcast.client.autopipelining.enabled': true,
-        'hazelcast.client.autopipelining.threshold.bytes': 8192,
+        'hazelcast.client.autopipelining.threshold.bytes': 65536,
         'hazelcast.client.socket.no.delay': true,
         'hazelcast.client.shuffle.member.list': true,
         'hazelcast.client.operation.backup.timeout.millis': 5000,


### PR DESCRIPTION
Closes #730

The default threshold (coalescing buffer size) is set to 8 KB, which is significantly smaller than Java client and member's setting (128 KB). This PR changes the default to a more sane value (64 KB), which may be valuable for users who work with relatively large payloads.