### PR TITLE
[API-378] Make defaultNumberType usage clear

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -581,7 +581,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: The `Long` type means the type provided by [long.js library](https://github.com/dcodeIO/long.js).**
 
-> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option. Refer to [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) in order to learn how you can configure it**
+> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the [serialization.defaultNumberType](http://hazelcast.github.io/hazelcast-nodejs-client/api/4.1.0/docs/interfaces/_config_serializationconfig_.serializationconfig.html#defaultnumbertype) config option.
 
 Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -581,7 +581,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: The `Long` type means the type provided by [long.js library](https://github.com/dcodeIO/long.js).**
 
-> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the [serialization.defaultNumberType](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/interfaces/_config_serializationconfig_.serializationconfig.html#defaultnumbertype) config option.**
+> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option. See [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) for more information.**
 
 Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -581,7 +581,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: The `Long` type means the type provided by [long.js library](https://github.com/dcodeIO/long.js).**
 
-> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option.**
+> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option. Refer to [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) in order to learn how you can configure it**
 
 Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -581,7 +581,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: The `Long` type means the type provided by [long.js library](https://github.com/dcodeIO/long.js).**
 
-> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the [serialization.defaultNumberType](http://hazelcast.github.io/hazelcast-nodejs-client/api/4.1.0/docs/interfaces/_config_serializationconfig_.serializationconfig.html#defaultnumbertype) config option.
+> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the [serialization.defaultNumberType](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/interfaces/_config_serializationconfig_.serializationconfig.html#defaultnumbertype) config option.**
 
 Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -573,7 +573,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 | Node.js         | Java                                  |
 |-----------------|---------------------------------------|
 | boolean         | Boolean                               |
-| number          | Byte, Short, Integer, Float, Double   |
+| number          | Short, Integer, Float, Double         |
 | string          | String                                |
 | Long            | Long                                  |
 | Buffer          | byte[]                                |
@@ -583,7 +583,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option. Refer to [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) in order to learn how you can configure it**
 
-Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
+Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 
 **Serialization Priority**
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -581,7 +581,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: The `Long` type means the type provided by [long.js library](https://github.com/dcodeIO/long.js).**
 
-> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option. See [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) for more information.**
+> **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `defaultNumberType` serialization config option. See [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) for more information.**
 
 Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -573,7 +573,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 | Node.js         | Java                                  |
 |-----------------|---------------------------------------|
 | boolean         | Boolean                               |
-| number          | Short, Integer, Float, Double         |
+| number          | Byte, Short, Integer, Float, Double   |
 | string          | String                                |
 | Long            | Long                                  |
 | Buffer          | byte[]                                |
@@ -583,7 +583,7 @@ Hazelcast serializes all your objects before sending them to the server. Certain
 
 > **NOTE: A `number` is serialized as `Double` by default. You can configure this behavior using the `serialization.defaultNumberType` config option. Refer to [API Documentation](http://hazelcast.github.io/hazelcast-nodejs-client/api/current/docs/) in order to learn how you can configure it**
 
-Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
+Arrays of the `boolean`, `number`, `string`, and `Long` types can be serialized as `boolean[]`, `byte[]`, `short[]`, `int[]`, `float[]`, `double[]`, `string[]`, and `long[]` for the Java server side, respectively.
 
 **Serialization Priority**
 

--- a/src/config/ConfigBuilder.ts
+++ b/src/config/ConfigBuilder.ts
@@ -222,7 +222,7 @@ export class ConfigBuilder {
     private handleSerialization(jsonObject: any): void {
         for (const key in jsonObject) {
             if (key === 'defaultNumberType') {
-                this.effectiveConfig.serialization.defaultNumberType = tryGetString(jsonObject[key]);
+                this.effectiveConfig.serialization.defaultNumberType = tryGetString(jsonObject[key]).toLowerCase();
             } else if (key === 'isBigEndian') {
                 this.effectiveConfig.serialization.isBigEndian = tryGetBoolean(jsonObject[key]);
             } else if (key === 'portableVersion') {

--- a/src/config/SerializationConfig.ts
+++ b/src/config/SerializationConfig.ts
@@ -25,9 +25,8 @@ import {JsonStringDeserializationPolicy} from './JsonStringDeserializationPolicy
 export interface SerializationConfig {
 
     /**
-     * Defines how the `number` type is represented on the cluster side. By default, it is serialized as `Double`.
-     * This option can be one of the following strings. The casing of the string does not matter, it's converted to lower
-     * case internally.
+     * Defines how the `number` type is represented on the cluster side. By default, it is serialized as `double`.
+     * This option can be one of the following case-insensitive strings.
      * * `byte`(8-bit signed integer)
      * * `short`(16-bit signed integer)
      * * `integer`(32-bit signed integer)
@@ -36,8 +35,8 @@ export interface SerializationConfig {
      * * `long`(64-bit integer from long.js library)
      *
      * Note:
-     * * If you are using byte, **for array of numbers** you need to use `Buffer.from([1,2,3])` instead of regular arrays.
-     * * If you are using long, you need to use Long objects **for array of numbers or a single number**.
+     * * If you are using `byte`, **for array of numbers** you need to use `Buffer` instead of regular arrays.
+     * * If you are using `long`, you need to use Long objects **for array of numbers or a single number**.
      */
     defaultNumberType?: string;
 

--- a/src/config/SerializationConfig.ts
+++ b/src/config/SerializationConfig.ts
@@ -26,6 +26,13 @@ export interface SerializationConfig {
 
     /**
      * Defines how the `number` type is represented on the cluster side. By default, it is serialized as `Double`.
+     * This option can be one of the following strings. The casing of the string does not matter, it's converted to lower
+     * case internally.
+     * * `byte`(8-bit signed integer)
+     * * `short`(16-bit signed integer)
+     * * `integer`(32-bit signed integer)
+     * * `float`(single-precision 32-bit IEEE 754 floating point)
+     * * `double`(double-precision 64-bit IEEE 754 floating point)
      */
     defaultNumberType?: string;
 

--- a/src/config/SerializationConfig.ts
+++ b/src/config/SerializationConfig.ts
@@ -28,11 +28,16 @@ export interface SerializationConfig {
      * Defines how the `number` type is represented on the cluster side. By default, it is serialized as `Double`.
      * This option can be one of the following strings. The casing of the string does not matter, it's converted to lower
      * case internally.
+     * * `byte`(8-bit signed integer)
      * * `short`(16-bit signed integer)
      * * `integer`(32-bit signed integer)
      * * `float`(single-precision 32-bit IEEE 754 floating point)
      * * `double`(double-precision 64-bit IEEE 754 floating point)
+     * * `long`(64-bit integer from long.js library)
      *
+     * Note:
+     * * If you are using byte, **for array of numbers** you need to use `Buffer.from([1,2,3])` instead of regular arrays.
+     * * If you are using long, you need to use Long objects **for array of numbers or a single number**.
      */
     defaultNumberType?: string;
 

--- a/src/config/SerializationConfig.ts
+++ b/src/config/SerializationConfig.ts
@@ -28,11 +28,11 @@ export interface SerializationConfig {
      * Defines how the `number` type is represented on the cluster side. By default, it is serialized as `Double`.
      * This option can be one of the following strings. The casing of the string does not matter, it's converted to lower
      * case internally.
-     * * `byte`(8-bit signed integer)
      * * `short`(16-bit signed integer)
      * * `integer`(32-bit signed integer)
      * * `float`(single-precision 32-bit IEEE 754 floating point)
      * * `double`(double-precision 64-bit IEEE 754 floating point)
+     *
      */
     defaultNumberType?: string;
 

--- a/test/integration/backward_compatible/map/MapAggregatorsLongTest.js
+++ b/test/integration/backward_compatible/map/MapAggregatorsLongTest.js
@@ -36,10 +36,7 @@ describe('MapAggregatorsLongTest', function () {
         cluster = await RC.createCluster(null, null);
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({
-            clusterName: cluster.id,
-            serialization: {
-                defaultNumberType: 'long'
-            }
+            clusterName: cluster.id
         });
         map = await client.getMap('aggregatorsMap');
     });

--- a/test/integration/backward_compatible/map/MapAggregatorsLongTest.js
+++ b/test/integration/backward_compatible/map/MapAggregatorsLongTest.js
@@ -36,7 +36,10 @@ describe('MapAggregatorsLongTest', function () {
         cluster = await RC.createCluster(null, null);
         await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({
-            clusterName: cluster.id
+            clusterName: cluster.id,
+            serialization: {
+                defaultNumberType: 'long'
+            }
         });
         map = await client.getMap('aggregatorsMap');
     });

--- a/test/unit/config/configurations/config-schema.json
+++ b/test/unit/config/configurations/config-schema.json
@@ -159,9 +159,10 @@
             "properties": {
                 "defaultNumberType": {
                     "enum": [
+                        "double",
+                        "short",
                         "integer",
-                        "float",
-                        "double"
+                        "float"
                     ],
                     "default": "double"
                 },

--- a/test/unit/config/configurations/config-schema.json
+++ b/test/unit/config/configurations/config-schema.json
@@ -162,7 +162,9 @@
                         "double",
                         "short",
                         "integer",
-                        "float"
+                        "float",
+                        "byte",
+                        "long"
                     ],
                     "default": "double"
                 },

--- a/test/unit/serialization/DefaultSerializersTest.js
+++ b/test/unit/serialization/DefaultSerializersTest.js
@@ -86,12 +86,17 @@ describe('DefaultSerializersTest', function () {
         'double',
         'short',
         'integer',
-        'float'
+        'long',
+        'float',
+        'byte'
     ];
 
     defaultNumberTypes.forEach((type) => {
         it('convert default number type: ' + type, function () {
-            const num = 56;
+            let num = 56;
+            if (type === 'long') {
+                num = Long.fromNumber(56);
+            }
             const config = new SerializationConfigImpl();
             config.defaultNumberType = type;
             const serializationService = new SerializationServiceV1(config);
@@ -102,7 +107,13 @@ describe('DefaultSerializersTest', function () {
 
     defaultNumberTypes.forEach((type) => {
         it('convert array of default number type: ' + type, function () {
-            const nums = [56, 101];
+            let nums = [56, 101];
+            if (type === 'long') {
+                nums = [Long.fromNumber(56), Long.fromNumber(101)];
+            }
+            if (type === 'byte') {
+                nums = Buffer.from(nums);
+            }
             const config = new SerializationConfigImpl();
             config.defaultNumberType = type;
             const serializationService = new SerializationServiceV1(config);

--- a/test/unit/serialization/DefaultSerializersTest.js
+++ b/test/unit/serialization/DefaultSerializersTest.js
@@ -86,16 +86,12 @@ describe('DefaultSerializersTest', function () {
         'double',
         'short',
         'integer',
-        'long',
         'float'
     ];
 
     defaultNumberTypes.forEach((type) => {
         it('convert default number type: ' + type, function () {
-            let num = 56;
-            if (type === 'long') {
-                num = Long.fromNumber(56);
-            }
+            const num = 56;
             const config = new SerializationConfigImpl();
             config.defaultNumberType = type;
             const serializationService = new SerializationServiceV1(config);
@@ -106,10 +102,7 @@ describe('DefaultSerializersTest', function () {
 
     defaultNumberTypes.forEach((type) => {
         it('convert array of default number type: ' + type, function () {
-            let nums = [56, 101];
-            if (type === 'long') {
-                nums = [Long.fromNumber(56), Long.fromNumber(101)];
-            }
+            const nums = [56, 101];
             const config = new SerializationConfigImpl();
             config.defaultNumberType = type;
             const serializationService = new SerializationServiceV1(config);

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,11 +1,9 @@
 {
     "out": "docs/",
-    "inputFiles": "src/",
+    "entryPoints": ["src/"],
     "exclude": "src/codec/**/*.ts",
-    "excludeNotExported": true,
     "excludeExternals": true,
-    "stripInternal": true,
-    "ignoreCompilerErrors": true,
+    "excludeInternal": true,
     "excludePrivate": true,
     "excludeProtected": true
 }


### PR DESCRIPTION
I encountered this while reading the documentation. 

The defaultNumberType option was not clear, this change makes it clear and allows it to accept string in any casing(uppercase or lowercase as opposed to accepting only lower case). 
