### PR TITLE
Increase cluster connect timeout to 2 mins

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1120,7 +1120,7 @@ The following are configuration element descriptions:
 * `initialBackoffMillis`: Specifies how long to wait (backoff), in milliseconds, after the first failure before retrying. Its default value is `1000` ms. It must be non-negative.
 * `maxBackoffMillis`: Specifies the upper limit for the backoff in milliseconds. Its default value is `30000` ms. It must be non-negative.
 * `multiplier`: Factor to multiply the backoff after a failed retry. Its default value is `1`. It must be greater than or equal to `1`.
-* `clusterConnectTimeoutMillis`: Timeout value in milliseconds for the client to give up to connect to the current cluster. Its default value is `20000`.
+* `clusterConnectTimeoutMillis`: Timeout value in milliseconds for the client to give up to connect to the current cluster. Its default value is `120000` (2 minutes).
 * `jitter`: Specifies by how much to randomize backoffs. Its default value is `0`. It must be in range `0` to `1`.
 
 A pseudo-code is as follows:

--- a/src/config/ConnectionRetryConfig.ts
+++ b/src/config/ConnectionRetryConfig.ts
@@ -35,8 +35,8 @@ export interface ConnectionRetryConfig {
 
     /**
      * Defines timeout value in milliseconds for the client to give up a connection
-     * attempt to the cluster. Must be non-negative. By default, set to `20000`
-     * (20 seconds).
+     * attempt to the cluster. Must be non-negative. By default, set to `120000`
+     * (2 minutes).
      */
     clusterConnectTimeoutMillis?: number;
 
@@ -65,7 +65,7 @@ export class ConnectionRetryConfigImpl implements ConnectionRetryConfig {
 
     initialBackoffMillis = 1000;
     maxBackoffMillis = 30000;
-    clusterConnectTimeoutMillis = 20000;
+    clusterConnectTimeoutMillis = 120000;
     multiplier = 1;
     jitter = 0;
 


### PR DESCRIPTION
Refs: https://github.com/hazelcast/hazelcast/pull/18019

The old default timeout was 20 seconds. The change is done for environments like k8s where an IP resolution/system restart could take around a minute. We don't want a client to shutdown in such cases, and we also want this to be out-of-the-box behavior.