### PR TITLE
Add `curly` and `keyword-spacing` rules to eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
-src/codec/**/*.ts
+src/codec/*.ts
+src/codec/custom/*.ts
 src/.eslintrc.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -96,6 +96,7 @@
                 "FunctionExpression > BlockStatement.body"
             ]
         }],
-        "space-in-parens": "error"
+        "space-in-parens": "error",
+        "curly": "error"
     }
 }

--- a/code_samples/paging_predicate.js
+++ b/code_samples/paging_predicate.js
@@ -34,8 +34,12 @@ class Comparator {
     // This comparator sorts entries according to their keys
     // in reverse alphabetical order.
     sort(a, b) {
-        if (a[0] > b[0]) return -1;
-        if (a[0] < b[0]) return 1;
+        if (a[0] > b[0]) {
+            return -1;
+        }
+        if (a[0] < b[0]) {
+            return 1;
+        }
         return 0;
     }
 

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -138,7 +138,9 @@ const shutdownProcesses = () => {
     if (ON_WINDOWS) {
         spawnSync('taskkill', ['/pid', testProcess.pid, '/f', '/t']); // simple sigkill not enough on windows
     } else {
-        if (testProcess && testProcess.exitCode === null) testProcess.kill('SIGKILL');
+        if (testProcess && testProcess.exitCode === null) {
+            testProcess.kill('SIGKILL');
+        }
     }
 };
 
@@ -146,7 +148,9 @@ const shutdownRC = () => {
     if (ON_WINDOWS) {
         spawnSync('taskkill', ['/pid', rcProcess.pid, '/f', '/t']);
     } else {
-        if (rcProcess && rcProcess.exitCode === null) rcProcess.kill('SIGKILL');
+        if (rcProcess && rcProcess.exitCode === null) {
+            rcProcess.kill('SIGKILL');
+        }
     }
 };
 

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -42,5 +42,7 @@ module.exports = {
         'prefer-rest-params': 'off',
         'max-len': [ 'error', 130, 4 ],
         'quotes': ['error', 'single'],
+        'curly': 'error',
+        'keyword-spacing': 'error',
     }
 };

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -42,7 +42,9 @@ module.exports = {
         'prefer-rest-params': 'off',
         'max-len': [ 'error', 130, 4 ],
         'quotes': ['error', 'single'],
-        'curly': 'error',
         'keyword-spacing': 'error',
+        'space-before-blocks': 'warn',
+        'space-in-parens': 'error',
+        'curly': 'error',
     }
 };

--- a/src/codec/builtin/FixSizedTypesCodec.ts
+++ b/src/codec/builtin/FixSizedTypesCodec.ts
@@ -64,7 +64,7 @@ export class FixSizedTypesCodec {
      */
     static encodeNonNegativeNumberAsLong(buffer: Buffer, offset: number, value: number): void {
         if (value < 0) {
-            throw new Error("Only positive numbers are allowed in this method, received: " + value);
+            throw new Error('Only positive numbers are allowed in this method, received: ' + value);
         }
 
         if (value + 1 >= TWO_PWR_63_DBL) {

--- a/src/config/ConfigBuilder.ts
+++ b/src/config/ConfigBuilder.ts
@@ -120,16 +120,19 @@ export class ConfigBuilder {
                 assertNonNegativeNumber(value, 'Max backoff must be non-negative!');
                 this.effectiveConfig.connectionStrategy.connectionRetry.maxBackoffMillis = value;
             } else if (key === 'multiplier') {
-                if(typeof value !== 'number' || value < 1.0)
+                if (typeof value !== 'number' || value < 1.0) {
                     throw new RangeError('Multiplier must be a number that is greater than or equal to 1.0!');
+                }
                 this.effectiveConfig.connectionStrategy.connectionRetry.multiplier = value;
             } else if (key === 'clusterConnectTimeoutMillis') {
-                if(typeof value !== 'number' || (value < 0 && value !== -1))
+                if (typeof value !== 'number' || (value < 0 && value !== -1)) {
                     throw new RangeError('ClusterConnectTimeoutMillis can be only non-negative number or -1!');
+                }
                 this.effectiveConfig.connectionStrategy.connectionRetry.clusterConnectTimeoutMillis = value;
             } else if (key === 'jitter') {
-                if(typeof value !== 'number' || (value < 0 || value > 1))
+                if (typeof value !== 'number' || (value < 0 || value > 1)) {
                     throw new RangeError('Jitter must be a number in range [0.0, 1.0]!');
+                }
                 this.effectiveConfig.connectionStrategy.connectionRetry.jitter = value;
             }
         }

--- a/src/proxy/ProxyManager.ts
+++ b/src/proxy/ProxyManager.ts
@@ -235,7 +235,7 @@ export class ProxyManager {
                 this.clusterService,
                 this.connectionRegistry
             );
-        } else if (serviceName === ProxyManager.MULTIMAP_SERVICE){
+        } else if (serviceName === ProxyManager.MULTIMAP_SERVICE) {
             localProxy = new MultiMapProxy(
                 serviceName,
                 name,
@@ -248,7 +248,7 @@ export class ProxyManager {
                 this.lockReferenceIdGenerator,
                 this.connectionRegistry
             );
-        } else if (serviceName === ProxyManager.RELIABLETOPIC_SERVICE){
+        } else if (serviceName === ProxyManager.RELIABLETOPIC_SERVICE) {
             localProxy = new ReliableTopicProxy(
                 serviceName,
                 name,
@@ -262,7 +262,7 @@ export class ProxyManager {
                 this.clusterService,
                 this.connectionRegistry
             );
-        } else if (serviceName === ProxyManager.FLAKEID_SERVICE){
+        } else if (serviceName === ProxyManager.FLAKEID_SERVICE) {
             localProxy = new FlakeIdGeneratorProxy(
                 serviceName,
                 name,

--- a/src/serialization/portable/DefaultPortableWriter.ts
+++ b/src/serialization/portable/DefaultPortableWriter.ts
@@ -23,7 +23,7 @@ import {Portable, FieldType, PortableWriter} from '../Portable';
 import * as Long from 'long';
 
 /** @internal */
-export class DefaultPortableWriter implements PortableWriter{
+export class DefaultPortableWriter implements PortableWriter {
 
     private serializer: PortableSerializer;
     private readonly output: PositionalDataOutput;

--- a/src/util/DatetimeUtil.ts
+++ b/src/util/DatetimeUtil.ts
@@ -93,7 +93,7 @@ export function getOffsetSecondsFromTimezoneString(timezoneString: string): numb
 
     const offsetSeconds = hourAsNumber*3600 + minuteAsNumber*60;
 
-    if(offsetSeconds > 64800){
+    if (offsetSeconds > 64800){
         throw new RangeError('Invalid offset');
     }
     return positive ? offsetSeconds : -offsetSeconds;

--- a/src/util/DatetimeUtil.ts
+++ b/src/util/DatetimeUtil.ts
@@ -93,7 +93,7 @@ export function getOffsetSecondsFromTimezoneString(timezoneString: string): numb
 
     const offsetSeconds = hourAsNumber*3600 + minuteAsNumber*60;
 
-    if (offsetSeconds > 64800){
+    if (offsetSeconds > 64800) {
         throw new RangeError('Invalid offset');
     }
     return positive ? offsetSeconds : -offsetSeconds;

--- a/test/integration/RC.js
+++ b/test/integration/RC.js
@@ -23,7 +23,9 @@ const controller = new RC('localhost', 9701);
 function createCluster(hzVersion, config) {
     const deferred = deferredPromise();
     controller.createCluster(hzVersion, config, (err, cluster) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(cluster);
     });
     return deferred.promise;
@@ -32,7 +34,9 @@ function createCluster(hzVersion, config) {
 function createClusterKeepClusterName(hzVersion, config) {
     const deferred = deferredPromise();
     controller.createClusterKeepClusterName(hzVersion, config, (err, cluster) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(cluster);
     });
     return deferred.promise;
@@ -41,7 +45,9 @@ function createClusterKeepClusterName(hzVersion, config) {
 function startMember(clusterId) {
     const deferred = deferredPromise();
     controller.startMember(clusterId, (err, member) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(member);
     });
     return deferred.promise;
@@ -50,7 +56,9 @@ function startMember(clusterId) {
 function exit() {
     const deferred = deferredPromise();
     controller.exit((err, res) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(res);
     });
     return deferred.promise;
@@ -59,7 +67,9 @@ function exit() {
 function shutdownMember(clusterId, memberUuid) {
     const deferred = deferredPromise();
     controller.shutdownMember(clusterId, memberUuid, (err, res) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(res);
     });
     return deferred.promise;
@@ -68,7 +78,9 @@ function shutdownMember(clusterId, memberUuid) {
 function shutdownCluster(clusterId) {
     const deferred = deferredPromise();
     controller.shutdownCluster(clusterId, (err, res) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(res);
     });
     return deferred.promise;
@@ -77,7 +89,9 @@ function shutdownCluster(clusterId) {
 function terminateMember(clusterId, memberUuid) {
     const deferred = deferredPromise();
     controller.terminateMember(clusterId, memberUuid, (err, res) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(res);
     });
     return deferred.promise;
@@ -86,7 +100,9 @@ function terminateMember(clusterId, memberUuid) {
 function terminateCluster(clusterId) {
     const deferred = deferredPromise();
     controller.terminateCluster(clusterId, (err, res) => {
-        if (err) return deferred.reject(err);
+        if (err) {
+            return deferred.reject(err);
+        }
         return deferred.resolve(res);
     });
     return deferred.promise;
@@ -95,8 +111,12 @@ function terminateCluster(clusterId) {
 function executeOnController(clusterId, script, lang) {
     const deferred = deferredPromise();
     controller.executeOnController(clusterId, script, lang, (err, res) => {
-        if (err) return deferred.reject(err);
-        if (res.success === false) return deferred.reject(res.message);
+        if (err) {
+            return deferred.reject(err);
+        }
+        if (res.success === false) {
+            return deferred.reject(res.message);
+        }
         return deferred.resolve(res);
     });
     return deferred.promise;

--- a/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
+++ b/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
@@ -40,8 +40,12 @@ describe('ReliableTopicOnClusterRestartTest', function () {
     });
 
     afterEach(async function () {
-        if (client1) await client1.shutdown();
-        if (client2) await client2.shutdown();
+        if (client1) {
+            await client1.shutdown();
+        }
+        if (client2) {
+            await client2.shutdown();
+        }
     });
 
     after(async function() {

--- a/test/unit/serialization/APortable.js
+++ b/test/unit/serialization/APortable.js
@@ -21,7 +21,9 @@ class APortable {
                 doubles, shorts, floats, ints, longs, strings, portables,
                 identifiedDataSerializable, customStreamSerializableObject,
                 customByteArraySerializableObject, data) {
-        if (arguments.length === 0) return;
+        if (arguments.length === 0) {
+            return;
+        }
         this.bool = bool;
         this.b = b;
         this.c = c;

--- a/test/unit/serialization/AnIdentifiedDataSerializable.js
+++ b/test/unit/serialization/AnIdentifiedDataSerializable.js
@@ -21,7 +21,9 @@ class AnIdentifiedDataSerializable {
                 doubles, shorts, floats, ints, longs, strings, portable,
                 identifiedDataSerializable, customStreamSerializable,
                 customByteArraySerializableObject, data) {
-        if (arguments.length === 0) return;
+        if (arguments.length === 0) {
+            return;
+        }
         this.bool = bool;
         this.b = b;
         this.c = c;

--- a/test/unit/serialization/AnInnerPortable.js
+++ b/test/unit/serialization/AnInnerPortable.js
@@ -33,12 +33,15 @@ AnInnerPortable.prototype.readPortable = function (reader) {
 };
 
 AnInnerPortable.prototype.equals = function (other) {
-    if (other === this)
+    if (other === this) {
         return true;
-    if (this.anInt !== other.anInt)
+    }
+    if (this.anInt !== other.anInt) {
         return false;
-    if (this.aFloat > other.aFloat + Number.EPSILON || this.aFloat < other.aFloat - Number.EPSILON)
+    }
+    if (this.aFloat > other.aFloat + Number.EPSILON || this.aFloat < other.aFloat - Number.EPSILON) {
         return false;
+    }
     return true;
 };
 


### PR DESCRIPTION
Added these new rules and fixed the problems in the code base
related to them.

Also, modified eslint ignore file so that it only ignores the auto
generated code, but not the handwritten ones.

closes #917 