### PR TITLE
Fix client version handling in the statistics tests

### DIFF
--- a/test/integration/backward_compatible/statistics/StatisticsTest.js
+++ b/test/integration/backward_compatible/statistics/StatisticsTest.js
@@ -115,7 +115,7 @@ describe('StatisticsTest (default period)', function () {
         expect(extractIntStatValue(stats, 'lastStatisticsCollectionTime')).to.be
             .within(Date.now() - Statistics.PERIOD_SECONDS_DEFAULT_VALUE * 2000, Date.now());
         expect(extractBooleanStatValue(stats, 'enterprise')).to.be.false;
-        const expectedClientType = TestUtil.isClientVersionAtLeast('4.1') ? 'NJS' : 'NodeJS';
+        const expectedClientType = TestUtil.isClientVersionAtLeast('4.0.2') ? 'NJS' : 'NodeJS';
         expect(extractStringStatValue(stats, 'clientType')).to.equal(expectedClientType);
         expect(extractStringStatValue(stats, 'clientVersion')).to.equal(BuildInfo.getClientVersion());
         const connection = TestUtil.getRandomConnection(client);


### PR DESCRIPTION
A fix for the data we send during the statistics collection is
also backported to 4.0.2, so we need to account for that and
fix the client version handling.

This is a required change for the backward compatibility tests.