### PR TITLE
API-868 Disable asserts in prod build

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -18,6 +18,7 @@
 * [2. Features](#2-features)
 * [3. Configuration](#3-configuration)
   * [3.1 Client Properties](#31-client-properties)
+  * [3.2 Enabling Assertions](#32-enabling-assertions)
 * [4. Serialization](#4-serialization)
   * [4.1. IdentifiedDataSerializable Serialization](#41-identifieddataserializable-serialization)
   * [4.2. Portable Serialization](#42-portable-serialization)
@@ -587,6 +588,11 @@ The following is the list of all client properties in alphabetical order.
 | hazelcast.invalidation.max.tolerated.miss.count        | 10                                  | number          | If missed invalidation count is bigger than this value, relevant cached data in a Near Cache will be made unreachable.                                                                                                                                                                                                                                                                                              |
 | hazelcast.invalidation.reconciliation.interval.seconds | 60                                  | number          | Period of the task that scans cluster members to compare generated invalidation events with the received ones from the client Near Cache.                                                                                                                                                                                                                                                                           |
 | hazelcast.logging.level                                | INFO                                | string          | Logging level. Can be one of `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`.                                                                                                                                                                                                                                                                                                                                      |
+
+# 3.2 Enabling Assertions
+
+There are some assertions in the Hazelcast Node.js Client's codebase, by default disabled to avoid performance penalty. By setting `HZ_NODEJS_ENV` environment
+variable to `development`, you can enable assertions. This can be useful to debug your code.
 
 # 4. Serialization
 

--- a/package.json
+++ b/package.json
@@ -42,18 +42,18 @@
     "scripts": {
         "clean": "rimraf lib *.jar *.log",
         "compile": "tsc",
-        "test": "node scripts/test-runner.js all",
-        "test:unit": "node scripts/test-runner.js unit",
-        "test:integration": "node scripts/test-runner.js integration",
+        "test": "HZ_NODEJS_ENV=development node scripts/test-runner.js all",
+        "test:unit": "HZ_NODEJS_ENV=development node scripts/test-runner.js unit",
+        "test:integration": "HZ_NODEJS_ENV=development node scripts/test-runner.js integration",
         "validate-user-code": "tsc --build test/user_code/tsconfig.json",
-        "coverage": "node scripts/test-runner.js coverage",
+        "coverage": "HZ_NODEJS_ENV=development node scripts/test-runner.js coverage",
         "pregenerate-docs": "rimraf docs",
         "generate-docs": "typedoc --options typedoc.json",
         "generate-docs:watch": "typedoc --watch --options typedoc.json",
         "lint": "eslint --cache --ext .ts src && eslint --cache --plugin mocha test && eslint --cache  code_samples && eslint --cache scripts",
         "lint:fix": "eslint --cache --fix --ext .ts src && eslint --cache --fix --plugin mocha test && eslint --cache --fix code_samples && eslint --cache --fix scripts",
         "startrc": "node scripts/test-runner.js startrc",
-        "check-code-samples": "node scripts/test-runner.js check-code-samples",
+        "check-code-samples": "HZ_NODEJS_ENV=development node scripts/test-runner.js check-code-samples",
         "prepare": "husky install"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -42,18 +42,18 @@
     "scripts": {
         "clean": "rimraf lib *.jar *.log",
         "compile": "tsc",
-        "test": "HZ_NODEJS_ENV=development node scripts/test-runner.js all",
-        "test:unit": "HZ_NODEJS_ENV=development node scripts/test-runner.js unit",
-        "test:integration": "HZ_NODEJS_ENV=development node scripts/test-runner.js integration",
+        "test": "node scripts/test-runner.js all",
+        "test:unit": "node scripts/test-runner.js unit",
+        "test:integration": "node scripts/test-runner.js integration",
         "validate-user-code": "tsc --build test/user_code/tsconfig.json",
-        "coverage": "HZ_NODEJS_ENV=development node scripts/test-runner.js coverage",
+        "coverage": "node scripts/test-runner.js coverage",
         "pregenerate-docs": "rimraf docs",
         "generate-docs": "typedoc --options typedoc.json",
         "generate-docs:watch": "typedoc --watch --options typedoc.json",
         "lint": "eslint --cache --ext .ts src && eslint --cache --plugin mocha test && eslint --cache  code_samples && eslint --cache scripts",
         "lint:fix": "eslint --cache --fix --ext .ts src && eslint --cache --fix --plugin mocha test && eslint --cache --fix code_samples && eslint --cache --fix scripts",
         "startrc": "node scripts/test-runner.js startrc",
-        "check-code-samples": "HZ_NODEJS_ENV=development node scripts/test-runner.js check-code-samples",
+        "check-code-samples": "node scripts/test-runner.js check-code-samples",
         "prepare": "husky install"
     },
     "repository": {

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -39,6 +39,9 @@ let CLASSPATH = `hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar${PATH_S
               + `hazelcast-sql-${HAZELCAST_VERSION}.jar${PATH_SEPARATOR}`
               + 'test/javaclasses';
 
+// Set environment to development so that assertions in the code work.
+process.env.HZ_NODEJS_ENV = 'development';
+
 if (HAZELCAST_ENTERPRISE_KEY) {
     CLASSPATH = `hazelcast-enterprise-${HAZELCAST_ENTERPRISE_VERSION}.jar${PATH_SEPARATOR}`
               + `hazelcast-enterprise-${HAZELCAST_ENTERPRISE_TEST_VERSION}-tests.jar${PATH_SEPARATOR}`

--- a/src/config/ConfigBuilder.ts
+++ b/src/config/ConfigBuilder.ts
@@ -119,10 +119,10 @@ export class ConfigBuilder {
         for (const key in jsonObject) {
             const value = jsonObject[key];
             if (key === 'initialBackoffMillis') {
-                assertNonNegativeNumber(value, 'Initial backoff must be non-negative!');
+                assertNonNegativeNumber(value, 'Initial backoff must be non-negative!', true);
                 this.effectiveConfig.connectionStrategy.connectionRetry.initialBackoffMillis = value;
             } else if (key === 'maxBackoffMillis') {
-                assertNonNegativeNumber(value, 'Max backoff must be non-negative!');
+                assertNonNegativeNumber(value, 'Max backoff must be non-negative!', true);
                 this.effectiveConfig.connectionStrategy.connectionRetry.maxBackoffMillis = value;
             } else if (key === 'multiplier') {
                 if (typeof value !== 'number' || value < 1.0) {

--- a/src/config/FailoverConfigBuilder.ts
+++ b/src/config/FailoverConfigBuilder.ts
@@ -56,7 +56,7 @@ export class FailoverConfigBuilder {
             const value = jsonObject[key];
             if (key === 'tryCount') {
                 const tryCount = tryGetNumber(value);
-                assertNonNegativeNumber(tryCount, 'tryCount must be a non-negative integer.');
+                assertNonNegativeNumber(tryCount, 'tryCount must be a non-negative integer.', true);
                 this.effectiveConfig.tryCount = tryCount;
             } else if (key === 'clientConfigs') {
                 const configs = tryGetArray(value);
@@ -73,7 +73,7 @@ export class FailoverConfigBuilder {
 
     private validate(): void {
         const clientConfigs = this.effectiveConfig.clientConfigs;
-        assertPositiveNumber(clientConfigs.length, 'FailoverConfig must have at least one client config.');
+        assertPositiveNumber(clientConfigs.length, 'FailoverConfig must have at least one client config.', true);
         const main = clientConfigs[0];
         for (const alternative of clientConfigs.slice(1)) {
             this.validateAlternativeConfigs(main, alternative);
@@ -91,7 +91,8 @@ export class FailoverConfigBuilder {
                 + ' must have the same config as the initial config with cluster name '
                 + main.clusterName + ' except for the following options: '
                 + 'clusterName, customCredentials, network.clusterMembers, '
-                + 'network.ssl, network.hazelcastCloud'
+                + 'network.ssl, network.hazelcastCloud',
+            true
         );
     }
 

--- a/src/config/FailoverConfigBuilder.ts
+++ b/src/config/FailoverConfigBuilder.ts
@@ -15,14 +15,14 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
 import * as util from 'util';
 import {InvalidConfigurationError} from '../core';
 import {
     assertPositiveNumber,
     assertNonNegativeNumber,
     tryGetArray,
-    tryGetNumber
+    tryGetNumber,
+    assert
 } from '../util/Util';
 import {ConfigBuilder} from './ConfigBuilder';
 import {ClientConfigImpl} from './Config';

--- a/src/core/HazelcastJsonValue.ts
+++ b/src/core/HazelcastJsonValue.ts
@@ -43,7 +43,7 @@ export class HazelcastJsonValue {
      * @param jsonString a non-null Json string
      */
     constructor(jsonString: string) {
-        assertString(jsonString);
+        assertString(jsonString, true);
         this.jsonString = jsonString;
     }
 

--- a/src/invocation/ClusterService.ts
+++ b/src/invocation/ClusterService.ts
@@ -107,7 +107,7 @@ export class ClusterService implements Cluster {
     }
 
     addMembershipListener(listener: MembershipListener): string {
-        assertNotNull(listener);
+        assertNotNull(listener, true);
 
         const registrationId = UuidUtil.generate().toString();
         this.listeners.set(registrationId, listener);
@@ -125,7 +125,7 @@ export class ClusterService implements Cluster {
     }
 
     removeMembershipListener(listenerId: string): boolean {
-        assertNotNull(listenerId);
+        assertNotNull(listenerId, true);
         return this.listeners.delete(listenerId);
     }
 

--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -15,7 +15,6 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
 import {
     ClientNotActiveError,
     HazelcastInstanceNotActiveError,
@@ -39,7 +38,8 @@ import {
     cancelRepetitionTask,
     Task,
     deferredPromise,
-    DeferredPromise
+    DeferredPromise,
+    assert
 } from '../util/Util';
 import {ClientConfig} from '../config';
 import {ListenerService} from '../listener/ListenerService';

--- a/src/nearcache/RepairingTask.ts
+++ b/src/nearcache/RepairingTask.ts
@@ -15,7 +15,7 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
+import { assert } from '../util/Util';
 import * as Long from 'long';
 import {MetadataFetcher} from './MetadataFetcher';
 import {NearCache} from './NearCache';

--- a/src/nearcache/RepairingTask.ts
+++ b/src/nearcache/RepairingTask.ts
@@ -93,7 +93,7 @@ export class RepairingTask {
     }
 
     start(): void {
-        assert(this.reconcilliationInterval > 0);
+        assert(this.reconcilliationInterval > 0, undefined, true);
         this.antientropyTaskHandle = setInterval(this.antiEntropyTask.bind(this), this.reconcilliationInterval);
     }
 

--- a/src/proxy/MapProxy.ts
+++ b/src/proxy/MapProxy.ts
@@ -99,7 +99,7 @@ type EntryEventHander = (key: Data, value: Data, oldValue: Data, mergingValue: D
 /** @internal */
 export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     aggregate<R>(aggregator: Aggregator<R>): Promise<R> {
-        assertNotNull(aggregator);
+        assertNotNull(aggregator, true);
         const aggregatorData = this.toData(aggregator);
         return this.encodeInvokeOnRandomTarget(MapAggregateCodec, aggregatorData)
             .then((clientMessage) => {
@@ -109,8 +109,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     aggregateWithPredicate<R>(aggregator: Aggregator<R>, predicate: Predicate): Promise<R> {
-        assertNotNull(aggregator);
-        assertNotNull(predicate);
+        assertNotNull(aggregator, true);
+        assertNotNull(predicate, true);
         this.checkNotPagingPredicate(predicate);
         const aggregatorData = this.toData(aggregator);
         const predicateData = this.toData(predicate);
@@ -122,8 +122,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     executeOnKeys(keys: K[], entryProcessor: IdentifiedDataSerializable | Portable): Promise<any[]> {
-        assertNotNull(keys);
-        assertArray(keys);
+        assertNotNull(keys, true);
+        assertArray(keys, true);
         if (keys.length === 0) {
             return Promise.resolve([]);
         } else {
@@ -139,8 +139,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     executeOnKey(key: K, entryProcessor: IdentifiedDataSerializable | Portable): Promise<V> {
-        assertNotNull(key);
-        assertNotNull(entryProcessor);
+        assertNotNull(key, true);
+        assertNotNull(entryProcessor, true);
         const keyData = this.toData(key);
         const proData = this.toData(entryProcessor);
 
@@ -148,7 +148,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     executeOnEntries(entryProcessor: IdentifiedDataSerializable | Portable, predicate: Predicate = null): Promise<Array<[K, V]>> {
-        assertNotNull(entryProcessor);
+        assertNotNull(entryProcessor, true);
         const proData = this.toData(entryProcessor);
         const toObject = this.toObject.bind(this);
         if (predicate == null) {
@@ -169,7 +169,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     entrySetWithPredicate(predicate: Predicate): Promise<any[]> {
-        assertNotNull(predicate);
+        assertNotNull(predicate, true);
 
         const toObject = this.toObject.bind(this);
         if (predicate instanceof PagingPredicateImpl) {
@@ -193,7 +193,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     keySetWithPredicate(predicate: Predicate): Promise<K[]> {
-        assertNotNull(predicate);
+        assertNotNull(predicate, true);
 
         const toObject = this.toObject.bind(this);
         if (predicate instanceof PagingPredicateImpl) {
@@ -217,7 +217,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     valuesWithPredicate(predicate: Predicate): Promise<ReadOnlyLazyList<V>> {
-        assertNotNull(predicate);
+        assertNotNull(predicate, true);
         if (predicate instanceof PagingPredicateImpl) {
             predicate.setIterationType(IterationType.VALUE);
             const serializationService = this.serializationService;
@@ -244,21 +244,21 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     containsKey(key: K): Promise<boolean> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.containsKeyInternal(keyData);
     }
 
     containsValue(value: V): Promise<boolean> {
-        assertNotNull(value);
+        assertNotNull(value, true);
         const valueData = this.toData(value);
         return this.encodeInvokeOnRandomTarget(MapContainsValueCodec, valueData)
             .then(MapContainsValueCodec.decodeResponse);
     }
 
     put(key: K, value: V, ttl?: number | Long, maxIdle?: number | Long): Promise<V> {
-        assertNotNull(key);
-        assertNotNull(value);
+        assertNotNull(key, true);
+        assertNotNull(value, true);
         const keyData: Data = this.toData(key);
         const valueData: Data = this.toData(value);
         return this.putInternal(keyData, valueData, ttl, maxIdle);
@@ -273,13 +273,13 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     get(key: K): Promise<V> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.getInternal(keyData);
     }
 
     remove(key: K, value: V = null): Promise<V | boolean> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.removeInternal(keyData, value);
     }
@@ -299,8 +299,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     getAll(keys: K[]): Promise<any[]> {
-        assertNotNull(keys);
-        assertArray(keys);
+        assertNotNull(keys, true);
+        assertArray(keys, true);
         const partitionService = this.partitionService;
         const partitionsToKeys: { [id: string]: Data[] } = {};
         let key: K;
@@ -318,7 +318,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     delete(key: K): Promise<void> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.deleteInternal(keyData);
     }
@@ -332,7 +332,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     evict(key: K): Promise<boolean> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.evictInternal(keyData);
     }
@@ -346,7 +346,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     lock(key: K, leaseTime = -1): Promise<void> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.encodeInvokeOnKeyWithTimeout(
             Number.MAX_SAFE_INTEGER, MapLockCodec, keyData, keyData, 0, leaseTime, 0
@@ -354,20 +354,20 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     isLocked(key: K): Promise<boolean> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(MapIsLockedCodec, keyData, keyData)
             .then(MapIsLockedCodec.decodeResponse);
     }
 
     unlock(key: K): Promise<void> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(MapUnlockCodec, keyData, keyData, 0, 0).then(() => {});
     }
 
     forceUnlock(key: K): Promise<void> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(MapForceUnlockCodec, keyData, keyData, 0).then(() => {});
     }
@@ -393,33 +393,33 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     putIfAbsent(key: K, value: V, ttl?: number | Long, maxIdle?: number | Long): Promise<V> {
-        assertNotNull(key);
-        assertNotNull(value);
+        assertNotNull(key, true);
+        assertNotNull(value, true);
         const keyData = this.toData(key);
         const valueData = this.toData(value);
         return this.putIfAbsentInternal(keyData, valueData, ttl, maxIdle);
     }
 
     putTransient(key: K, value: V, ttl?: number | Long, maxIdle?: number | Long): Promise<void> {
-        assertNotNull(key);
-        assertNotNull(value);
+        assertNotNull(key, true);
+        assertNotNull(value, true);
         const keyData = this.toData(key);
         const valueData = this.toData(value);
         return this.putTransientInternal(keyData, valueData, ttl, maxIdle);
     }
 
     replace(key: K, newValue: V): Promise<V> {
-        assertNotNull(key);
-        assertNotNull(newValue);
+        assertNotNull(key, true);
+        assertNotNull(newValue, true);
         const keyData = this.toData(key);
         const newValueData = this.toData(newValue);
         return this.replaceInternal(keyData, newValueData);
     }
 
     replaceIfSame(key: K, oldValue: V, newValue: V): Promise<boolean> {
-        assertNotNull(key);
-        assertNotNull(oldValue);
-        assertNotNull(newValue);
+        assertNotNull(key, true);
+        assertNotNull(oldValue, true);
+        assertNotNull(newValue, true);
         const keyData = this.toData(key);
         const newValueData = this.toData(newValue);
         const oldValueData = this.toData(oldValue);
@@ -427,8 +427,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     set(key: K, value: V, ttl?: number | Long, maxIdle?: number | Long): Promise<void> {
-        assertNotNull(key);
-        assertNotNull(value);
+        assertNotNull(key, true);
+        assertNotNull(value, true);
         const keyData = this.toData(key);
         const valueData = this.toData(value);
         return this.setInternal(keyData, valueData, ttl, maxIdle);
@@ -443,7 +443,7 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     getEntryView(key: K): Promise<SimpleEntryView<K, V>> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(MapGetEntryViewCodec, keyData, keyData, 0)
             .then((clientMessage) => {
@@ -461,13 +461,13 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     addIndex(indexConfig: IndexConfig): Promise<void> {
-        assertNotNull(indexConfig);
+        assertNotNull(indexConfig, true);
         const normalizedConfig = IndexUtil.validateAndNormalize(this.name, indexConfig);
         return this.encodeInvokeOnRandomTarget(MapAddIndexCodec, normalizedConfig).then(() => {});
     }
 
     tryLock(key: K, timeout = 0, leaseTime = -1): Promise<boolean> {
-        assertNotNull(key);
+        assertNotNull(key, true);
         const keyData = this.toData(key);
         return this.encodeInvokeOnKeyWithTimeout(
             Number.MAX_SAFE_INTEGER, MapTryLockCodec, keyData, keyData, 0, leaseTime, timeout, 0
@@ -475,17 +475,17 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     tryPut(key: K, value: V, timeout: number): Promise<boolean> {
-        assertNotNull(key);
-        assertNotNull(value);
-        assertNotNull(timeout);
+        assertNotNull(key, true);
+        assertNotNull(value, true);
+        assertNotNull(timeout, true);
         const keyData = this.toData(key);
         const valueData = this.toData(value);
         return this.tryPutInternal(keyData, valueData, timeout);
     }
 
     tryRemove(key: K, timeout: number): Promise<boolean> {
-        assertNotNull(key);
-        assertNotNull(timeout);
+        assertNotNull(key, true);
+        assertNotNull(timeout, true);
         const keyData = this.toData(key);
         return this.tryRemoveInternal(keyData, timeout);
     }
@@ -499,8 +499,8 @@ export class MapProxy<K, V> extends BaseProxy implements IMap<K, V> {
     }
 
     setTtl(key: K, ttl: number): Promise<boolean> {
-        assertNotNull(key);
-        assertNotNull(ttl);
+        assertNotNull(key, true);
+        assertNotNull(ttl, true);
         const keyData = this.toData(key);
         return this.setTtlInternal(keyData, ttl);
     }

--- a/src/proxy/ReplicatedMapProxy.ts
+++ b/src/proxy/ReplicatedMapProxy.ts
@@ -58,8 +58,8 @@ type EntryEventHander = (key: Data, value: Data, oldValue: Data, mergingValue: D
 export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements ReplicatedMap<K, V> {
 
     put(key: K, value: V, ttl: Long | number = 0): Promise<V> {
-        assertNotNull(key);
-        assertNotNull(value);
+        assertNotNull(key, true);
+        assertNotNull(value, true);
 
         const valueData: Data = this.toData(value);
         const keyData: Data = this.toData(key);
@@ -75,7 +75,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
     }
 
     get(key: K): Promise<V> {
-        assertNotNull(key);
+        assertNotNull(key, true);
 
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(ReplicatedMapGetCodec, keyData, keyData)
@@ -86,7 +86,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
     }
 
     containsKey(key: K): Promise<boolean> {
-        assertNotNull(key);
+        assertNotNull(key, true);
 
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(ReplicatedMapContainsKeyCodec, keyData, keyData)
@@ -94,7 +94,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
     }
 
     containsValue(value: V): Promise<boolean> {
-        assertNotNull(value);
+        assertNotNull(value, true);
 
         const valueData = this.toData(value);
         return this.encodeInvoke(ReplicatedMapContainsValueCodec, valueData)
@@ -112,7 +112,7 @@ export class ReplicatedMapProxy<K, V> extends PartitionSpecificProxy implements 
     }
 
     remove(key: K): Promise<V> {
-        assertNotNull(key);
+        assertNotNull(key, true);
 
         const keyData = this.toData(key);
         return this.encodeInvokeOnKey(ReplicatedMapRemoveCodec, keyData, keyData)

--- a/src/proxy/cpsubsystem/AtomicLongProxy.ts
+++ b/src/proxy/cpsubsystem/AtomicLongProxy.ts
@@ -51,7 +51,7 @@ export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
 
     addAndGet(delta: Long | number): Promise<Long> {
         if (!Long.isLong(delta)) {
-            assertNumber(delta);
+            assertNumber(delta, true);
             delta = Long.fromNumber(delta as number);
         }
         return this.encodeInvokeOnRandomTarget(AtomicLongAddAndGetCodec, this.groupId, this.objectName, delta)
@@ -60,11 +60,11 @@ export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
 
     compareAndSet(expect: Long | number, update: Long | number): Promise<boolean> {
         if (!Long.isLong(expect)) {
-            assertNumber(expect);
+            assertNumber(expect, true);
             expect = Long.fromNumber(expect as number);
         }
         if (!Long.isLong(update)) {
-            assertNumber(update);
+            assertNumber(update, true);
             update = Long.fromNumber(update as number);
         }
         return this.encodeInvokeOnRandomTarget(AtomicLongCompareAndSetCodec, this.groupId, this.objectName, expect, update)
@@ -82,7 +82,7 @@ export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
 
     getAndAdd(delta: Long | number): Promise<Long> {
         if (!Long.isLong(delta)) {
-            assertNumber(delta);
+            assertNumber(delta, true);
             delta = Long.fromNumber(delta as number);
         }
         return this.encodeInvokeOnRandomTarget(AtomicLongGetAndAddCodec, this.groupId, this.objectName, delta)
@@ -95,7 +95,7 @@ export class AtomicLongProxy extends BaseCPProxy implements IAtomicLong {
 
     getAndSet(newValue: Long | number): Promise<Long> {
         if (!Long.isLong(newValue)) {
-            assertNumber(newValue);
+            assertNumber(newValue, true);
             newValue = Long.fromNumber(newValue as number);
         }
         return this.encodeInvokeOnRandomTarget(AtomicLongGetAndSetCodec, this.groupId, this.objectName, newValue)

--- a/src/proxy/cpsubsystem/CPProxyManager.ts
+++ b/src/proxy/cpsubsystem/CPProxyManager.ts
@@ -39,14 +39,14 @@ const DEFAULT_GROUP_NAME = 'default';
 
 /** @internal */
 export function withoutDefaultGroupName(name: string): string {
-    assertString(name);
+    assertString(name, true);
     name = name.trim();
     const i = name.indexOf('@');
     if (i === -1) {
         return name;
     }
 
-    assert(name.indexOf('@', i + 1) === -1, 'Custom group name must be specified at most once');
+    assert(name.indexOf('@', i + 1) === -1, 'Custom group name must be specified at most once', true);
     const groupName = name.slice(i + 1).trim();
     if (groupName === DEFAULT_GROUP_NAME) {
         return name.slice(0, i);
@@ -56,15 +56,15 @@ export function withoutDefaultGroupName(name: string): string {
 
 /** @internal */
 export function getObjectNameForProxy(name: string): string {
-    assertString(name);
+    assertString(name, true);
     const i = name.indexOf('@');
     if (i === -1) {
         return name;
     }
 
-    assert(i < (name.length - 1), 'Custom CP group name cannot be empty string');
+    assert(i < (name.length - 1), 'Custom CP group name cannot be empty string', true);
     const objectName = name.slice(0, i).trim();
-    assert(objectName.length > 0, 'Object name cannot be empty string');
+    assert(objectName.length > 0, 'Object name cannot be empty string', true);
     return objectName;
 }
 

--- a/src/proxy/cpsubsystem/CPProxyManager.ts
+++ b/src/proxy/cpsubsystem/CPProxyManager.ts
@@ -15,7 +15,6 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
 import {
     DistributedObject,
     IllegalStateError
@@ -31,7 +30,7 @@ import {SessionAwareSemaphoreProxy} from './SessionAwareSemaphoreProxy';
 import {RaftGroupId} from './RaftGroupId';
 import {CPGroupCreateCPGroupCodec} from '../../codec/CPGroupCreateCPGroupCodec';
 import {SemaphoreGetSemaphoreTypeCodec} from '../../codec/SemaphoreGetSemaphoreTypeCodec';
-import {assertString} from '../../util/Util';
+import {assertString, assert} from '../../util/Util';
 import {InvocationService} from '../../invocation/InvocationService';
 import {SerializationService} from '../../serialization/SerializationService';
 import {CPSessionManager} from './CPSessionManager';

--- a/src/proxy/cpsubsystem/CountDownLatchProxy.ts
+++ b/src/proxy/cpsubsystem/CountDownLatchProxy.ts
@@ -58,7 +58,7 @@ export class CountDownLatchProxy extends BaseCPProxy implements ICountDownLatch 
     }
 
     await(timeout: number): Promise<boolean> {
-        assertNumber(timeout);
+        assertNumber(timeout, true);
         timeout = Math.max(0, timeout);
         const invocationUid = UuidUtil.generate();
         return this.encodeInvokeOnRandomTarget(
@@ -114,7 +114,7 @@ export class CountDownLatchProxy extends BaseCPProxy implements ICountDownLatch 
     }
 
     trySetCount(count: number): Promise<boolean> {
-        assertPositiveNumber(count);
+        assertPositiveNumber(count, undefined, true);
         return this.encodeInvokeOnRandomTarget(
             CountDownLatchTrySetCountCodec,
             this.groupId,

--- a/src/proxy/cpsubsystem/FencedLockProxy.ts
+++ b/src/proxy/cpsubsystem/FencedLockProxy.ts
@@ -97,7 +97,7 @@ export class FencedLockProxy extends CPSessionAwareProxy implements FencedLock {
                 return this.requestLock(sessionId, Long.fromNumber(threadId), invocationUid);
             })
             .then((fence: Fence) => {
-                assert(isValidFence(fence), 'FencedLock somehow hit reentrant lock limit');
+                assert(isValidFence(fence), 'FencedLock somehow hit reentrant lock limit', true);
                 this.lockedSessionIds.set(threadId, sessionId);
                 fence[fenceThreadIdSymbol] = threadId;
                 return fence;
@@ -117,7 +117,7 @@ export class FencedLockProxy extends CPSessionAwareProxy implements FencedLock {
     }
 
     tryLock(timeout = 0): Promise<Fence | undefined> {
-        assertNonNegativeNumber(timeout);
+        assertNonNegativeNumber(timeout, undefined, true);
 
         const threadId = this.nextThreadId();
         const invocationUid = UuidUtil.generate();

--- a/src/proxy/cpsubsystem/FencedLockProxy.ts
+++ b/src/proxy/cpsubsystem/FencedLockProxy.ts
@@ -15,7 +15,7 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
+import { assert } from '../../util/Util';
 import * as Long from 'long';
 import {CPSessionAwareProxy} from './CPSessionAwareProxy';
 import {FencedLock} from '../FencedLock';

--- a/src/proxy/cpsubsystem/SessionAwareSemaphoreProxy.ts
+++ b/src/proxy/cpsubsystem/SessionAwareSemaphoreProxy.ts
@@ -73,13 +73,13 @@ export class SessionAwareSemaphoreProxy extends CPSessionAwareProxy implements I
     }
 
     init(permits: number): Promise<boolean> {
-        assertNonNegativeNumber(permits);
+        assertNonNegativeNumber(permits, undefined, true);
         return this.encodeInvokeOnRandomTarget(SemaphoreInitCodec, this.groupId, this.objectName, permits)
             .then(SemaphoreInitCodec.decodeResponse);
     }
 
     acquire(permits = 1): Promise<void> {
-        assertPositiveNumber(permits);
+        assertPositiveNumber(permits, undefined, true);
 
         const invocationUid = UuidUtil.generate();
         return this.doAcquire(permits, invocationUid);
@@ -109,8 +109,8 @@ export class SessionAwareSemaphoreProxy extends CPSessionAwareProxy implements I
     }
 
     tryAcquire(permits = 1, timeout = 0): Promise<boolean> {
-        assertPositiveNumber(permits);
-        assertNonNegativeNumber(timeout);
+        assertPositiveNumber(permits, undefined, true);
+        assertNonNegativeNumber(timeout, undefined, true);
 
         const invocationUid = UuidUtil.generate();
         return this.doTryAcquire(permits, timeout, invocationUid);
@@ -150,7 +150,7 @@ export class SessionAwareSemaphoreProxy extends CPSessionAwareProxy implements I
     }
 
     release(permits = 1): Promise<void> {
-        assertPositiveNumber(permits);
+        assertPositiveNumber(permits, undefined, true);
 
         const sessionId = this.getSessionId();
         if (NO_SESSION_ID.equals(sessionId)) {
@@ -205,7 +205,7 @@ export class SessionAwareSemaphoreProxy extends CPSessionAwareProxy implements I
     }
 
     reducePermits(reduction: number): Promise<void> {
-        assertNonNegativeNumber(reduction);
+        assertNonNegativeNumber(reduction, undefined, true);
         if (reduction === 0) {
             return Promise.resolve();
         }
@@ -213,7 +213,7 @@ export class SessionAwareSemaphoreProxy extends CPSessionAwareProxy implements I
     }
 
     increasePermits(increase: number): Promise<void> {
-        assertNonNegativeNumber(increase);
+        assertNonNegativeNumber(increase, undefined, true);
         if (increase === 0) {
             return Promise.resolve();
         }

--- a/src/proxy/cpsubsystem/SessionlessSemaphoreProxy.ts
+++ b/src/proxy/cpsubsystem/SessionlessSemaphoreProxy.ts
@@ -65,20 +65,20 @@ export class SessionlessSemaphoreProxy extends BaseCPProxy implements ISemaphore
     }
 
     init(permits: number): Promise<boolean> {
-        assertNonNegativeNumber(permits);
+        assertNonNegativeNumber(permits, undefined, true);
         return this.encodeInvokeOnRandomTarget(SemaphoreInitCodec, this.groupId, this.objectName, permits)
             .then(SemaphoreInitCodec.decodeResponse);
     }
 
     acquire(permits = 1): Promise<void> {
-        assertPositiveNumber(permits);
+        assertPositiveNumber(permits, undefined, true);
 
         return this.doTryAcquire(permits, -1).then(() => {});
     }
 
     tryAcquire(permits = 1, timeout = 0): Promise<boolean> {
-        assertPositiveNumber(permits);
-        assertNonNegativeNumber(timeout);
+        assertPositiveNumber(permits, undefined, true);
+        assertNonNegativeNumber(timeout, undefined, true);
 
         return this.doTryAcquire(permits, timeout);
     }
@@ -109,7 +109,7 @@ export class SessionlessSemaphoreProxy extends BaseCPProxy implements ISemaphore
     }
 
     release(permits = 1): Promise<void> {
-        assertPositiveNumber(permits);
+        assertPositiveNumber(permits, undefined, true);
 
         const invocationUid = UuidUtil.generate();
         return this.getClusterWideThreadId()
@@ -149,7 +149,7 @@ export class SessionlessSemaphoreProxy extends BaseCPProxy implements ISemaphore
     }
 
     reducePermits(reduction: number): Promise<void> {
-        assertNonNegativeNumber(reduction);
+        assertNonNegativeNumber(reduction, undefined, true);
         if (reduction === 0) {
             return Promise.resolve();
         }
@@ -157,7 +157,7 @@ export class SessionlessSemaphoreProxy extends BaseCPProxy implements ISemaphore
     }
 
     increasePermits(increase: number): Promise<void> {
-        assertNonNegativeNumber(increase);
+        assertNonNegativeNumber(increase, undefined, true);
         if (increase === 0) {
             return Promise.resolve();
         }

--- a/src/serialization/ObjectData.ts
+++ b/src/serialization/ObjectData.ts
@@ -15,7 +15,7 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
+import { assert } from '../util/Util';
 import * as Long from 'long';
 import {BitsUtil} from '../util/BitsUtil';
 import {Data, DataInput, DataOutput, PositionalDataOutput} from './Data';

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -29,8 +29,8 @@ const IS_DEVELOPMENT_MODE = process.env.HZ_NODEJS_ENV === 'development';
  * Used to only turn on asserts in development mode
  * @internal
  */
-export function assert(value: any, message?: string | Error): asserts value {
-    if (IS_DEVELOPMENT_MODE) {
+export function assert(value: any, message?: string | Error, alwaysAssert?: boolean): asserts value {
+    if (IS_DEVELOPMENT_MODE || alwaysAssert) {
         _assert(value, message);
     }
 }
@@ -49,30 +49,30 @@ export function assertNotNull(v: any, alwaysAssert?: boolean): void {
 }
 
 /** @internal */
-export function assertArray(x: any): void {
-    exports.assert(Array.isArray(x), 'Should be array.');
+export function assertArray(x: any, alwaysAssert?: boolean): void {
+    exports.assert(Array.isArray(x), 'Should be array.', alwaysAssert);
 }
 
 /** @internal */
-export function assertString(v: any): void {
-    exports.assert(typeof v === 'string', 'String value expected.');
+export function assertString(v: any, alwaysAssert?: boolean): void {
+    exports.assert(typeof v === 'string', 'String value expected.', alwaysAssert);
 }
 
 /** @internal */
-export function assertNumber(v: any): void {
-    exports.assert(typeof v === 'number', 'Number value expected.');
+export function assertNumber(v: any, alwaysAssert?: boolean): void {
+    exports.assert(typeof v === 'number', 'Number value expected.', alwaysAssert);
 }
 
 /** @internal */
-export function assertNonNegativeNumber(v: any, m?: string): void {
-    exports.assert(typeof v === 'number', m || 'Number value expected.');
-    exports.assert(v >= 0, m || 'Non-negative value expected.');
+export function assertNonNegativeNumber(v: any, m?: string, alwaysAssert?: boolean): void {
+    exports.assert(typeof v === 'number', m || 'Number value expected.', alwaysAssert);
+    exports.assert(v >= 0, m || 'Non-negative value expected.', alwaysAssert);
 }
 
 /** @internal */
-export function assertPositiveNumber(v: any, m?: string): void {
-    exports.assert(typeof v === 'number', m || 'Number value expected.');
-    exports.assert(v > 0, m || 'Positive value expected.');
+export function assertPositiveNumber(v: any, m?: string, alwaysAssert?: boolean): void {
+    exports.assert(typeof v === 'number', m || 'Number value expected.', alwaysAssert);
+    exports.assert(v > 0, m || 'Positive value expected.', alwaysAssert);
 }
 
 /** @internal */

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -15,43 +15,58 @@
  */
 /** @ignore *//** */
 
-import * as assert from 'assert';
+import * as _assert from 'assert';
 import * as Long from 'long';
 import * as Path from 'path';
 import {BigDecimal, IllegalStateError, LocalDate, LocalDateTime, LocalTime, MemberImpl, OffsetDateTime, UUID} from '../core';
 import {MemberVersion} from '../core/MemberVersion';
 import {BuildInfo} from '../BuildInfo';
 
+// Used to assert only in development mode
+const IS_DEVELOPMENT_MODE = process.env.HZ_NODEJS_ENV === 'development';
+
+/**
+ * Used to only turn on asserts in development mode
+ * @internal
+ */
+export function assert(value: any, message?: string | Error): asserts value {
+    if (IS_DEVELOPMENT_MODE) {
+        _assert(value, message);
+    }
+}
+
 /** @internal */
 export function assertNotNull(v: any): void {
-    assert.notStrictEqual(v, null, 'Non null value expected.');
+    if (IS_DEVELOPMENT_MODE) {
+        _assert.notStrictEqual(v, null, 'Non null value expected.');
+    }
 }
 
 /** @internal */
 export function assertArray(x: any): void {
-    assert(Array.isArray(x), 'Should be array.');
+    exports.assert(Array.isArray(x), 'Should be array.');
 }
 
 /** @internal */
 export function assertString(v: any): void {
-    assert(typeof v === 'string', 'String value expected.');
+    exports.assert(typeof v === 'string', 'String value expected.');
 }
 
 /** @internal */
 export function assertNumber(v: any): void {
-    assert(typeof v === 'number', 'Number value expected.');
+    exports.assert(typeof v === 'number', 'Number value expected.');
 }
 
 /** @internal */
 export function assertNonNegativeNumber(v: any, m?: string): void {
-    assert(typeof v === 'number', m || 'Number value expected.');
-    assert(v >= 0, m || 'Non-negative value expected.');
+    exports.assert(typeof v === 'number', m || 'Number value expected.');
+    exports.assert(v >= 0, m || 'Non-negative value expected.');
 }
 
 /** @internal */
 export function assertPositiveNumber(v: any, m?: string): void {
-    assert(typeof v === 'number', m || 'Number value expected.');
-    assert(v > 0, m || 'Positive value expected.');
+    exports.assert(typeof v === 'number', m || 'Number value expected.');
+    exports.assert(v > 0, m || 'Positive value expected.');
 }
 
 /** @internal */
@@ -68,7 +83,9 @@ export function shuffleArray<T>(array: T[]): void {
 
 /** @internal */
 export function getType(obj: any): string {
-    assertNotNull(obj);
+    if (IS_DEVELOPMENT_MODE) {
+        assertNotNull(obj);
+    }
     if (Long.isLong(obj)) {
         return 'long';
     } else if (Buffer.isBuffer(obj)) {

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -35,9 +35,15 @@ export function assert(value: any, message?: string | Error): asserts value {
     }
 }
 
-/** @internal */
-export function assertNotNull(v: any): void {
-    if (IS_DEVELOPMENT_MODE) {
+/**
+ * Asserts a value is not null.
+ *
+ * @param v value to assert.
+ * @param alwaysAssert whether assertion should be run no matter we are in development mode or not.
+ * @internal
+ */
+export function assertNotNull(v: any, alwaysAssert?: boolean): void {
+    if (IS_DEVELOPMENT_MODE || alwaysAssert) {
         _assert.notStrictEqual(v, null, 'Non null value expected.');
     }
 }


### PR DESCRIPTION
Adds a env variable check to decide whether to run assertions. Ideally we should skip runtime assertions but we should keep assertions that are used for validation. (Specified in the API docs). Let me know if there are any changes needed.

resolves #482 