### PR TITLE
Delete pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run test:unit


### PR DESCRIPTION
deletes the pre-push hook that runs unit tests before pushing, because its run takes long time and feels a bit unnecessary