### PR TITLE
Enable eslint cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ coverage
 # Hazelcast Remote Controller output files
 rc_stderr.txt
 rc_stdout.txt
+
+# Eslint cache
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
         "coverage": "node scripts/test-runner.js coverage",
         "pregenerate-docs": "rimraf docs",
         "generate-docs": "typedoc --options typedoc.json",
-        "lint": "eslint --ext .ts src && eslint --plugin mocha test && eslint code_samples && eslint scripts",
-        "lint:fix": "eslint --fix --ext .ts src && eslint --fix --plugin mocha test && eslint --fix code_samples && eslint --fix scripts",
+        "lint": "eslint --cache --ext .ts src && eslint --cache --plugin mocha test && eslint --cache  code_samples && eslint --cache scripts",
+        "lint:fix": "eslint --cache --fix --ext .ts src && eslint --cache --fix --plugin mocha test && eslint --cache --fix code_samples && eslint --cache --fix scripts",
         "startrc": "node scripts/test-runner.js startrc"
     },
     "repository": {


### PR DESCRIPTION
This increases eslint performance which affects development time. Currently a single linting takes 10-15 seconds whereas with cache it takes 1-2 seconds.

https://eslint.org/docs/user-guide/command-line-interface#caching