### PR TITLE
Make dependabot weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
     - package-ecosystem: npm
       directory: "/"
       schedule:
-        interval: daily
+        interval: weekly
         time: "09:00"
         timezone: "Asia/Istanbul"
       open-pull-requests-limit: 10


### PR DESCRIPTION
Too frequent prs pollute git history.