### PR TITLE
Fix test that asserts originated member uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hazelcast-client",
-    "version": "4.2.0",
+    "version": "5.0",
     "description": "Hazelcast - open source In-Memory Data Grid - client for Node.js",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hazelcast-client",
-    "version": "5.0",
+    "version": "5.0.0",
     "description": "Hazelcast - open source In-Memory Data Grid - client for Node.js",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -518,7 +518,7 @@ describe('SqlExecuteTest', function () {
             if (TestUtil.isClientVersionAtLeast('5.0.0')) {
                 error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
             } else {
-                error1.originatingMemberId.should.be.eq(member.uuid);
+                error1.originatingMemberId.toString().should.be.eq(member.uuid);
             }
         });
 
@@ -551,7 +551,7 @@ describe('SqlExecuteTest', function () {
             if (TestUtil.isClientVersionAtLeast('5.0.0')) {
                 error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
             } else {
-                error1.originatingMemberId.should.be.eq(member.uuid);
+                error1.originatingMemberId.toString().should.be.eq(member.uuid);
             }
         });
 

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -499,6 +499,7 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
+            TestUtil.markClientVersionAtLeast(this, '4.2.1');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
@@ -521,6 +522,9 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
+            // There was a fix regarding originatingMemberId in 4.2.1
+            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
+            TestUtil.markClientVersionAtLeast(this, '4.2.1');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
@@ -547,6 +551,9 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
+            // There was a fix regarding originatingMemberId in 4.2.1
+            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
+            TestUtil.markClientVersionAtLeast(this, '4.2.1');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -499,10 +499,6 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
-            // There was a fix regarding originatingMemberId in 5.0 and 4.2.x after 4.2.
-            // TODO: Update here to be 4.2.1 if we release 4.2.1
-            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
-            TestUtil.markClientVersionAtLeast(this, '5.0.0');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
@@ -516,7 +512,14 @@ describe('SqlExecuteTest', function () {
             });
             error1.should.be.instanceof(getHazelcastSqlException());
             error1.code.should.be.eq(getSqlErrorCode().CONNECTION_PROBLEM);
-            error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
+            // There was a fix regarding originatingMemberId in 5.0 and 4.2.x after 4.2.0.
+            // TODO: Update here to be 4.2.1 if we release 4.2.1
+            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
+            if (TestUtil.isClientVersionAtLeast('5.0.0')) {
+                error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
+            } else {
+                error1.originatingMemberId.should.be.eq(member.uuid);
+            }
         });
 
         it('should return an error if connection lost - statement', async function () {
@@ -525,10 +528,6 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
-            // There was a fix regarding originatingMemberId in 5.0 and 4.2.x after 4.2.
-            // TODO: Update here to be 4.2.1 if we release 4.2.1
-            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
-            TestUtil.markClientVersionAtLeast(this, '5.0.0');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
@@ -546,7 +545,14 @@ describe('SqlExecuteTest', function () {
             });
             error1.should.be.instanceof(getHazelcastSqlException());
             error1.code.should.be.eq(getSqlErrorCode().CONNECTION_PROBLEM);
-            error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
+            // There was a fix regarding originatingMemberId in 5.0 and 4.2.x after 4.2.0.
+            // TODO: Update here to be 4.2.1 if we release 4.2.1
+            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
+            if (TestUtil.isClientVersionAtLeast('5.0.0')) {
+                error1.originatingMemberId.should.be.eq(client.connectionManager.getClientUuid());
+            } else {
+                error1.originatingMemberId.should.be.eq(member.uuid);
+            }
         });
 
         it('should return an error if sql is invalid', async function () {

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -499,7 +499,10 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
-            TestUtil.markClientVersionAtLeast(this, '4.2.1');
+            // There was a fix regarding originatingMemberId in 5.0 and 4.2.x after 4.2.
+            // TODO: Update here to be 4.2.1 if we release 4.2.1
+            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
+            TestUtil.markClientVersionAtLeast(this, '5.0.0');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
@@ -522,9 +525,10 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
-            // There was a fix regarding originatingMemberId in 4.2.1
+            // There was a fix regarding originatingMemberId in 5.0 and 4.2.x after 4.2.
+            // TODO: Update here to be 4.2.1 if we release 4.2.1
             // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
-            TestUtil.markClientVersionAtLeast(this, '4.2.1');
+            TestUtil.markClientVersionAtLeast(this, '5.0.0');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -555,9 +555,6 @@ describe('SqlExecuteTest', function () {
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
-            // There was a fix regarding originatingMemberId in 4.2.1
-            // https://github.com/hazelcast/hazelcast-nodejs-client/pull/940
-            TestUtil.markClientVersionAtLeast(this, '4.2.1');
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);


### PR DESCRIPTION
Updates client version to 5.0(should we do it? we should do for the test to run in master ci tests) and adds client version check of 4.2.1 to a test to fix back compatibility tests.

failing: https://github.com/srknzl/test/actions/runs/967207890
after tests update, the one that should pass: https://github.com/srknzl/test/actions/runs/967371138