### PR TITLE
Add missing registration for default list serializers

### DIFF
--- a/src/serialization/SerializationService.ts
+++ b/src/serialization/SerializationService.ts
@@ -26,6 +26,7 @@ import * as Util from '../util/Util';
 import {Data, DataInput, DataOutput} from './Data';
 import {Serializer, IdentifiedDataSerializableFactory} from './Serializable';
 import {
+    ArrayListSerializer,
     BooleanArraySerializer,
     BooleanSerializer,
     ByteArraySerializer,
@@ -43,6 +44,7 @@ import {
     IntegerSerializer,
     JavaClassSerializer,
     JsonSerializer,
+    LinkedListSerializer,
     LongArraySerializer,
     LongSerializer,
     NullSerializer,
@@ -266,6 +268,8 @@ export class SerializationServiceV1 implements SerializationService {
         this.registerSerializer('stringArray', new StringArraySerializer());
         this.registerSerializer('javaClass', new JavaClassSerializer());
         this.registerSerializer('floatArray', new FloatArraySerializer());
+        this.registerSerializer('arrayList', new ArrayListSerializer());
+        this.registerSerializer('linkedList', new LinkedListSerializer());
         this.registerSerializer('uuid', new UuidSerializer());
         this.registerIdentifiedFactories();
         this.registerSerializer('!portable', new PortableSerializer(this.serializationConfig));

--- a/test/integration/serialization/DefaultSerializersLiveTest.js
+++ b/test/integration/serialization/DefaultSerializersLiveTest.js
@@ -152,4 +152,32 @@ describe('DefaultSerializersLiveTest', function () {
         const result = JSON.parse(response.result);
         expect(result).to.equal(uuid.toString());
     });
+
+    it('should deserialize ArrayList', async function () {
+        const script = 'var map = instance_0.getMap("' + map.getName() + '");\n' +
+            'var list = new java.util.ArrayList();\n' +
+            'list.add(1);\n' +
+            'list.add(2);\n' +
+            'list.add(3);\n' +
+            'map.set("key", list);\n';
+
+        await RC.executeOnController(cluster.id, script, 1);
+
+        const actualValue = await map.get('key');
+        expect(actualValue).to.deep.equal([1, 2, 3]);
+    });
+
+    it('should deserialize LinkedList', async function () {
+        const script = 'var map = instance_0.getMap("' + map.getName() + '");\n' +
+            'var list = new java.util.LinkedList();\n' +
+            'list.add(1);\n' +
+            'list.add(2);\n' +
+            'list.add(3);\n' +
+            'map.set("key", list);\n';
+
+        await RC.executeOnController(cluster.id, script, 1);
+
+        const actualValue = await map.get('key');
+        expect(actualValue).to.deep.equal([1, 2, 3]);
+    });
 });


### PR DESCRIPTION
Fixes #798

Serializers for `j.u.ArrayList` and `j.u.LinkedList` were present, but they weren't registered as default serializers