### PR TITLE
[BACKPORT] Fix RepetitionTaskTest flakiness

### DIFF
--- a/test/RepetitionTaskTest.js
+++ b/test/RepetitionTaskTest.js
@@ -25,13 +25,13 @@ describe('Repetition Task', function () {
         var counter = 0;
         var task = Util.scheduleWithRepetition(function () {
             counter++;
-        }, 50, 75);
+        }, 50, 100);
 
-        return TestUtil.promiseWaitMilliseconds(40).then(function () {
+        return TestUtil.promiseWaitMilliseconds(25).then(function () {
             Util.cancelRepetitionTask(task);
             expect(counter).to.be.equal(0);
         }).then(function () {
-            return TestUtil.promiseWaitMilliseconds(130)
+            return TestUtil.promiseWaitMilliseconds(150)
         }).then(function () {
             expect(counter).to.be.equal(0);
         });
@@ -41,13 +41,13 @@ describe('Repetition Task', function () {
         var counter = 0;
         var task = Util.scheduleWithRepetition(function () {
             counter++;
-        }, 50, 75);
+        }, 50, 100);
 
-        return TestUtil.promiseWaitMilliseconds(60).then(function () {
+        return TestUtil.promiseWaitMilliseconds(100).then(function () {
             Util.cancelRepetitionTask(task);
             expect(counter).to.be.equal(1);
         }).then(function () {
-            return TestUtil.promiseWaitMilliseconds(75)
+            return TestUtil.promiseWaitMilliseconds(100)
         }).then(function () {
             expect(counter).to.be.equal(1);
         });
@@ -57,9 +57,9 @@ describe('Repetition Task', function () {
         var counter = 0;
         var task = Util.scheduleWithRepetition(function () {
             counter++;
-        }, 50, 75);
+        }, 50, 100);
 
-        return TestUtil.promiseWaitMilliseconds(130).then(function () {
+        return TestUtil.promiseWaitMilliseconds(200).then(function () {
             Util.cancelRepetitionTask(task);
             expect(counter).to.be.equal(2);
         }).then(function () {


### PR DESCRIPTION
Backport of #746

Fixes the following RepetitionTaskTest flakiness on 3.12.x (windows):
http://jenkins.hazelcast.com/job/NodeJS-4-3.12.x-windows/224/testReport/junit/(root)/should%20be%20cancelled%20after%20interval/Repetition_Task_should_be_cancelled_after_interval/