### PR TITLE
Make sure to close socket on connection timeout

### DIFF
--- a/src/discovery/HazelcastCloudDiscovery.ts
+++ b/src/discovery/HazelcastCloudDiscovery.ts
@@ -41,8 +41,6 @@ export class HazelcastCloudDiscovery {
 
     private readonly endpointUrl: string;
     private readonly connectionTimeoutMillis: number;
-    // only used in tests
-    private port: number;
 
     constructor(endpointUrl: string, connectionTimeoutMillis: number) {
         this.endpointUrl = endpointUrl;
@@ -63,12 +61,13 @@ export class HazelcastCloudDiscovery {
 
         const url = URL.parse(this.endpointUrl);
         const endpointUrlOptions: RequestOptions = {
-            host: url.host,
+            host: url.hostname,
             path: url.path,
             timeout: this.connectionTimeoutMillis
         };
-        if (this.port !== undefined) {
-            endpointUrlOptions.port = this.port;
+        // non-default port is used in tests
+        if (url.port != null) {
+            endpointUrlOptions.port = url.port;
         }
 
         let dataAsAString = '';
@@ -107,10 +106,5 @@ export class HazelcastCloudDiscovery {
         }
 
         return privateToPublicAddresses;
-    }
-
-    // only used in tests
-    private overridePort(port: number) {
-        this.port = port;
     }
 }

--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -272,20 +272,16 @@ export class ClientConnectionManager extends EventEmitter {
             .then(() => clientConnection.registerResponseCallback(processResponseCallback))
             .then(() => this.authenticateOnCluster(clientConnection))
             .then((conn) => connectionResolver.resolve(conn))
-            .catch((error) => connectionResolver.reject(error));
+            .catch((err) => {
+                // make sure to close connection on errors
+                if (clientConnection != null) {
+                    clientConnection.close(null, err);
+                }
+                connectionResolver.reject(err);
+            });
 
-        return timedPromise(
-            connectionResolver.promise,
-            this.connectionTimeoutMillis,
-            new HazelcastError('Connection timed out to address ' + address.toString())
-        ).catch((err) => {
-            // make sure to close connection on errors
-            if (clientConnection != null) {
-                clientConnection.close(null, err);
-            }
-            throw err;
-        })
-        .finally(() => this.pendingConnections.delete(addressKey));
+        return connectionResolver.promise
+            .finally(() => this.pendingConnections.delete(addressKey));
     }
 
     getRandomConnection(): ClientConnection {

--- a/test/ConnectionManagerTest.js
+++ b/test/ConnectionManagerTest.js
@@ -27,7 +27,6 @@ const RC = require('./RC');
 const { Client, IllegalStateError } = require('../');
 const { AddressImpl } = require('../lib/core/Address');
 const { promiseWaitMilliseconds } = require('./Util');
-const { ClientConnection } = require('../lib/network/ClientConnection');
 
 describe('ConnectionManagerTest', function () {
 
@@ -84,27 +83,6 @@ describe('ConnectionManagerTest', function () {
             client = cl;
             return client.getConnectionManager().getOrConnect(new AddressImpl('localhost', 9999));
         }).should.eventually.be.rejected;
-    });
-
-    it('closes connection after initial communication timeout', function () {
-        const timeoutTime = 1000;
-        startUnresponsiveServer(9999);
-        let closeConnSpy;
-
-        return Client.newHazelcastClient({
-            clusterName: cluster.id,
-            network: {
-                connectionTimeout: timeoutTime
-            }
-        }).then(function (cl) {
-            client = cl;
-            closeConnSpy = sandbox.spy(ClientConnection.prototype, 'close');
-            return client.getConnectionManager().getOrConnect(new AddressImpl('localhost', 9999));
-        }).catch(function () {
-            // no-op
-        }).then(function () {
-            expect(closeConnSpy.calledOnce).to.be.true;
-        });
     });
 
     it('destroys socket after connection timeout', function () {

--- a/test/ConnectionManagerTest.js
+++ b/test/ConnectionManagerTest.js
@@ -20,11 +20,14 @@ chai.should();
 chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 const sinon = require('sinon');
+const sandbox = sinon.createSandbox();
 const net = require('net');
 
-const Controller = require('./RC');
+const RC = require('./RC');
 const { Client, IllegalStateError } = require('../');
 const { AddressImpl } = require('../lib/core/Address');
+const { promiseWaitMilliseconds } = require('./Util');
+const { ClientConnection } = require('../lib/network/ClientConnection');
 
 describe('ConnectionManagerTest', function () {
 
@@ -32,9 +35,9 @@ describe('ConnectionManagerTest', function () {
     let testend, server;
 
     before(function () {
-        return Controller.createCluster(null, null).then(function (cl) {
+        return RC.createCluster(null, null).then(function (cl) {
             cluster = cl;
-            return Controller.startMember(cluster.id);
+            return RC.startMember(cluster.id);
         });
     });
 
@@ -43,6 +46,7 @@ describe('ConnectionManagerTest', function () {
     });
 
     afterEach(function () {
+        sandbox.restore();
         testend = true;
         stopUnresponsiveServer();
         if (client != null) {
@@ -51,7 +55,7 @@ describe('ConnectionManagerTest', function () {
     });
 
     after(function () {
-        return Controller.terminateCluster(cluster.id);
+        return RC.terminateCluster(cluster.id);
     });
 
     function startUnresponsiveServer(port) {
@@ -70,6 +74,7 @@ describe('ConnectionManagerTest', function () {
     it('gives up connecting after timeout', function () {
         const timeoutTime = 1000;
         startUnresponsiveServer(9999);
+
         return Client.newHazelcastClient({
             clusterName: cluster.id,
             network: {
@@ -79,6 +84,51 @@ describe('ConnectionManagerTest', function () {
             client = cl;
             return client.getConnectionManager().getOrConnect(new AddressImpl('localhost', 9999));
         }).should.eventually.be.rejected;
+    });
+
+    it('closes connection after initial communication timeout', function () {
+        const timeoutTime = 1000;
+        startUnresponsiveServer(9999);
+        let closeConnSpy;
+
+        return Client.newHazelcastClient({
+            clusterName: cluster.id,
+            network: {
+                connectionTimeout: timeoutTime
+            }
+        }).then(function (cl) {
+            client = cl;
+            closeConnSpy = sandbox.spy(ClientConnection.prototype, 'close');
+            return client.getConnectionManager().getOrConnect(new AddressImpl('localhost', 9999));
+        }).catch(function () {
+            // no-op
+        }).then(function () {
+            expect(closeConnSpy.calledOnce).to.be.true;
+        });
+    });
+
+    it('destroys socket after connection timeout', function () {
+        const timeoutTime = 1000;
+        let socketStub;
+
+        return Client.newHazelcastClient({
+            clusterName: cluster.id,
+            network: {
+                connectionTimeout: timeoutTime
+            }
+        }).then(function (cl) {
+            client = cl;
+
+            // emulate connection timeout with a stub socket
+            socketStub = sandbox.stub(net.Socket.prototype);
+            sandbox.stub(net, 'connect').returns(socketStub);
+
+            return client.getConnectionManager().getOrConnect(new AddressImpl('localhost', 9999));
+        }).catch(() => {
+            return promiseWaitMilliseconds(100);
+        }).then(function () {
+            expect(socketStub.destroy.callCount).to.be.equal(1);
+        });
     });
 
     it('does not give up when timeout=0', function (done) {
@@ -132,7 +182,7 @@ describe('ConnectionManagerTest', function () {
         const conn = await client.getConnectionManager().getOrConnect(new AddressImpl('localhost', 5701));
         expect(conn.isAlive()).to.be.true;
 
-        const closeSpy = sinon.spy(conn, 'close');
+        const closeSpy = sandbox.spy(conn, 'close');
         const err = new Error('boom');
         err.code = 'ECONNRESET';
         conn.socket.emit('error', err);

--- a/test/discovery/HazelcastCloudDiscoveryTest.js
+++ b/test/discovery/HazelcastCloudDiscoveryTest.js
@@ -80,8 +80,7 @@ describe('HazelcastCloudDiscoveryTest', function () {
         startUnresponsiveServer(9999);
 
         const connectionTimeoutMs = 100;
-        const discovery = new HazelcastCloudDiscovery('https://localhost', connectionTimeoutMs);
-        discovery.overridePort(9999);
+        const discovery = new HazelcastCloudDiscovery('https://localhost:9999', connectionTimeoutMs);
 
         await expect(discovery.discoverNodes()).to.be.rejectedWith(HazelcastError);
     });

--- a/test/discovery/HazelcastCloudProviderTest.js
+++ b/test/discovery/HazelcastCloudProviderTest.js
@@ -15,8 +15,9 @@
  */
 'use strict';
 
+const { expect } = require('chai');
 const sinon = require('sinon');
-const expect = require('chai').expect;
+const sandbox = sinon.createSandbox();
 
 const { LogLevel } = require('../../lib/');
 const { IllegalStateError } = require('../../');
@@ -40,16 +41,13 @@ describe('HazelcastCloudProviderTest', function () {
     beforeEach(() => {
         const logger = new LoggingService(null, LogLevel.INFO).getLogger();
         hazelcastCloudDiscovery = new HazelcastCloudDiscovery();
-        sinon.stub(HazelcastCloudDiscovery.prototype, 'discoverNodes').callsFake(() => Promise.resolve(expectedAddresses));
+        sandbox.stub(HazelcastCloudDiscovery.prototype, 'discoverNodes').callsFake(() => Promise.resolve(expectedAddresses));
 
         provider = new HazelcastCloudAddressProvider(hazelcastCloudDiscovery, null, logger);
     });
 
     afterEach(function () {
-        if (HazelcastCloudDiscovery.prototype.discoverNodes.restore
-            && HazelcastCloudDiscovery.prototype.discoverNodes.restore.sinon) {
-            HazelcastCloudDiscovery.prototype.discoverNodes.restore();
-        }
+        sandbox.restore();
     });
 
     it('loadAddresses', function () {
@@ -60,7 +58,7 @@ describe('HazelcastCloudProviderTest', function () {
 
     it('loadAddresses_whenErrorIsThrown', function () {
         HazelcastCloudDiscovery.prototype.discoverNodes.restore();
-        sinon.stub(HazelcastCloudDiscovery.prototype, 'discoverNodes').callsFake(function () {
+        sandbox.stub(HazelcastCloudDiscovery.prototype, 'discoverNodes').callsFake(function () {
             return Promise.reject(new IllegalStateError('Expected exception'));
         });
 
@@ -99,7 +97,7 @@ describe('HazelcastCloudProviderTest', function () {
 
     it('refresh_whenException_thenLogWarning', function () {
         HazelcastCloudDiscovery.prototype.discoverNodes.restore();
-        sinon.stub(HazelcastCloudDiscovery.prototype, 'discoverNodes').callsFake(function () {
+        sandbox.stub(HazelcastCloudDiscovery.prototype, 'discoverNodes').callsFake(function () {
             return Promise.reject(new IllegalStateError('Expected exception'));
         });
         provider.refresh();


### PR DESCRIPTION
Closes: #737

Connection manager was not closing the underlying connection and socket in case of connection timeout. This could potentially lead to socket leaks.

Also includes the following:
* Fix request timeout handling in `HazelcastCloudDiscovery`. The [`timeout` event](https://nodejs.org/api/http.html#http_event_timeout) wasn't handled correctly
* Some minor improvements in tests.