### PR TITLE
Change server version and disable transitive download

### DIFF
--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -1,6 +1,6 @@
 'use strict';
-const HZ_VERSION = '4.1.1';
-const HZ_TEST_VERSION = '4.1.1';
+const HZ_VERSION = '4.2.1-SNAPSHOT';
+const HZ_TEST_VERSION = '4.2.1-SNAPSHOT';
 const HAZELCAST_TEST_VERSION = HZ_TEST_VERSION;
 const HAZELCAST_VERSION = HZ_VERSION;
 const HAZELCAST_ENTERPRISE_VERSION = HZ_VERSION;
@@ -49,6 +49,7 @@ const downloadRC = () => {
             [
                 '-q',
                 'dependency:get',
+                '-Dtransitive=false',
                 `-DrepoUrl=${SNAPSHOT_REPO}`,
                 `-Dartifact=com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}`,
                 `-Ddest=hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar`
@@ -71,6 +72,7 @@ const downloadRC = () => {
             [
                 '-q',
                 'dependency:get',
+                '-Dtransitive=false',
                 `-DrepoUrl=${TEST_REPO}`,
                 `-Dartifact=com.hazelcast:hazelcast:${HAZELCAST_TEST_VERSION}:jar:tests`,
                 `-Ddest=hazelcast-${HAZELCAST_TEST_VERSION}-tests.jar`
@@ -94,6 +96,7 @@ const downloadRC = () => {
             const subprocess = spawnSync('mvn', [
                 '-q',
                 'dependency:get',
+                '-Dtransitive=false',
                 `-DrepoUrl=${ENTERPRISE_REPO}`,
                 `-Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_ENTERPRISE_VERSION}`,
                 `-Ddest=hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar`
@@ -116,6 +119,7 @@ const downloadRC = () => {
             const subprocess = spawnSync('mvn', [
                 '-q',
                 'org.apache.maven.plugins:maven-dependency-plugin:2.8:get',
+                '-Dtransitive=false',
                 `-DrepoUrl=${ENTERPRISE_TEST_REPO}`,
                 `-Dartifact=com.hazelcast:hazelcast-enterprise:${HAZELCAST_TEST_VERSION}:jar:tests`,
                 `-Ddest=hazelcast-enterprise-${HAZELCAST_TEST_VERSION}-tests.jar`
@@ -138,6 +142,7 @@ const downloadRC = () => {
             const subprocess = spawnSync('mvn', [
                 '-q',
                 'dependency:get',
+                '-Dtransitive=false',
                 `-DrepoUrl=${REPO}`,
                 `-Dartifact=com.hazelcast:hazelcast:${HAZELCAST_VERSION}`,
                 `-Ddest=hazelcast-${HAZELCAST_VERSION}.jar`


### PR DESCRIPTION
Certificate expired, server update needed. Transitive download was causing problems on the ci.