### PR TITLE
Fix sql tests and code samples 

### DIFF
--- a/code_samples/bigdecimal_sample.js
+++ b/code_samples/bigdecimal_sample.js
@@ -53,7 +53,22 @@ function portableFactory(classId) {
         };
 
         const client = await Client.newHazelcastClient(cfg);
-        const map = await client.getMap('decimalMap');
+        const mapName = 'decimalMap';
+        const map = await client.getMap(mapName);
+        // To be able to use our map in SQL we need to create mapping for it.
+        const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key VARCHAR,
+                this DECIMAL
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'varchar',
+                'valueFormat' = 'decimal'
+            )
+        `;
+        // executions are async, await on update count to wait for execution.
+        await client.getSql().execute(createMappingQuery).getUpdateCount();
 
         // You can use BigDecimals for any operation
         // Let's add some BigDecimals:

--- a/code_samples/sql-basic-usage.js
+++ b/code_samples/sql-basic-usage.js
@@ -20,7 +20,23 @@ const { Client, SqlColumnType, HazelcastSqlException } = require('hazelcast-clie
 (async () => {
     try {
         const client = await Client.newHazelcastClient();
-        const map = await client.getMap('myMap');
+        const mapName = 'myMap';
+        const map = await client.getMap(mapName);
+
+        // To be able to use our map in SQL we need to create mapping for it.
+        const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key VARCHAR,
+                this DOUBLE
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'varchar',
+                'valueFormat' = 'double'
+            )
+        `;
+        // executions are async, await on update count to wait for execution.
+        await client.getSql().execute(createMappingQuery).getUpdateCount();
 
         await map.put('key1', 1);
         await map.put('key2', 2);

