### PR TITLE
Properly log tried addresses when the client cannot connect to cluster

### DIFF
--- a/src/network/ConnectionManager.ts
+++ b/src/network/ConnectionManager.ts
@@ -643,7 +643,7 @@ export class ConnectionManager extends EventEmitter {
                         }
                         this.logger.info('ConnectionManager', 'Unable to connect to any address '
                             + 'from the cluster with name: ' + ctx.clusterName
-                            + '. The following addresses were tried: ' + triedAddresses);
+                            + '. The following addresses were tried: ' + Array.from(triedAddresses).join(', '));
                         return false;
                     });
             })


### PR DESCRIPTION
Sets do not properly display their elements when they are being tried
to represented as text values. We were trying to convert the tried
addresses set to a string while logging that the client is unable
to connect a cluster which was not working very well.

Now, we convert the set to an array and join it with `, ` to produce
a better output.

Before:
```
... The following addresses were tried: [object Set]
```

After:
```
... The following addresses were tried: 127.0.0.1:5701, 127.0.0.1:5703, 127.0.0.1:5702
```