### PR TITLE
Reset member list version when registering cluster view listener

### DIFF
--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -158,8 +158,8 @@ export class ClusterService implements Cluster {
 
     waitForInitialMemberList(): Promise<void> {
         return timedPromise(this.initialListFetched.promise, INITIAL_MEMBERS_TIMEOUT_IN_MILLIS)
-            .catch((error) => {
-                return Promise.reject(new IllegalStateError('Could not get initial member list from the cluster!', error));
+            .catch((err) => {
+                return Promise.reject(new IllegalStateError('Could not get initial member list from the cluster!', err));
             });
     }
 

--- a/src/listener/ClusterViewListenerService.ts
+++ b/src/listener/ClusterViewListenerService.ts
@@ -75,6 +75,7 @@ export class ClusterViewListenerService {
         invocation.handler = handler;
 
         this.logger.trace('ClusterViewListenerService', `Register attempt of cluster view handler to ${connection}`);
+        this.clusterService.clearMemberListVersion();
         this.client.getInvocationService().invokeUrgent(invocation)
             .then(() => {
                 this.logger.trace('ClusterViewListenerService', `Registered cluster view handler to ${connection}`);
@@ -106,5 +107,4 @@ export class ClusterViewListenerService {
                 });
         };
     }
-
 }


### PR DESCRIPTION
Refs: https://github.com/hazelcast/hazelcast/pull/17147
Refs: https://github.com/hazelcast/hazelcast-remote-controller/issues/30
Fixes: #732

As remote controller doesn't support split brain emulation, no tests are added.