### PR TITLE
Using root level hooks to destroy rc connection

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,6 +1,5 @@
 {
     "timeout": 120000,
-    "exit": true,
     "exclude": [
         "test/soak_test/**",
         "test/user_code/**"

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,5 +3,6 @@
     "exclude": [
         "test/soak_test/**",
         "test/user_code/**"
-    ]
+    ],
+    "require": "test/hooks.js"
 }

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -162,25 +162,24 @@ if (process.argv.length === 3 || process.argv.length === 4) {
         testType = 'unit';
     } else if (process.argv[2] === 'integration') {
         if (process.argv.length === 4) {
-            testCommand = 'node node_modules/mocha/bin/mocha --require test/hooks.js --recursive -g ' +
+            testCommand = 'node node_modules/mocha/bin/mocha --recursive -g ' +
                           `${process.argv[3]} "test/integration/**/*.js"`;
         } else {
-            testCommand = 'node node_modules/mocha/bin/mocha --require test/hooks.js "test/integration/**/*.js"';
+            testCommand = 'node node_modules/mocha/bin/mocha "test/integration/**/*.js"';
         }
         testType = 'integration';
     } else if (process.argv[2] === 'all') {
         if (process.argv.length === 4) {
-            testCommand = `node node_modules/mocha/bin/mocha --require test/hooks.js --recursive -g ${process.argv[3]}`
-                        + '"test/**/*.js"';
+            testCommand = `node node_modules/mocha/bin/mocha --recursive -g ${process.argv[3]} "test/**/*.js"`;
         } else {
-            testCommand = 'node node_modules/mocha/bin/mocha --require test/hooks.js "test/**/*.js"';
+            testCommand = 'node node_modules/mocha/bin/mocha "test/**/*.js"';
         }
         testType = 'all';
     } else if (process.argv[2] === 'startrc') {
         runTests = false;
     } else if (process.argv[2] === 'coverage') {
-        testCommand = 'node node_modules/nyc/bin/nyc node_modules/mocha/bin/_mocha --require test/hooks.js '
-                    + '"test/**/*.js" -- --reporter-options mochaFile=report.xml --reporter mocha-junit-reporter';
+        testCommand = 'node node_modules/nyc/bin/nyc node_modules/mocha/bin/_mocha "test/**/*.js" -- '
+                    + '--reporter-options mochaFile=report.xml --reporter mocha-junit-reporter';
         testType = 'coverage';
     } else {
         throw 'Operation type can be one of "unit", "integration", "all", "startrc"';

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -162,24 +162,25 @@ if (process.argv.length === 3 || process.argv.length === 4) {
         testType = 'unit';
     } else if (process.argv[2] === 'integration') {
         if (process.argv.length === 4) {
-            testCommand = 'node node_modules/mocha/bin/mocha --recursive -g ' +
+            testCommand = 'node node_modules/mocha/bin/mocha --require test/hooks.js --recursive -g ' +
                           `${process.argv[3]} "test/integration/**/*.js"`;
         } else {
-            testCommand = 'node node_modules/mocha/bin/mocha "test/integration/**/*.js"';
+            testCommand = 'node node_modules/mocha/bin/mocha --require test/hooks.js "test/integration/**/*.js"';
         }
         testType = 'integration';
     } else if (process.argv[2] === 'all') {
         if (process.argv.length === 4) {
-            testCommand = `node node_modules/mocha/bin/mocha --recursive -g ${process.argv[3]} "test/**/*.js"`;
+            testCommand = `node node_modules/mocha/bin/mocha --require test/hooks.js --recursive -g ${process.argv[3]}`
+                        + '"test/**/*.js"';
         } else {
-            testCommand = 'node node_modules/mocha/bin/mocha "test/**/*.js"';
+            testCommand = 'node node_modules/mocha/bin/mocha --require test/hooks.js "test/**/*.js"';
         }
         testType = 'all';
     } else if (process.argv[2] === 'startrc') {
         runTests = false;
     } else if (process.argv[2] === 'coverage') {
-        testCommand = 'node node_modules/nyc/bin/nyc node_modules/mocha/bin/_mocha "test/**/*.js" -- '
-                    + '--reporter-options mochaFile=report.xml --reporter mocha-junit-reporter';
+        testCommand = 'node node_modules/nyc/bin/nyc node_modules/mocha/bin/_mocha --require test/hooks.js '
+                    + '"test/**/*.js" -- --reporter-options mochaFile=report.xml --reporter mocha-junit-reporter';
         testType = 'coverage';
     } else {
         throw 'Operation type can be one of "unit", "integration", "all", "startrc"';

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,9 @@
+const { destroyConnection } = require('./integration/RC');
+
+exports.mochaHooks = {
+    // Destroy connection after all tests to prevent mocha from hanging.
+    afterAll(done) {
+        destroyConnection();
+        done();
+    }
+};

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,12 @@
+const { destroyController, initController } = require('./integration/RC');
+
+exports.mochaHooks = {
+    beforeAll(done) {
+        initController();
+        done();
+    },
+    afterAll(done) {
+        destroyController();
+        done();
+    }
+};

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,9 +1,0 @@
-const { destroyConnection } = require('./integration/RC');
-
-exports.mochaHooks = {
-    // Destroy connection after all tests to prevent mocha from hanging.
-    afterAll(done) {
-        destroyConnection();
-        done();
-    }
-};

--- a/test/integration/RC.js
+++ b/test/integration/RC.js
@@ -20,16 +20,18 @@ const { deferredPromise } = require('../../lib/util/Util');
 
 let controller;
 
-function getController() {
-    if (!controller) {
-        controller = new RC('localhost', 9701);
+function initController(){
+    controller = new RC('localhost', 9701);
+}
+
+function destroyController(){
+    if (controller) {
+        controller.destroyConnection();
     }
-    return controller;
 }
 
 function createCluster(hzVersion, config) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.createCluster(hzVersion, config, function (err, cluster) {
         if (err) return deferred.reject(err);
         return deferred.resolve(cluster);
@@ -39,7 +41,6 @@ function createCluster(hzVersion, config) {
 
 function createClusterKeepClusterName(hzVersion, config) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.createClusterKeepClusterName(hzVersion, config, function (err, cluster) {
         if (err) return deferred.reject(err);
         return deferred.resolve(cluster);
@@ -49,7 +50,6 @@ function createClusterKeepClusterName(hzVersion, config) {
 
 function startMember(clusterId) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.startMember(clusterId, function (err, member) {
         if (err) return deferred.reject(err);
         return deferred.resolve(member);
@@ -59,7 +59,6 @@ function startMember(clusterId) {
 
 function exit() {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.exit(function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -69,7 +68,6 @@ function exit() {
 
 function shutdownMember(clusterId, memberUuid) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.shutdownMember(clusterId, memberUuid, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -79,9 +77,7 @@ function shutdownMember(clusterId, memberUuid) {
 
 function shutdownCluster(clusterId) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.shutdownCluster(clusterId, function (err, res) {
-        controller.destroyConnection();
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
     });
@@ -90,7 +86,6 @@ function shutdownCluster(clusterId) {
 
 function terminateMember(clusterId, memberUuid) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.terminateMember(clusterId, memberUuid, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -100,9 +95,7 @@ function terminateMember(clusterId, memberUuid) {
 
 function terminateCluster(clusterId) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.terminateCluster(clusterId, function (err, res) {
-        controller.destroyConnection();
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
     });
@@ -111,7 +104,6 @@ function terminateCluster(clusterId) {
 
 function executeOnController(clusterId, script, lang) {
     const deferred = deferredPromise();
-    const controller = getController();
     controller.executeOnController(clusterId, script, lang, function (err, res) {
         if (err) return deferred.reject(err);
         if (res.success === false) return deferred.reject(res.message);
@@ -129,3 +121,5 @@ exports.shutdownCluster = shutdownCluster;
 exports.executeOnController = executeOnController;
 exports.terminateMember = terminateMember;
 exports.terminateCluster = terminateCluster;
+exports.initController = initController;
+exports.destroyController = destroyController;

--- a/test/integration/RC.js
+++ b/test/integration/RC.js
@@ -18,10 +18,18 @@
 const RC = require('./remote_controller/Controller');
 const { deferredPromise } = require('../../lib/util/Util');
 
-const controller = new RC('localhost', 9701);
+let controller;
+
+function getController() {
+    if (!controller) {
+        controller = new RC('localhost', 9701);
+    }
+    return controller;
+}
 
 function createCluster(hzVersion, config) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.createCluster(hzVersion, config, function (err, cluster) {
         if (err) return deferred.reject(err);
         return deferred.resolve(cluster);
@@ -31,6 +39,7 @@ function createCluster(hzVersion, config) {
 
 function createClusterKeepClusterName(hzVersion, config) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.createClusterKeepClusterName(hzVersion, config, function (err, cluster) {
         if (err) return deferred.reject(err);
         return deferred.resolve(cluster);
@@ -40,6 +49,7 @@ function createClusterKeepClusterName(hzVersion, config) {
 
 function startMember(clusterId) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.startMember(clusterId, function (err, member) {
         if (err) return deferred.reject(err);
         return deferred.resolve(member);
@@ -49,6 +59,7 @@ function startMember(clusterId) {
 
 function exit() {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.exit(function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -58,6 +69,7 @@ function exit() {
 
 function shutdownMember(clusterId, memberUuid) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.shutdownMember(clusterId, memberUuid, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -67,7 +79,9 @@ function shutdownMember(clusterId, memberUuid) {
 
 function shutdownCluster(clusterId) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.shutdownCluster(clusterId, function (err, res) {
+        controller.destroyConnection();
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
     });
@@ -76,6 +90,7 @@ function shutdownCluster(clusterId) {
 
 function terminateMember(clusterId, memberUuid) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.terminateMember(clusterId, memberUuid, function (err, res) {
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
@@ -85,7 +100,9 @@ function terminateMember(clusterId, memberUuid) {
 
 function terminateCluster(clusterId) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.terminateCluster(clusterId, function (err, res) {
+        controller.destroyConnection();
         if (err) return deferred.reject(err);
         return deferred.resolve(res);
     });
@@ -94,6 +111,7 @@ function terminateCluster(clusterId) {
 
 function executeOnController(clusterId, script, lang) {
     const deferred = deferredPromise();
+    const controller = getController();
     controller.executeOnController(clusterId, script, lang, function (err, res) {
         if (err) return deferred.reject(err);
         if (res.success === false) return deferred.reject(res.message);
@@ -111,4 +129,3 @@ exports.shutdownCluster = shutdownCluster;
 exports.executeOnController = executeOnController;
 exports.terminateMember = terminateMember;
 exports.terminateCluster = terminateCluster;
-exports.destroyConnection = controller.destroyConnection;

--- a/test/integration/RC.js
+++ b/test/integration/RC.js
@@ -111,3 +111,4 @@ exports.shutdownCluster = shutdownCluster;
 exports.executeOnController = executeOnController;
 exports.terminateMember = terminateMember;
 exports.terminateCluster = terminateCluster;
+exports.destroyConnection = controller.destroyConnection;

--- a/test/integration/remote_controller/Controller.js
+++ b/test/integration/remote_controller/Controller.js
@@ -18,11 +18,13 @@
 const thrift = require('thrift');
 const RemoteController = require('./RemoteController');
 
+let connection;
+
 function HzRemoteController() {
     const transport = thrift.TBufferedTransport();
     const protocol = thrift.TBinaryProtocol();
 
-    const connection = thrift.createConnection('localhost', 9701, {
+    connection = thrift.createConnection('localhost', 9701, {
         transport: transport,
         protocol: protocol
     });
@@ -33,6 +35,10 @@ function HzRemoteController() {
 
     this.client = thrift.createClient(RemoteController, connection);
 }
+
+HzRemoteController.prototype.destroyConnection = function () {
+    connection.destroy();
+};
 
 HzRemoteController.prototype.ping = function(callback) {
     return this.client.ping(callback);

--- a/test/integration/remote_controller/Controller.js
+++ b/test/integration/remote_controller/Controller.js
@@ -18,28 +18,24 @@
 const thrift = require('thrift');
 const RemoteController = require('./RemoteController');
 
-let connection;
-
 function HzRemoteController() {
     const transport = thrift.TBufferedTransport();
     const protocol = thrift.TBinaryProtocol();
 
-    connection = thrift.createConnection('localhost', 9701, {
+    this.connection = thrift.createConnection('localhost', 9701, {
         transport: transport,
         protocol: protocol
     });
 
-    connection.on('error', function(err) {
+    this.connection.on('error', function(err) {
         console.log(err);
     });
 
-    this.client = thrift.createClient(RemoteController, connection);
+    this.client = thrift.createClient(RemoteController, this.connection);
 }
 
 HzRemoteController.prototype.destroyConnection = function () {
-    if (connection) {
-        connection.destroy();
-    }
+    this.connection.destroy();
 };
 
 HzRemoteController.prototype.ping = function(callback) {

--- a/test/integration/remote_controller/Controller.js
+++ b/test/integration/remote_controller/Controller.js
@@ -37,7 +37,9 @@ function HzRemoteController() {
 }
 
 HzRemoteController.prototype.destroyConnection = function () {
-    connection.destroy();
+    if (connection) {
+        connection.destroy();
+    }
 };
 
 HzRemoteController.prototype.ping = function(callback) {


### PR DESCRIPTION
* This change is my suggestion to deal with
  * mocha will hang if we do not use --exit option. (right now it is used mocha config file.) As in the link below, using --exit is not necessarily recommended. 
  * construction of rc controller every time `RC.js` required. 
  * possible resource leak
* The controller is contructed once in beforeAll hook and its connection is destroyed on afterAll hook.
* Background on [--exit](https://mochajs.org/#-exit) 
* Background on [global root hooks I used](https://mochajs.org/#root-hook-plugins) 

Update:

* **small problem:** If I run small portion of tests with a pattern, or no test runs, mocha exits without hanging. However, when I call all the integration tests, it hangs at the end.
* They are probably due to open sockets opened somewhere and not closed. Wtfnode output when all tests passed and hanging started:  

```
[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 2 (tty) (stdio)
  - fd 1 (tty) (stdio)
- Sockets:
  - 127.0.0.1:46138 -> 127.0.0.1:9999
  - ::ffff:127.0.0.1:9999 -> ::ffff:127.0.0.1:46138
  - 127.0.0.1:46184 -> 127.0.0.1:9999
  - ::ffff:127.0.0.1:9999 -> ::ffff:127.0.0.1:46184
  - 127.0.0.1:46190 -> 127.0.0.1:9999
  - ::ffff:127.0.0.1:9999 -> ::ffff:127.0.0.1:46190

```