### PR TITLE
Fix typo in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
       directory: "/"
       schedule:
         interval: daily
-        time: "9:00"
+        time: "09:00"
         timezone: "Asia/Istanbul"
       open-pull-requests-limit: 10
       target-branch: master


### PR DESCRIPTION
Fixes a typo due to version:2. Now validation passes, see https://dependabot.com/docs/config-file/validator/