### PR TITLE
Change level for cluster failover logging

### DIFF
--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -433,7 +433,7 @@ export class ClientConnectionManager extends EventEmitter {
 
     private cleanupAndTryNextCluster(nextCtx: CandidateClusterContext): Promise<boolean> {
         this.client.onClusterChange();
-        this.logger.warn('ConnectionManager', 'Trying to connect to next cluster: '
+        this.logger.info('ConnectionManager', 'Trying to connect to next cluster: '
             + nextCtx.clusterName);
         this.switchingToNextCluster = true;
         return this.doConnectToCandidateCluster(nextCtx)


### PR DESCRIPTION
Java client has the same log message under `INFO`, so that users who set logging level to `INFO` will see the cluster name.