### PR TITLE
HazelcastClient implements ClientForConnectionManager

### DIFF
--- a/src/HazelcastClient.ts
+++ b/src/HazelcastClient.ts
@@ -64,7 +64,7 @@ import {RoundRobinLB} from './util/RoundRobinLB';
 import {ClusterViewListenerService} from './listener/ClusterViewListenerService';
 import {ClientMessage} from './protocol/ClientMessage';
 import {Connection} from './network/Connection';
-import {ConnectionRegistryImpl} from './network/ConnectionManager';
+import {ConnectionRegistryImpl, ClientForConnectionManager} from './network/ConnectionManager';
 
 /**
  * Hazelcast client instance. When you want to use Hazelcast's distributed
@@ -73,7 +73,7 @@ import {ConnectionRegistryImpl} from './network/ConnectionManager';
  *
  * Client instances should be shut down explicitly.
  */
-export class HazelcastClient {
+export class HazelcastClient implements ClientForConnectionManager {
 
     /** @internal */
     private static CLIENT_ID = 0;

--- a/src/network/ConnectionManager.ts
+++ b/src/network/ConnectionManager.ts
@@ -272,7 +272,7 @@ export class ConnectionRegistryImpl implements ConnectionRegistry {
     }
 }
 
-interface ClientForConnectionManager {
+export interface ClientForConnectionManager {
     onClusterChange(): void;
 
     sendStateToCluster(): Promise<void>;

--- a/src/network/ConnectionManager.ts
+++ b/src/network/ConnectionManager.ts
@@ -272,6 +272,7 @@ export class ConnectionRegistryImpl implements ConnectionRegistry {
     }
 }
 
+/** @internal */
 export interface ClientForConnectionManager {
     onClusterChange(): void;
 


### PR DESCRIPTION
ConnectionManager get the client instance with an interface called `ClientForConnectionManager`. This pr makes the `HazelcastClient` implement the interface. 

This is not a must change, but it helps to suppress some IDE's unused method behaviour. (e.g in jetbrains IDE)