### PR TITLE
Make codecov patch informational

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -3,3 +3,6 @@ coverage:
         project:
             default:
                 informational: true
+        patch:
+            default:
+                informational: true


### PR DESCRIPTION
makes patch status informational

https://docs.codecov.com/docs/commit-status#patch-status