### PR TITLE
SQL related improvements

### DIFF
--- a/src/sql/SqlError.ts
+++ b/src/sql/SqlError.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/** @ignore *//** */
 
 import {UUID} from '../core';
 

--- a/src/sql/SqlErrorCode.ts
+++ b/src/sql/SqlErrorCode.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/** @ignore *//** */
 
 /**
  * Error codes used in Hazelcast SQL.

--- a/src/sql/SqlPage.ts
+++ b/src/sql/SqlPage.ts
@@ -54,7 +54,6 @@ export class SqlPage {
 
     /**
      * This is needed for better mocking. Constructor mocking is not trivial with sinon.
-     * @internal
      */
     static fromColumns(columnTypes: SqlColumnType[], columns: any[][], last: boolean): SqlPage {
         return new SqlPage(columnTypes, columns, last);

--- a/src/sql/SqlPage.ts
+++ b/src/sql/SqlPage.ts
@@ -53,6 +53,7 @@ export class SqlPage {
 
     /**
      * This is needed for better mocking. Constructor mocking is not trivial with sinon.
+     * @internal
      */
     static fromColumns(columnTypes: SqlColumnType[], columns: any[][], last: boolean): SqlPage {
         return new SqlPage(columnTypes, columns, last);

--- a/src/sql/SqlPage.ts
+++ b/src/sql/SqlPage.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/** @ignore *//** */
 
 import {SqlColumnType} from './SqlColumnMetadata';
 

--- a/src/sql/SqlQueryId.ts
+++ b/src/sql/SqlQueryId.ts
@@ -17,6 +17,7 @@
 import {UUID} from '../core';
 import {UuidUtil} from '../util/UuidUtil';
 import * as Long from 'long';
+/** @ignore *//** */
 
 /**
  * @internal

--- a/src/sql/SqlResult.ts
+++ b/src/sql/SqlResult.ts
@@ -211,7 +211,7 @@ export class SqlResultImpl implements SqlResult {
 
     isRowSet(): Promise<boolean> {
         return this.executeDeferred.promise.then(() => {
-            return this.updateCount === Long.fromInt(-1);
+            return this.rowMetadata !== null;
         });
     }
 

--- a/src/sql/SqlResult.ts
+++ b/src/sql/SqlResult.ts
@@ -189,7 +189,6 @@ export class SqlResultImpl implements SqlResult {
     /**
      * Useful for mocking. (Constructor mocking is hard/impossible)
      * @returns new result object.
-     * @internal
      */
     static newResult(
         sqlService: SqlServiceImpl,
@@ -243,7 +242,7 @@ export class SqlResultImpl implements SqlResult {
         // Prevent ongoing/future fetch requests
         if (!this.fetchDeferred) {
             this.fetchDeferred = deferredPromise<SqlPage>();
-            this.fetchDeferred.promise.catch(()=>{});
+            this.fetchDeferred.promise.catch(() => {});
         }
         this.fetchDeferred.reject(error);
         // Send the close request.
@@ -260,7 +259,6 @@ export class SqlResultImpl implements SqlResult {
     /**
      * Called when next page of the result is received.
      * @param page
-     * @internal
      */
     private onNextPage(page: SqlPage) {
         this.currentPage = page;
@@ -276,7 +274,6 @@ export class SqlResultImpl implements SqlResult {
     /**
      * Called when an error is occurred during SQL execution.
      * @param error The wrapped error that can be propagated to the user through executeDeferred.
-     * @internal
      */
     onExecuteError(error: HazelcastSqlException): void {
         // Ignore the error if SQL result is closed.
@@ -292,7 +289,6 @@ export class SqlResultImpl implements SqlResult {
     /**
      * Used by {@link next}.
      * @returns the current row.
-     * @internal
      */
     private getCurrentRow(): SqlRowType {
         if (this.returnRawResult) { // Return SqlRow
@@ -319,7 +315,6 @@ export class SqlResultImpl implements SqlResult {
      * @param rowMetadata  The row metadata. It is null if the response only contains the update count.
      * @param rowPage The first page of the result. It is null if the response only contains the update count.
      * @param updateCount The update count.
-     * @internal
      */
     onExecuteResponse(rowMetadata: SqlRowMetadata | null, rowPage: SqlPage | null, updateCount: Long) {
         // Ignore the response if the SQL result is closed.
@@ -367,7 +362,6 @@ export class SqlResultImpl implements SqlResult {
 
     /**
      * Checks if there are rows to iterate in a recursive manner, similar to a non-blocking while block
-     * @internal
      */
     private checkHasNext(): Promise<boolean> {
         if (this.currentPosition === this.currentRowCount) {
@@ -389,7 +383,6 @@ export class SqlResultImpl implements SqlResult {
     /**
      * Used by {@link next}.
      * @returns if there are rows to be iterated.
-     * @internal
      */
     private hasNext(): Promise<boolean> {
         return this.executeDeferred.promise.then(() => {

--- a/src/sql/SqlResult.ts
+++ b/src/sql/SqlResult.ts
@@ -354,8 +354,8 @@ export class SqlResultImpl implements SqlResult {
 
         this.fetchDeferred = deferredPromise<SqlPage>();
 
-        this.sqlService.fetch(this.connection, this.queryId, this.cursorBufferSize).then(value => {
-            this.fetchDeferred.resolve(value);
+        this.sqlService.fetch(this.connection, this.queryId, this.cursorBufferSize).then(sqlPage => {
+            this.fetchDeferred.resolve(sqlPage);
             this.fetchDeferred = undefined; // Set fetchDeferred to undefined to be able to fetch again
         }).catch(err => {
             this.fetchDeferred.reject(this.sqlService.toHazelcastSqlException(err, this.connection));

--- a/src/sql/SqlResult.ts
+++ b/src/sql/SqlResult.ts
@@ -243,6 +243,7 @@ export class SqlResultImpl implements SqlResult {
         // Prevent ongoing/future fetch requests
         if (!this.fetchDeferred) {
             this.fetchDeferred = deferredPromise<SqlPage>();
+            this.fetchDeferred.promise.catch(()=>{});
         }
         this.fetchDeferred.reject(error);
         // Send the close request.
@@ -349,7 +350,7 @@ export class SqlResultImpl implements SqlResult {
         }
         // Do not start a fetch if the result is already closed
         if (this.closed) {
-            return Promise.reject('Cannot fetch, the result is already closed');
+            return Promise.reject(new IllegalStateError('Cannot fetch, the result is already closed'));
         }
 
         this.fetchDeferred = deferredPromise<SqlPage>();

--- a/src/sql/SqlService.ts
+++ b/src/sql/SqlService.ts
@@ -292,6 +292,7 @@ export class SqlServiceImpl implements SqlService {
 
         const connection = this.connectionRegistry.getRandomConnection(true);
         if (connection === null) {
+            // Either the client is not connected to the cluster, or there are no data members in the cluster.
             throw new HazelcastSqlException(
                 this.connectionManager.getClientUuid(),
                 SqlErrorCode.CONNECTION_PROBLEM,

--- a/src/sql/SqlService.ts
+++ b/src/sql/SqlService.ts
@@ -261,7 +261,8 @@ export class SqlServiceImpl implements SqlService {
     toHazelcastSqlException(err: any, connection: Connection) : HazelcastSqlException {
         if (!connection.isAlive()) {
             return new HazelcastSqlException(
-                connection.getRemoteUuid(), SqlErrorCode.CONNECTION_PROBLEM,
+                this.connectionManager.getClientUuid(),
+                SqlErrorCode.CONNECTION_PROBLEM,
                 'Cluster topology changed while a query was executed:' +
                 `Member cannot be reached: ${connection.getRemoteAddress()}`,
                 err

--- a/src/sql/SqlService.ts
+++ b/src/sql/SqlService.ts
@@ -200,7 +200,6 @@ export class SqlServiceImpl implements SqlService {
      *
      * @param sqlStatement
      * @throws RangeError if validation is not successful
-     * @internal
      */
     private static validateSqlStatement(sqlStatement: SqlStatement | null): void {
         if (sqlStatement === null) {
@@ -223,7 +222,6 @@ export class SqlServiceImpl implements SqlService {
      *
      * @param sqlStatementOptions
      * @throws RangeError if validation is not successful
-     * @internal
      */
     private static validateSqlStatementOptions(sqlStatementOptions: SqlStatementOptions): void {
         if (sqlStatementOptions.hasOwnProperty('schema')) {
@@ -253,7 +251,6 @@ export class SqlServiceImpl implements SqlService {
 
     /**
      * Converts an error to HazelcastSqlException and returns it. Used by execute, close and fetch
-     * @internal
      * @param err
      * @param connection
      * @returns {@link HazelcastSqlException}
@@ -384,7 +381,6 @@ export class SqlServiceImpl implements SqlService {
      * Sends a close request on a connection for an SQL result using its query id.
      * @param connection The connection the request will be sent to
      * @param queryId The query id that defines the SQL result
-     * @internal
      */
     close(connection: Connection, queryId: SqlQueryId): Promise<ClientMessage> {
         const requestMessage = SqlCloseCodec.encodeRequest(queryId);
@@ -396,7 +392,6 @@ export class SqlServiceImpl implements SqlService {
      * @param connection The connection the request will be sent to
      * @param queryId The query id that defines the SQL result
      * @param cursorBufferSize The cursor buffer size associated with SQL fetch request, i.e its page size
-     * @internal
      */
     fetch(connection: Connection, queryId: SqlQueryId, cursorBufferSize: number): Promise<SqlPage> {
         const requestMessage = SqlFetchCodec.encodeRequest(queryId, cursorBufferSize);

--- a/src/sql/SqlService.ts
+++ b/src/sql/SqlService.ts
@@ -379,11 +379,24 @@ export class SqlServiceImpl implements SqlService {
         return this.executeStatement(sqlStatement);
     }
 
+    /**
+     * Sends a close request on a connection for an SQL result using its query id.
+     * @param connection The connection the request will be sent to
+     * @param queryId The query id that defines the SQL result
+     * @internal
+     */
     close(connection: Connection, queryId: SqlQueryId): Promise<ClientMessage> {
         const requestMessage = SqlCloseCodec.encodeRequest(queryId);
         return this.invocationService.invokeOnConnection(connection, requestMessage);
     }
 
+    /**
+     * Sends a fetch request on a connection for an SQL result using its query id.
+     * @param connection The connection the request will be sent to
+     * @param queryId The query id that defines the SQL result
+     * @param cursorBufferSize The cursor buffer size associated with SQL fetch request, i.e its page size
+     * @internal
+     */
     fetch(connection: Connection, queryId: SqlQueryId, cursorBufferSize: number): Promise<SqlPage> {
         const requestMessage = SqlFetchCodec.encodeRequest(queryId, cursorBufferSize);
         return this.invocationService.invokeOnConnection(connection, requestMessage).then(clientMessage => {

--- a/src/util/DatetimeUtil.ts
+++ b/src/util/DatetimeUtil.ts
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/** @ignore *//** */
 
 /**
- Constructs and returns timezone for ISO string from offsetSeconds
- @internal
-
- @param offsetSeconds Offset in seconds, can be negative or positive. must be in valid timezone range [-64800, 64800]. If out of
- this range, the limit values are assumed.
- @throws RangeError if offset seconds is not number
- @return Timezone string, can be 'Z', +hh:mm or -hh:mm
+ * Constructs and returns timezone for ISO string from offsetSeconds
+ * @internal
+ *
+ * @param offsetSeconds Offset in seconds, can be negative or positive. must be in valid timezone range [-64800, 64800]. If out of
+ * this range, the limit values are assumed.
+ * @throws RangeError if offset seconds is not number
+ * @return Timezone string, can be 'Z', +hh:mm or -hh:mm
  */
 export function getTimezoneOffsetFromSeconds(offsetSeconds: number): string {
     if (!Number.isInteger(offsetSeconds)) {
@@ -57,12 +57,12 @@ export function getTimezoneOffsetFromSeconds(offsetSeconds: number): string {
 }
 
 /**
- Parses timezone string and returns offset in seconds
- @internal
-
- @param timezoneString string, can be 'Z', +hh:mm or -hh:mm
- @throws RangeError If timezoneString is invalid
- @return Timezone Offset in seconds, can be negative or positive. must be in valid timezone range [-64800, 64800]
+ * Parses timezone string and returns offset in seconds
+ * @internal
+ *
+ * @param timezoneString string, can be 'Z', +hh:mm or -hh:mm
+ * @throws RangeError If timezoneString is invalid
+ * @return Timezone Offset in seconds, can be negative or positive. must be in valid timezone range [-64800, 64800]
  */
 export function getOffsetSecondsFromTimezoneString(timezoneString: string): number {
     if (typeof timezoneString !== 'string') {
@@ -100,8 +100,9 @@ export function getOffsetSecondsFromTimezoneString(timezoneString: string): numb
 }
 
 /**
- * Give this function integer and it will zero pad to the given length.
  * @internal
+ * Give this function integer and it will zero pad to the given length.
+ *
  * @param value
  * @param length total length after padding
  * @returns Zero padded string
@@ -130,7 +131,9 @@ enum Months {
 }
 
 /**
+ * @internal
  * Returns the string representation of a local date.
+ *
  * @param year Must be between -999999999-999999999
  * @param month Must be between 1-12
  * @param date Must be between 1-31 depending on year and month
@@ -187,6 +190,7 @@ export function getLocalDateString(year: number, month: number, date: number): s
 }
 
 /**
+ * @internal
  * Returns the string representation of a local time.
  *
  * @param hour The hour-of-day to represent, from 0 to 23

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -512,7 +512,7 @@ describe('SqlExecuteTest', function () {
             });
             error1.should.be.instanceof(getHazelcastSqlException());
             error1.code.should.be.eq(getSqlErrorCode().CONNECTION_PROBLEM);
-            error1.originatingMemberId.toString().should.be.eq(member.uuid);
+            error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
         });
 
         it('should return an error if connection lost - statement', async function () {
@@ -538,7 +538,7 @@ describe('SqlExecuteTest', function () {
             });
             error1.should.be.instanceof(getHazelcastSqlException());
             error1.code.should.be.eq(getSqlErrorCode().CONNECTION_PROBLEM);
-            error1.originatingMemberId.toString().should.be.eq(member.uuid);
+            error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
         });
 
         it('should return an error if sql is invalid', async function () {

--- a/test/unit/sql/SqlResult.js
+++ b/test/unit/sql/SqlResult.js
@@ -302,7 +302,7 @@ describe('SqlResultTest', function () {
             }, 100);
         });
 
-        it('should not call onExecuteError and change properties after an error is received', function (done) {
+        it('should call onExecuteError and change properties after an error is received', function (done) {
             const sqlResult = new SqlResultImpl(fakeSqlService, {}, {}, {}, 4096);
             const onExecuteErrorFake = sandbox.replace(sqlResult, 'onExecuteError', sandbox.fake(sqlResult.onExecuteError));
             // simulate a response then call close()


### PR DESCRIPTION
### Changes

* If connection is not alive, client's uuid is used instead of remote uuid. fixes that. Note: Due to this change I think we should backport this to 4.2.x 

* Changes isRowSet logic to make it faster

* Doc or API doc changes

* Changes 'should reject iteration after close()' test to run close() at the middle of iteration with page size of 1. It was flaky in the previous version because if the result is received before close() is called, it will fail. Also adds catch() to rejected fetchPromise to suppress UnhandledPromiseRejectionWarning  Note: Also due to this change I think we should backport this to 4.2.x
* ignore empty modules from api doc