--- a/code_samples/sql-data-types.js
+++ b/code_samples/sql-data-types.js
@@ -40,7 +40,22 @@ class Student {
 
 const varcharExample = async (client) => {
     console.log('----------VARCHAR Example----------');
-    const someMap = await client.getMap('varcharMap');
+    const mapName = 'varcharMap';
+    const someMap = await client.getMap(mapName);
+    // To be able to use our map in SQL we need to create mapping for it.
+    const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key DOUBLE,
+                this VARCHAR
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'double',
+                'valueFormat' = 'varchar'
+            )
+        `;
+    // executions are async, await on update count to wait for execution.
+    await client.getSql().execute(createMappingQuery).getUpdateCount();
 
     for (let key = 0; key < 10; key++) {
         await someMap.set(key, key.toString());
@@ -73,7 +88,22 @@ const varcharExample = async (client) => {
 */
 const integersExample = async (client) => {
     console.log('---------- BIGINT Example----------');
-    const someMap = await client.getMap('bigintMap');
+    const mapName = 'bigintMap';
+    const someMap = await client.getMap(mapName);
+    // To be able to use our map in SQL we need to create mapping for it.
+    const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key DOUBLE,
+                this BIGINT
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'double',
+                'valueFormat' = 'bigint'
+            )
+        `;
+    // executions are async, await on update count to wait for execution.
+    await client.getSql().execute(createMappingQuery).getUpdateCount();
 
     for (let key = 0; key < 10; key++) {
         await someMap.set(key, long.fromNumber(key * 2));
@@ -124,10 +154,27 @@ const integersExample = async (client) => {
 };
 
 // Portable example
-const objectExample = async (client) => {
+const objectExample = async (client, classId, factoryId) => {
     console.log('----------OBJECT Example----------');
-
-    const someMap = await client.getMap('studentMap');
+    const mapName = 'studentMap';
+    const someMap = await client.getMap(mapName);
+    // To be able to use our map in SQL we need to create mapping for it.
+    const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key DOUBLE,
+                age INT,
+                height DOUBLE
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'double',
+                'valueFormat' = 'portable',
+                'valuePortableFactoryId' = '${factoryId}',
+                'valuePortableClassId' = '${classId}'
+            )
+        `;
+    // executions are async, await on update count to wait for execution.
+    await client.getSql().execute(createMappingQuery).getUpdateCount();
 
     for (let key = 0; key < 10; key++) {
         await someMap.set(key, new Student(long.fromNumber(key), 1.1));
@@ -182,7 +229,7 @@ const objectExample = async (client) => {
 
         await varcharExample(client);
         await integersExample(client);
-        await objectExample(client);
+        await objectExample(client, 1, 23);
 
         await client.shutdown();
     } catch (err) {

--- a/code_samples/sql-order-by-limit-offset-example.js
+++ b/code_samples/sql-order-by-limit-offset-example.js
@@ -20,7 +20,22 @@ const { Client, HazelcastSqlException } = require('hazelcast-client');
 (async () => {
     try {
         const client = await Client.newHazelcastClient();
-        const map = await client.getMap('myMap');
+        const mapName = 'myMap';
+        const map = await client.getMap(mapName);
+        // To be able to use our map in SQL we need to create mapping for it.
+        const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key VARCHAR,
+                this DOUBLE
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = 'varchar',
+                'valueFormat' = 'double'
+            )
+        `;
+        // executions are async, await on update count to wait for execution.
+        await client.getSql().execute(createMappingQuery).getUpdateCount();
 
         // populate map
         await map.put('key1', 1);

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -320,3 +320,33 @@ exports.getBigDecimal = function() {
     const { BigDecimal } = require('..');
     return BigDecimal;
 };
+
+/**
+ * Creates mapping for SQL queries. In 5.0, users started to write explicit mapping for SQL queries against maps.
+ * @param serverVersionNewerThanFive True if server is newer than version five
+ * @param client Hazelcast client object
+ * @param keyFormat SQL column type of map key, case insensitive
+ * @param valueFormat SQL column type of map value, case insensitive
+ * @param mapName Name of the map
+ */
+exports.createMapping = async (serverVersionNewerThanFive, client, keyFormat, valueFormat, mapName) => {
+    if (!serverVersionNewerThanFive) {
+        // Before 5.0, mappings are created implicitly, thus we don't need to create explicitly.
+        return;
+    }
+    const createMappingQuery = `
+            CREATE MAPPING ${mapName} (
+                __key ${keyFormat.toUpperCase()},
+                this ${valueFormat.toUpperCase()}
+            )
+            TYPE IMAP
+            OPTIONS (
+                'keyFormat' = '${keyFormat.toLowerCase()}',
+                'valueFormat' = '${valueFormat.toLowerCase()}'
+            )
+        `;
+
+    const result = exports.getSql(client).execute(createMappingQuery);
+    // Wait for execution to end.
+    await result.getUpdateCount();
+};

--- a/test/integration/backward_compatible/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/sql/DataTypeTest.js
@@ -83,32 +83,6 @@ describe('Data type test', function () {
     });
 
     /**
-     * Creates mapping for SQL queries. In 5.0, users started to write explicit mapping for SQL queries against maps.
-     * @param valueFormat SQL column type, case insensitive
-     */
-    const createMapping = async (valueFormat) => {
-        if (!serverVersionNewerThanFive) {
-            // Before 5.0, mappings are created implicitly, thus we don't need to create explicitly.
-            return;
-        }
-        const createMappingQuery = `
-            CREATE MAPPING ${mapName} (
-                __key INT,
-                this ${valueFormat.toUpperCase()}
-            )
-            TYPE IMAP
-            OPTIONS (
-                'keyFormat' = 'int',
-                'valueFormat' = '${valueFormat.toLowerCase()}'
-            )
-        `;
-
-        const result = TestUtil.getSql(client).execute(createMappingQuery);
-        // Wait for execution to end.
-        await result.getUpdateCount();
-    };
-
-    /**
      * Creates portable mapping for SQL queries. In 5.0, users started to write explicit mapping for SQL queries against maps.
      * @param keyFormat Key format
      * @param factoryId Portable's factory id
@@ -179,7 +153,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize VARCHAR', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('varchar');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'varchar', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -209,7 +183,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize BOOLEAN', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('boolean');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'boolean', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -236,7 +210,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize TINYINT', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('tinyint');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'tinyint', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -266,7 +240,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize SMALLINT', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('smallint');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'smallint', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -296,7 +270,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize INTEGER', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('int');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'int', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -326,7 +300,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize BIGINT', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('bigint');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'bigint', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -361,7 +335,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize DECIMAL', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('decimal');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'decimal', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -430,7 +404,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize REAL', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('real');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'real', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -465,7 +439,7 @@ describe('Data type test', function () {
     it('should be able to decode/serialize DOUBLE', async function () {
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('double');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'double', mapName);
         const script =
             `
             var map = instance_0.getMap("${mapName}");
@@ -503,7 +477,7 @@ describe('Data type test', function () {
         const leftZeroPadInteger = TestUtil.getDateTimeUtil().leftZeroPadInteger;
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('date');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'date', mapName);
 
         // major versions different skip
         // year in client protocol changed https://github.com/hazelcast/hazelcast/pull/18984
@@ -568,7 +542,7 @@ describe('Data type test', function () {
         const leftZeroPadInteger = TestUtil.getDateTimeUtil().leftZeroPadInteger;
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('time');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'time', mapName);
 
         if (clientVersionNewerThanFive && !serverVersionNewerThanFive) {
             // in this case client will send parameters using default serializers but server does not have them yet.
@@ -635,7 +609,7 @@ describe('Data type test', function () {
         const leftZeroPadInteger = TestUtil.getDateTimeUtil().leftZeroPadInteger;
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('timestamp');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'timestamp', mapName);
 
         // major versions different skip
         // year in client protocol changed https://github.com/hazelcast/hazelcast/pull/18984
@@ -727,7 +701,7 @@ describe('Data type test', function () {
 
         const SqlColumnType = TestUtil.getSqlColumnType();
         await basicSetup(this);
-        await createMapping('timestamp with time zone');
+        await TestUtil.createMapping(serverVersionNewerThanFive, client, 'int', 'timestamp with time zone', mapName);
 
         // major versions different skip
         // year in client protocol changed https://github.com/hazelcast/hazelcast/pull/18984

--- a/test/integration/backward_compatible/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/sql/DataTypeTest.js
@@ -95,13 +95,7 @@ describe('Data type test', function () {
             return;
         }
 
-        const entries = Object.entries(columns);
-
-        const numberOfColumns = entries.length;
-
-        const columnsString = entries.reduce((accumulator, current, currentIndex) => {
-            return accumulator + `${current[0]} ${current[1].toUpperCase()}${currentIndex !== numberOfColumns - 1 ? ',' : ''}\n`;
-        }, '');
+        const columnsString = Object.entries(columns).map(column => `${column[0]} ${column[1].toUpperCase()}`).join(',\n');
 
         const createMappingQuery = `
             CREATE MAPPING ${mapName} (

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -63,9 +63,10 @@ describe('SqlExecuteTest', function () {
     let someMap;
     let mapName;
     let CLUSTER_CONFIG;
+    let serverVersionNewerThanFive;
 
     const runSQLQueryWithParams = async () => {
-        for (const _mapName of [mapName, 'partitioned.' + mapName]) {
+        for (const _mapName of [mapName, 'public.' + mapName]) {
             const entryCount = 10;
             const limit = 6;
 
@@ -113,7 +114,7 @@ describe('SqlExecuteTest', function () {
         TestUtil.markClientVersionAtLeast(this, '4.2');
 
         const JET_ENABLED_CONFIG = fs.readFileSync(path.join(__dirname, 'jet_enabled.xml'), 'utf8');
-        const serverVersionNewerThanFive = await TestUtil.compareServerVersionWithRC(RC, '5.0') >= 0;
+        serverVersionNewerThanFive = await TestUtil.compareServerVersionWithRC(RC, '5.0') >= 0;
         CLUSTER_CONFIG = serverVersionNewerThanFive ? JET_ENABLED_CONFIG : null;
     });
 
@@ -126,17 +127,20 @@ describe('SqlExecuteTest', function () {
     };
 
     describe('sql parameter count', function () {
+        const mapName = 'someMap';
+
         before(async function () {
             cluster = await RC.createCluster(null, CLUSTER_CONFIG);
             await RC.startMember(cluster.id);
             client = await Client.newHazelcastClient({
                 clusterName: cluster.id
             });
+            await TestUtil.createMapping(serverVersionNewerThanFive, client, 'double', 'double', mapName);
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
         });
 
         beforeEach(async function () {
-            someMap = await client.getMap('someMap');
+            someMap = await client.getMap(mapName);
         });
 
         after(async function () {
@@ -224,6 +228,7 @@ describe('SqlExecuteTest', function () {
         beforeEach(async function () {
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
+            await TestUtil.createMapping(serverVersionNewerThanFive, client, 'double', 'double', mapName);
         });
 
         after(async function () {
@@ -236,7 +241,7 @@ describe('SqlExecuteTest', function () {
         });
 
         it('should execute without params', async function () {
-            for (const _mapName of [mapName, 'partitioned.' + mapName]) {
+            for (const _mapName of [mapName, 'public.' + mapName]) {
                 const entryCount = 10;
                 await populateMap(entryCount);
 
@@ -292,6 +297,7 @@ describe('SqlExecuteTest', function () {
             TestUtil.markServerVersionAtLeast(this, client, '4.2');
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
+            await TestUtil.createMapping(serverVersionNewerThanFive, client, 'double', 'double', mapName);
         });
 
         after(async function () {
@@ -316,6 +322,7 @@ describe('SqlExecuteTest', function () {
         beforeEach(async function () {
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
+            await TestUtil.createMapping(serverVersionNewerThanFive, client, 'double', 'double', mapName);
         });
 
         after(async function () {

--- a/test/integration/backward_compatible/sql/JetTest.js
+++ b/test/integration/backward_compatible/sql/JetTest.js
@@ -154,6 +154,7 @@ describe('Jet Test', function () {
     it('should be able to run aggregate methods', async function () {
         const mapName = 'a';
         const map = await client.getMap(mapName);
+        await TestUtil.createMapping(true, client, 'double', 'double', mapName);
 
         await map.set(1, 2);
         await map.set(2, 3);

--- a/test/integration/backward_compatible/sql/ResultTest.js
+++ b/test/integration/backward_compatible/sql/ResultTest.js
@@ -65,6 +65,7 @@ describe('SqlResultTest', function () {
     beforeEach(async function () {
         mapName = TestUtil.randomString(10);
         someMap = await client.getMap(mapName);
+        await TestUtil.createMapping(true, client, 'double', 'double', mapName);
         await someMap.put(0, 1);
         await someMap.put(1, 2);
         await someMap.put(2, 3);

--- a/test/integration/backward_compatible/sql/RowTest.js
+++ b/test/integration/backward_compatible/sql/RowTest.js
@@ -52,6 +52,7 @@ describe('SqlRowTest', function () {
         await someMap.put(0, '1');
         await someMap.put(1, '2');
         await someMap.put(2, '3');
+        await TestUtil.createMapping(true, client, 'double', 'varchar', mapName);
 
         const sqlService = TestUtil.getSql(client);
         result = sqlService.execute(`SELECT * FROM ${mapName} WHERE __key > ?`, [0], {


### PR DESCRIPTION
Fixes sql tests for backward compat tests and normal tests.

fixes include:

create mapping need
make checking server version is >= 5 correct.
conditionally give jet enabled flag
updates code samples to include create mapping