### PR TITLE
Add generate-docs workflow, revert ts version to 4.2 

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,13 @@
+on: [pull_request]
+name: Generate docs
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+          npm install
+    - name: Generate docs
+      run: |
+          npm run generate-docs

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "source-map-support": "^0.5.19",
         "thrift": "~0.14.1",
         "typedoc": "~0.20.36",
-        "typescript": "~4.3.2",
+        "typescript": "~4.2.4",
         "winston": "~3.3.3",
         "yargs": "~17.0.1"
     },


### PR DESCRIPTION
Our current typedoc version only supports typescript up to 4.2, version bump is done by accident since we do not generate docs in our ci. Adds a new workflow that generates docs