### PR TITLE
Fix RepetitionTaskTest flakiness

### DIFF
--- a/test/unit/RepetitionTaskTest.js
+++ b/test/unit/RepetitionTaskTest.js
@@ -52,7 +52,7 @@ describe('RepetitionTaskTest', function () {
         await TestUtil.promiseWaitMilliseconds(200);
         Util.cancelRepetitionTask(task);
         expect(counter).to.be.equal(2);
-        await TestUtil.promiseWaitMilliseconds(50);
+        await TestUtil.promiseWaitMilliseconds(75);
         expect(counter).to.be.equal(2);
     });
 

--- a/test/unit/RepetitionTaskTest.js
+++ b/test/unit/RepetitionTaskTest.js
@@ -23,45 +23,41 @@ describe('RepetitionTaskTest', function () {
 
     it('should be cancelled before timeout', async function () {
         let counter = 0;
-        const task = Util.scheduleWithRepetition(function () {
-            counter++;
-        }, 50, 75);
+        const task = Util.scheduleWithRepetition(() => counter++, 50, 100);
 
-        await TestUtil.promiseWaitMilliseconds(40);
+        await TestUtil.promiseWaitMilliseconds(25);
         Util.cancelRepetitionTask(task);
         expect(counter).to.be.equal(0);
-        await TestUtil.promiseWaitMilliseconds(130);
+        await TestUtil.promiseWaitMilliseconds(150);
         expect(counter).to.be.equal(0);
     });
 
     it('should be cancelled after timeout', async function () {
         let counter = 0;
-        const task = Util.scheduleWithRepetition(function () {
+        const task = Util.scheduleWithRepetition(() => {
             counter++;
-        }, 50, 75);
+        }, 50, 100);
 
-        await TestUtil.promiseWaitMilliseconds(60);
+        await TestUtil.promiseWaitMilliseconds(100);
         Util.cancelRepetitionTask(task);
         expect(counter).to.be.equal(1);
-        await TestUtil.promiseWaitMilliseconds(75);
+        await TestUtil.promiseWaitMilliseconds(100);
         expect(counter).to.be.equal(1);
     });
 
     it('should be cancelled after interval', async function () {
         let counter = 0;
-        const task = Util.scheduleWithRepetition(function () {
-            counter++;
-        }, 50, 75);
+        const task = Util.scheduleWithRepetition(() => counter++, 50, 100);
 
-        await TestUtil.promiseWaitMilliseconds(130);
+        await TestUtil.promiseWaitMilliseconds(200);
         Util.cancelRepetitionTask(task);
         expect(counter).to.be.equal(2);
-        await TestUtil.promiseWaitMilliseconds(75);
+        await TestUtil.promiseWaitMilliseconds(50);
         expect(counter).to.be.equal(2);
     });
 
     it('should not throw when cancelled twice', function () {
-        const task = Util.scheduleWithRepetition(() => { }, 100, 200);
+        const task = Util.scheduleWithRepetition(() => {}, 100, 200);
 
         Util.cancelRepetitionTask(task);
         Util.cancelRepetitionTask(task);


### PR DESCRIPTION
Increases timeouts in order to fix the following `RepetitionTaskTest` flakiness on Windows CI machine:
http://jenkins.hazelcast.com/job/NodeJS-12-windows-master/71/testReport/junit/(root)/should%20be%20cancelled%20after%20interval/RepetitionTaskTest_should_be_cancelled_after_interval/
```
should be cancelled after interval.RepetitionTaskTest should be cancelled after interval (from RepetitionTaskTest)

Error Message
expected 1 to equal 2
Stacktrace
AssertionError: expected 1 to equal 2
    at Context.<anonymous> (test\unit\RepetitionTaskTest.js:58:31)
    at runNextTicks (internal/process/task_queues.js:62:5)
    at processTimers (internal/timers.js:489:9)
```