### PR TITLE
API-673 HeartbeatfromServer flaky test fix

### DIFF
--- a/src/core/MembershipListener.ts
+++ b/src/core/MembershipListener.ts
@@ -62,14 +62,14 @@ export interface MembershipListener {
      *
      * @param {MembershipEvent} event event object
      */
-    memberAdded(event: MembershipEvent): void;
+    memberAdded?(event: MembershipEvent): void;
 
     /**
      * Invoked when an existing member leaves the cluster.
      *
      * @param {MembershipEvent} event event object
      */
-    memberRemoved(event: MembershipEvent): void;
+    memberRemoved?(event: MembershipEvent): void;
 
 }
 

--- a/test/integration/heartbeat/HeartbeatFromServerTest.js
+++ b/test/integration/heartbeat/HeartbeatFromServerTest.js
@@ -53,6 +53,7 @@ describe('HeartbeatFromServerTest', function () {
     }
 
     beforeEach(async function () {
+        this.timeout(200000);
         cluster = await RC.createCluster(null, null);
     });
 

--- a/test/integration/heartbeat/HeartbeatFromServerTest.js
+++ b/test/integration/heartbeat/HeartbeatFromServerTest.js
@@ -90,8 +90,6 @@ describe('HeartbeatFromServerTest', function () {
             member2 = m2;
             return memberAddedPromise.promise;
         }).then(() => {
-            simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000);
-        }).then(() => {
             client.getConnectionManager().once('connectionRemoved', (connection) => {
                 const remoteAddress = connection.getRemoteAddress();
                 if (remoteAddress.host === member2.host && remoteAddress.port === member2.port) {
@@ -106,6 +104,7 @@ describe('HeartbeatFromServerTest', function () {
                         + member2.host + ':' + member2.port));
                 }
             });
+            simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000);
         }).catch(done);
     });
 

--- a/test/integration/heartbeat/HeartbeatFromServerTest.js
+++ b/test/integration/heartbeat/HeartbeatFromServerTest.js
@@ -53,7 +53,6 @@ describe('HeartbeatFromServerTest', function () {
     }
 
     beforeEach(async function () {
-        this.timeout(200000);
         cluster = await RC.createCluster(null, null);
     });
 
@@ -105,7 +104,18 @@ describe('HeartbeatFromServerTest', function () {
                         + member2.host + ':' + member2.port));
                 }
             });
-            simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000);
+            /*
+            Run more than once to avoid the following case:
+
+            as a result of ping requests lastReadTime of a connection is continuously updated.
+            let's say we called simulateHeartbeatLost and then
+            before the heartbeatFunction() has a chance to run(it has 500 interval for this test)
+            data may be received on the socket, which updates the lastReadTime. Then heartbeatFunction
+            runs and since lastReadTime is updated, it won't close the connection.
+             */
+            for (let i = 0; i < 5; i++) {
+                setTimeout(() => simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000), 100 * i);
+            }
         }).catch(done);
     });
 
@@ -153,7 +163,21 @@ describe('HeartbeatFromServerTest', function () {
                         + member2.host + ':' + member2.port));
                 }
             });
-            simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000);
+            /*
+            Run more than once to avoid the following case:
+
+            as a result of ping requests lastReadTime of a connection is continuously updated.
+            let's say we called simulateHeartbeatLost and then
+            before the heartbeatFunction() has a chance to run(it has 500 interval for this test)
+            data may be received on the socket, which updates the lastReadTime. Then heartbeatFunction
+            runs and since lastReadTime is updated, it won't close the connection.
+             */
+            for (let i = 0; i < 5; i++) {
+                setTimeout(
+                    () => simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000),
+                    2000 + i * 100
+                );
+            }
         }).catch(done);
     });
 });


### PR DESCRIPTION
1.  Sets lastReadTimeMillis in simulateHeartbeatLost more than once to avoid the following case:

As a result of ping requests, lastReadTime of a connection is continuously updated.
Let's say we called simulateHeartbeatLost and then
before the heartbeatFunction() has a chance to run some
data may be received on the socket, which updates the lastReadTime. Then, when heartbeatFunction
runs, it won't close the connection because lastReadTime is updated.

2) Avoids a race by registering connectionRemoved handler before simulating heartbeat lost. Connection checker method may run before the handler is registered. This would lead to a fail.

3) Adjusts memberAdded and memberRemoved properties to be optional in type definition.

fixes #820 