### PR TITLE
API-555 Fix ReliableTopicOnClusterRestart test

### DIFF
--- a/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
+++ b/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
@@ -92,7 +92,7 @@ describe('ReliableTopicOnClusterRestartTest', function () {
             messageArrived = true;
         });
 
-        // wait some time for adding message listener
+        // wait some time for message listener to initialized
         await promiseWaitMilliseconds(2000);
 
         await RC.shutdownMember(cluster.id, member.uuid);
@@ -123,7 +123,7 @@ describe('ReliableTopicOnClusterRestartTest', function () {
             messageArrived = true;
         });
 
-        // wait some time for adding message listener
+        // wait some time for message listener to initialized
         await promiseWaitMilliseconds(2000);
 
         await RC.shutdownMember(cluster.id, member.uuid);
@@ -154,7 +154,7 @@ describe('ReliableTopicOnClusterRestartTest', function () {
             messageArrived = true;
         });
 
-        // wait some time for adding message listener
+        // wait some time for message listener to initialized
         await promiseWaitMilliseconds(2000);
 
         await RC.shutdownMember(cluster.id, member.uuid);

--- a/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
+++ b/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
@@ -92,6 +92,9 @@ describe('ReliableTopicOnClusterRestartTest', function () {
             messageArrived = true;
         });
 
+        // wait some time for adding message listener
+        await promiseWaitMilliseconds(2000);
+
         await RC.shutdownMember(cluster.id, member.uuid);
         await RC.startMember(cluster.id);
 
@@ -120,6 +123,9 @@ describe('ReliableTopicOnClusterRestartTest', function () {
             messageArrived = true;
         });
 
+        // wait some time for adding message listener
+        await promiseWaitMilliseconds(2000);
+
         await RC.shutdownMember(cluster.id, member.uuid);
 
         // wait for the topic operation to timeout
@@ -147,6 +153,9 @@ describe('ReliableTopicOnClusterRestartTest', function () {
         topic1.addMessageListener(() => {
             messageArrived = true;
         });
+
+        // wait some time for adding message listener
+        await promiseWaitMilliseconds(2000);
 
         await RC.shutdownMember(cluster.id, member.uuid);
         await RC.startMember(cluster.id);

--- a/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
+++ b/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
@@ -29,7 +29,7 @@ describe('ReliableTopicOnClusterRestartTest', function () {
     let client1;
     let client2;
 
-    before(function (){
+    before(function () {
         markClientVersionAtLeast(this, '4.0.2');
     });
 

--- a/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
+++ b/test/integration/backward_compatible/topic/ReliableTopicOnClusterRestart.js
@@ -20,7 +20,7 @@ chai.should();
 
 const RC = require('../../RC');
 const { Client } = require('../../../../');
-const { promiseWaitMilliseconds, assertTrueEventually, randomString } = require('../../../TestUtil');
+const { promiseWaitMilliseconds, assertTrueEventually, randomString, markClientVersionAtLeast } = require('../../../TestUtil');
 
 describe('ReliableTopicOnClusterRestartTest', function () {
 
@@ -28,6 +28,10 @@ describe('ReliableTopicOnClusterRestartTest', function () {
     let member;
     let client1;
     let client2;
+
+    before(function (){
+        markClientVersionAtLeast(this, '4.0.2');
+    });
 
     beforeEach(async function () {
         client1 = undefined;


### PR DESCRIPTION
I realized in Github actions addMessageListener's `tailSequence` call may not be completed before shutting down the member. This leads to uninitialized message listener, therefore an error:  'Failed to fetch sequence for runner.'.

To fix this we should wait some time for the message listener to be initialized before shutting down the member. 


Also adds 4.0.2 min version since there was a fix on 4.0.2  https://github.com/hazelcast/hazelcast-nodejs-client/pull/704


green gh runs for 4.1.0, 4.2.0, 4.0.2 and os, enterprise combinations:

https://github.com/srknzl/test/runs/2898723299
https://github.com/srknzl/test/runs/2898838318
https://github.com/srknzl/test/runs/2898840470
https://github.com/srknzl/test/runs/2898842130
https://github.com/srknzl/test/runs/2898932621
https://github.com/srknzl/test/runs/2898931833


fixes #939 