### PR TITLE
Make codecov informational

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+    status:
+        project:
+            default:
+                informational: true


### PR DESCRIPTION
Codecov gh app makes codecov appear in gh checks. In gh checks codecov shows as a failing job if coverage drops.  We make codecov only informational in github checks.

informational mode: https://docs.codecov.com/docs/commit-status#informational

to validate yaml: https://docs.codecov.com/docs/codecov-yaml#validate-your-repository-yaml

about the location and name of the file: https://docs.codecov.com/docs/codecov-yaml#can-i-name-the-file-codecovyml