### PR TITLE
Convert ClientReconnectTest to async await

### DIFF
--- a/src/listener/ClusterViewListenerService.ts
+++ b/src/listener/ClusterViewListenerService.ts
@@ -15,7 +15,12 @@
  */
 /** @ignore *//** */
 
-import {ConnectionManager, ConnectionRegistry} from '../network/ConnectionManager';
+import {
+    ConnectionManager,
+    ConnectionRegistry,
+    CONNECTION_ADDED_EVENT_NAME,
+    CONNECTION_REMOVED_EVENT_NAME
+} from '../network/ConnectionManager';
 import {PartitionServiceImpl} from '../PartitionService';
 import {ClusterService} from '../invocation/ClusterService';
 import {ILogger} from '../logging/ILogger';
@@ -44,8 +49,8 @@ export class ClusterViewListenerService {
     ) {}
 
     public start(): void {
-        this.connectionManager.on('connectionAdded', this.connectionAdded.bind(this));
-        this.connectionManager.on('connectionRemoved', this.connectionRemoved.bind(this));
+        this.connectionManager.on(CONNECTION_ADDED_EVENT_NAME, this.connectionAdded.bind(this));
+        this.connectionManager.on(CONNECTION_REMOVED_EVENT_NAME, this.connectionRemoved.bind(this));
     }
 
     private connectionAdded(connection: Connection): void {

--- a/src/listener/ListenerService.ts
+++ b/src/listener/ListenerService.ts
@@ -30,7 +30,12 @@ import {ListenerMessageCodec} from './ListenerMessageCodec';
 import {deferredPromise} from '../util/Util';
 import {UuidUtil} from '../util/UuidUtil';
 import {ILogger} from '../logging';
-import {ConnectionManager, ConnectionRegistry} from '../network/ConnectionManager';
+import {
+    ConnectionManager,
+    ConnectionRegistry,
+    CONNECTION_ADDED_EVENT_NAME,
+    CONNECTION_REMOVED_EVENT_NAME
+} from '../network/ConnectionManager';
 
 /** @internal */
 export class ListenerService {
@@ -50,8 +55,8 @@ export class ListenerService {
     }
 
     start(): void {
-        this.connectionManager.on('connectionAdded', this.onConnectionAdded.bind(this));
-        this.connectionManager.on('connectionRemoved', this.onConnectionRemoved.bind(this));
+        this.connectionManager.on(CONNECTION_ADDED_EVENT_NAME, this.onConnectionAdded.bind(this));
+        this.connectionManager.on(CONNECTION_REMOVED_EVENT_NAME, this.onConnectionRemoved.bind(this));
     }
 
     onConnectionAdded(connection: Connection): void {

--- a/src/network/ConnectionManager.ts
+++ b/src/network/ConnectionManager.ts
@@ -71,8 +71,10 @@ import {AddressProvider} from '../connection/AddressProvider';
 import {ClusterService} from '../invocation/ClusterService';
 import {SerializationService} from '../serialization/SerializationService';
 
-const CONNECTION_REMOVED_EVENT_NAME = 'connectionRemoved';
-const CONNECTION_ADDED_EVENT_NAME = 'connectionAdded';
+/** @internal */
+export const CONNECTION_REMOVED_EVENT_NAME = 'connectionRemoved';
+/** @internal */
+export const CONNECTION_ADDED_EVENT_NAME = 'connectionAdded';
 
 /** @internal */
 export const CLIENT_TYPE = 'NJS';


### PR DESCRIPTION
done was not being called in case of an error. fixes that and also converts to async await


Also makes a change to export CONNECTION_REMOVED_EVENT_NAME, CONNECTION_ADDED_EVENT_NAME event names and use them