### PR TITLE
Fix pattern with space in test runner

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -155,7 +155,7 @@ const shutdownRC = () => {
 if (process.argv.length === 3 || process.argv.length === 4) {
     if (process.argv[2] === 'unit') {
         if (process.argv.length === 4) {
-            testCommand = `node node_modules/mocha/bin/mocha --recursive -g ${process.argv[3]} "test/unit/**/*.js"`;
+            testCommand = `node node_modules/mocha/bin/mocha --recursive -g "${process.argv[3]}" "test/unit/**/*.js"`;
         } else {
             testCommand = 'node node_modules/mocha/bin/mocha "test/unit/**/*.js"';
         }
@@ -163,14 +163,14 @@ if (process.argv.length === 3 || process.argv.length === 4) {
     } else if (process.argv[2] === 'integration') {
         if (process.argv.length === 4) {
             testCommand = 'node node_modules/mocha/bin/mocha --recursive -g ' +
-                          `${process.argv[3]} "test/integration/**/*.js"`;
+                          `"${process.argv[3]}" "test/integration/**/*.js"`;
         } else {
             testCommand = 'node node_modules/mocha/bin/mocha "test/integration/**/*.js"';
         }
         testType = 'integration';
     } else if (process.argv[2] === 'all') {
         if (process.argv.length === 4) {
-            testCommand = `node node_modules/mocha/bin/mocha --recursive -g ${process.argv[3]} "test/**/*.js"`;
+            testCommand = `node node_modules/mocha/bin/mocha --recursive -g "${process.argv[3]}" "test/**/*.js"`;
         } else {
             testCommand = 'node node_modules/mocha/bin/mocha "test/**/*.js"';
         }


### PR DESCRIPTION
* In #803, I thought that on windows quotes cause patterns to be interpreted differently, e.g(just on windows):
  * matches tests with backup: `npm run test:integration backup`
  * does not match tests with backup: `npm run test:integration "backup"`

* Now I realized this is not the case. The two commands above are equivalent on windows. Somehow, a command I tried was failed and in #803 I concluded not to put quotes around pattern argument in mocha command.
* This pr adds the quotes again. Currently, `npm run test:integration "should create AtomicLong with respect to given CP group"` fails to match pattern with this output:
```
Running tests... Test type: integration, Test command: node node_modules/mocha/bin/mocha --recursive -g should create AtomicLong with respect to given CP group "test/integration/**/*.js"
Warning: Cannot find any files matching pattern "create"
Warning: Cannot find any files matching pattern "AtomicLong"
Warning: Cannot find any files matching pattern "with"
Warning: Cannot find any files matching pattern "respect"
Warning: Cannot find any files matching pattern "to"
Warning: Cannot find any files matching pattern "given"
Warning: Cannot find any files matching pattern "CP"
Warning: Cannot find any files matching pattern "group"


  ClientBackupAcksTest


```
To be sure, I tested these commands on both linux and windows:

* `npm run test:integration "should create AtomicLong with respect to given CP group"` runs single test with the description in pattern.
* `npm run test:integration AtomicLongTest ` runs 28 test in AtomicLongTest suite. 
* `npm run test:integration "AtomicLongTest" ` runs 28 test in AtomicLongTest suite. 
