### PR TITLE
Add dependabot config yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+        interval: daily
+        time: "9:00"
+        timezone: "Asia/Istanbul"
+      open-pull-requests-limit: 10
+      target-branch: master
+      versioning-strategy: increase
+      ignore:
+        - dependency-name: "@types/node"
+          versions: [ "^11.0.0" ]
+      labels:
+        - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,6 @@ updates:
       versioning-strategy: increase
       ignore:
         - dependency-name: "@types/node"
-          versions: [ "^11.0.0" ]
+          versions: [ ">=11.0.0" ]
       labels:
         - "dependencies"


### PR DESCRIPTION
Dependabot will increase all versions without trying to respect what is in package.json file. (Could not find any option related to this). I ignored @types/node package's version (11.0.0 and beyond) since we should support Node 10. 

So any major, minor or patch version upgrades will trigger a pr. The check will occur every day at 9.00 am in Istanbul time. 