### PR TITLE
Make sql execute return promise api-877

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ src/codec/*.ts
 src/codec/custom/*.ts
 src/.eslintrc.js
 lib/**
+docs/**

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2599,7 +2599,7 @@ await map.put('key1', 1);
 await map.put('key2', 2);
 await map.put('key3', 3);
 
-const result = client.getSql().execute(`SELECT __key, this FROM my-distributed-map WHERE this > 1`);
+const result = await client.getSql().execute(`SELECT __key, this FROM my-distributed-map WHERE this > 1`);
 
 for await (const row of result) {
     console.log(row); // {__key: 'key3', this: 3} and {__key: 'key2', this: 2}
@@ -2749,7 +2749,7 @@ comparable with `INTEGER`, the query needs a `CAST`. Note that, the cast can fai
 an integer.
 
 ```javascript
-const result = client.getSql().execute('SELECT * FROM myMap WHERE age > CAST(? AS INTEGER) AND age < CAST(? AS INTEGER)',
+const result = await client.getSql().execute('SELECT * FROM myMap WHERE age > CAST(? AS INTEGER) AND age < CAST(? AS INTEGER)',
     [13, 18]
 );
 ```

--- a/code_samples/bigdecimal_sample.js
+++ b/code_samples/bigdecimal_sample.js
@@ -67,8 +67,7 @@ function portableFactory(classId) {
                 'valueFormat' = 'decimal'
             )
         `;
-        // executions are async, await on update count to wait for execution.
-        await client.getSql().execute(createMappingQuery).getUpdateCount();
+        await client.getSql().execute(createMappingQuery);
 
         // You can use BigDecimals for any operation
         // Let's add some BigDecimals:
@@ -91,7 +90,7 @@ function portableFactory(classId) {
 
         // You can run an SQL query with a BigDecimal:
 
-        const result = client.getSql().execute(
+        const result = await client.getSql().execute(
             'SELECT * FROM decimalMap WHERE this > ?',
             [BigDecimal.fromString('2.22222222222222222')]
         );

--- a/code_samples/datetime_classes_sample.js
+++ b/code_samples/datetime_classes_sample.js
@@ -77,8 +77,7 @@ function portableFactory(classId) {
                 'valueFormat' = 'timestamp with time zone'
             )
         `;
-        // executions are async, await on update count to wait for execution.
-        await client.getSql().execute(createMappingQuery).getUpdateCount();
+        await client.getSql().execute(createMappingQuery);
 
         // You can use datetime classes for any operation
         // Let's add some timestamp with timezones using `OffsetDatetime`:
@@ -105,7 +104,7 @@ function portableFactory(classId) {
 
         // You can run an SQL query:
 
-        const result = client.getSql().execute('SELECT * FROM timestampWithTimezoneMap WHERE this > ?', [
+        const result = await client.getSql().execute('SELECT * FROM timestampWithTimezoneMap WHERE this > ?', [
             OffsetDateTime.from(2020, 3, 1, 5, 6, 7, 123456789, 3600)
         ]);
 

--- a/code_samples/sql-basic-usage.js
+++ b/code_samples/sql-basic-usage.js
@@ -44,8 +44,8 @@ const { Client, SqlColumnType, HazelcastSqlException } = require('hazelcast-clie
         let result;
         try {
             result = await client.getSql().execute('SELECT __key, this FROM myMap WHERE this > ?', [1]);
-            const rowMetadata = await result.getRowMetadata();
-            const columns = await rowMetadata.getColumns();
+            const rowMetadata = result.getRowMetadata();
+            const columns = rowMetadata.getColumns();
 
             console.log('Columns:');
             for (const column of columns) {

--- a/code_samples/sql-basic-usage.js
+++ b/code_samples/sql-basic-usage.js
@@ -35,8 +35,7 @@ const { Client, SqlColumnType, HazelcastSqlException } = require('hazelcast-clie
                 'valueFormat' = 'double'
             )
         `;
-        // executions are async, await on update count to wait for execution.
-        await client.getSql().execute(createMappingQuery).getUpdateCount();
+        await client.getSql().execute(createMappingQuery);
 
         await map.put('key1', 1);
         await map.put('key2', 2);
@@ -44,7 +43,7 @@ const { Client, SqlColumnType, HazelcastSqlException } = require('hazelcast-clie
 
         let result;
         try {
-            result = client.getSql().execute('SELECT __key, this FROM myMap WHERE this > ?', [1]);
+            result = await client.getSql().execute('SELECT __key, this FROM myMap WHERE this > ?', [1]);
             const rowMetadata = await result.getRowMetadata();
             const columns = await rowMetadata.getColumns();
 
@@ -70,7 +69,7 @@ const { Client, SqlColumnType, HazelcastSqlException } = require('hazelcast-clie
 
         try {
             // You can set returnRawResult to true to get rows as `SqlRow` objects
-            result = client.getSql().execute('SELECT __key, this FROM myMap WHERE this > ?', [1], {
+            result = await client.getSql().execute('SELECT __key, this FROM myMap WHERE this > ?', [1], {
                 returnRawResult: true
             });
 

--- a/code_samples/sql-data-types.js
+++ b/code_samples/sql-data-types.js
@@ -54,15 +54,14 @@ const varcharExample = async (client) => {
                 'valueFormat' = 'varchar'
             )
         `;
-    // executions are async, await on update count to wait for execution.
-    await client.getSql().execute(createMappingQuery).getUpdateCount();
+    await client.getSql().execute(createMappingQuery);
 
     for (let key = 0; key < 10; key++) {
         await someMap.set(key, key.toString());
     }
 
     try {
-        const result = client.getSql().execute('SELECT * FROM varcharMap WHERE this = ? OR this = ?', ['7', '2']);
+        const result = await client.getSql().execute('SELECT * FROM varcharMap WHERE this = ? OR this = ?', ['7', '2']);
         const rowMetadata = await result.getRowMetadata();
         const columnIndex = rowMetadata.findColumn('this');
         const columnMetadata = rowMetadata.getColumn(columnIndex);
@@ -102,15 +101,14 @@ const integersExample = async (client) => {
                 'valueFormat' = 'bigint'
             )
         `;
-    // executions are async, await on update count to wait for execution.
-    await client.getSql().execute(createMappingQuery).getUpdateCount();
+    await client.getSql().execute(createMappingQuery);
 
     for (let key = 0; key < 10; key++) {
         await someMap.set(key, long.fromNumber(key * 2));
     }
 
     try {
-        const result = client.getSql().execute(
+        const result = await client.getSql().execute(
             'SELECT * FROM bigintMap WHERE this > ? AND this < ?',
             [long.fromNumber(10), long.fromNumber(18)]
         );
@@ -134,7 +132,7 @@ const integersExample = async (client) => {
 
     try {
         // Casting example. Casting to other integer types is also possible.
-        const result = client.getSql().execute(
+        const result = await client.getSql().execute(
             'SELECT * FROM bigintMap WHERE this > CAST(? AS BIGINT) AND this < CAST(? AS BIGINT)',
             [10, 18]
         );
@@ -173,8 +171,7 @@ const objectExample = async (client, classId, factoryId) => {
                 'valuePortableClassId' = '${classId}'
             )
         `;
-    // executions are async, await on update count to wait for execution.
-    await client.getSql().execute(createMappingQuery).getUpdateCount();
+    await client.getSql().execute(createMappingQuery);
 
     for (let key = 0; key < 10; key++) {
         await someMap.set(key, new Student(long.fromNumber(key), 1.1));
@@ -184,7 +181,7 @@ const objectExample = async (client, classId, factoryId) => {
         // Note: If you do not specify `this` and use *, by default, `age` and `height` columns will be fetched
         // instead of `this`.
         // This is true only for complex custom objects like portable and identified serializable.
-        const result = client.getSql().execute(
+        const result = await client.getSql().execute(
             'SELECT __key, this FROM studentMap WHERE age > CAST(? AS INTEGER) AND age < CAST(? AS INTEGER)',
             [3, 8]
         );

--- a/code_samples/sql-data-types.js
+++ b/code_samples/sql-data-types.js
@@ -62,7 +62,7 @@ const varcharExample = async (client) => {
 
     try {
         const result = await client.getSql().execute('SELECT * FROM varcharMap WHERE this = ? OR this = ?', ['7', '2']);
-        const rowMetadata = result.getRowMetadata();
+        const rowMetadata = result.rowMetadata;
         const columnIndex = rowMetadata.findColumn('this');
         const columnMetadata = rowMetadata.getColumn(columnIndex);
         console.log(SqlColumnType[columnMetadata.type]); // VARCHAR
@@ -107,47 +107,27 @@ const integersExample = async (client) => {
         await someMap.set(key, long.fromNumber(key * 2));
     }
 
-    try {
-        const result = await client.getSql().execute(
-            'SELECT * FROM bigintMap WHERE this > ? AND this < ?',
-            [long.fromNumber(10), long.fromNumber(18)]
-        );
-        const rowMetadata = result.getRowMetadata();
-        const columnIndex = rowMetadata.findColumn('this');
-        const columnMetadata = rowMetadata.getColumn(columnIndex);
-        console.log(SqlColumnType[columnMetadata.type]); // BIGINT
+    const result = await client.getSql().execute(
+        'SELECT * FROM bigintMap WHERE this > ? AND this < ?',
+        [long.fromNumber(10), long.fromNumber(18)]
+    );
+    const rowMetadata = result.rowMetadata;
+    const columnIndex = rowMetadata.findColumn('this');
+    const columnMetadata = rowMetadata.getColumn(columnIndex);
+    console.log(SqlColumnType[columnMetadata.type]); // BIGINT
 
-        for await (const row of result) {
-            console.log(row);
-        }
-    } catch (e) {
-        if (e instanceof HazelcastSqlException) {
-            // HazelcastSqlException is thrown if an error occurs during SQL execution.
-            console.log(`An SQL error occurred while running SQL: ${e}`);
-        } else {
-            // for all other errors
-            console.log(`An error occurred while running SQL: ${e}`);
-        }
+    for await (const row of result) {
+        console.log(row);
     }
 
-    try {
-        // Casting example. Casting to other integer types is also possible.
-        const result = await client.getSql().execute(
-            'SELECT * FROM bigintMap WHERE this > CAST(? AS BIGINT) AND this < CAST(? AS BIGINT)',
-            [10, 18]
-        );
+    // Casting example. Casting to other integer types is also possible.
+    const result2 = await client.getSql().execute(
+        'SELECT * FROM bigintMap WHERE this > CAST(? AS BIGINT) AND this < CAST(? AS BIGINT)',
+        [10, 18]
+    );
 
-        for await (const row of result) {
-            console.log(row);
-        }
-    } catch (e) {
-        if (e instanceof HazelcastSqlException) {
-            // HazelcastSqlException is thrown if an error occurs during SQL execution.
-            console.log(`An SQL error occurred while running SQL: ${e}`);
-        } else {
-            // for all other errors
-            console.log(`An error occurred while running SQL: ${e}`);
-        }
+    for await (const row of result2) {
+        console.log(row);
     }
 };
 
@@ -177,32 +157,22 @@ const objectExample = async (client, classId, factoryId) => {
         await someMap.set(key, new Student(long.fromNumber(key), 1.1));
     }
 
-    try {
-        // Note: If you do not specify `this` and use *, by default, `age` and `height` columns will be fetched
-        // instead of `this`.
-        // This is true only for complex custom objects like portable and identified serializable.
-        const result = await client.getSql().execute(
-            'SELECT __key, this FROM studentMap WHERE age > CAST(? AS INTEGER) AND age < CAST(? AS INTEGER)',
-            [3, 8]
-        );
+    // Note: If you do not specify `this` and use *, by default, `age` and `height` columns will be fetched
+    // instead of `this`.
+    // This is true only for complex custom objects like portable and identified serializable.
+    const result = await client.getSql().execute(
+        'SELECT __key, this FROM studentMap WHERE age > CAST(? AS INTEGER) AND age < CAST(? AS INTEGER)',
+        [3, 8]
+    );
 
-        const rowMetadata = result.getRowMetadata();
-        const columnIndex = rowMetadata.findColumn('this');
-        const columnMetadata = rowMetadata.getColumn(columnIndex);
-        console.log(SqlColumnType[columnMetadata.type]); // OBJECT
+    const rowMetadata = result.rowMetadata;
+    const columnIndex = rowMetadata.findColumn('this');
+    const columnMetadata = rowMetadata.getColumn(columnIndex);
+    console.log(SqlColumnType[columnMetadata.type]); // OBJECT
 
-        for await (const row of result) {
-            const student = row['this'];
-            console.log(student);
-        }
-    } catch (e) {
-        if (e instanceof HazelcastSqlException) {
-            // HazelcastSqlException is thrown if an error occurs during SQL execution.
-            console.log(`An SQL error occurred while running SQL: ${e}`);
-        } else {
-            // for all other errors
-            console.log(`An error occurred while running SQL: ${e}`);
-        }
+    for await (const row of result) {
+        const student = row['this'];
+        console.log(student);
     }
 };
 

--- a/code_samples/sql-data-types.js
+++ b/code_samples/sql-data-types.js
@@ -62,7 +62,7 @@ const varcharExample = async (client) => {
 
     try {
         const result = await client.getSql().execute('SELECT * FROM varcharMap WHERE this = ? OR this = ?', ['7', '2']);
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = result.getRowMetadata();
         const columnIndex = rowMetadata.findColumn('this');
         const columnMetadata = rowMetadata.getColumn(columnIndex);
         console.log(SqlColumnType[columnMetadata.type]); // VARCHAR
@@ -112,7 +112,7 @@ const integersExample = async (client) => {
             'SELECT * FROM bigintMap WHERE this > ? AND this < ?',
             [long.fromNumber(10), long.fromNumber(18)]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = result.getRowMetadata();
         const columnIndex = rowMetadata.findColumn('this');
         const columnMetadata = rowMetadata.getColumn(columnIndex);
         console.log(SqlColumnType[columnMetadata.type]); // BIGINT
@@ -186,7 +186,7 @@ const objectExample = async (client, classId, factoryId) => {
             [3, 8]
         );
 
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = result.getRowMetadata();
         const columnIndex = rowMetadata.findColumn('this');
         const columnMetadata = rowMetadata.getColumn(columnIndex);
         console.log(SqlColumnType[columnMetadata.type]); // OBJECT

--- a/code_samples/sql-order-by-limit-offset-example.js
+++ b/code_samples/sql-order-by-limit-offset-example.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const { Client, HazelcastSqlException } = require('hazelcast-client');
+const { Client } = require('hazelcast-client');
 
 (async () => {
     try {
@@ -43,21 +43,11 @@ const { Client, HazelcastSqlException } = require('hazelcast-client');
         await map.put('key4', 4);
         await map.put('key5', 5);
 
-        try {
-            const result = await client.getSql().execute('SELECT * FROM myMap');
+        const result = await client.getSql().execute('SELECT * FROM myMap');
 
-            console.log('Rows from unsorted query:');
-            for await (const row of result) {
-                console.log(`${row['__key']}: ${row['this']}`);
-            }
-        } catch (e) {
-            if (e instanceof HazelcastSqlException) {
-                // HazelcastSqlException is thrown if an error occurs during SQL execution.
-                console.log(`An SQL error occurred while running SQL: ${e}`);
-            } else {
-                // for all other errors
-                console.log(`An error occurred while running SQL: ${e}`);
-            }
+        console.log('Rows from unsorted query:');
+        for await (const row of result) {
+            console.log(`${row['__key']}: ${row['this']}`);
         }
 
         // In order to add an index clear the map.
@@ -76,22 +66,12 @@ const { Client, HazelcastSqlException } = require('hazelcast-client');
         await map.put('key4', 4);
         await map.put('key5', 5);
 
-        try {
-            // Expected to see 2 3 4
-            const result = await client.getSql().execute('SELECT * FROM myMap ORDER BY this ASC LIMIT 3 OFFSET 1');
+        // Expected to see 2 3 4
+        const result2 = await client.getSql().execute('SELECT * FROM myMap ORDER BY this ASC LIMIT 3 OFFSET 1');
 
-            console.log('Rows from sorted query with limit 3 and offset 1:');
-            for await (const row of result) {
-                console.log(`${row['__key']}: ${row['this']}`);
-            }
-        } catch (e) {
-            if (e instanceof HazelcastSqlException) {
-                // HazelcastSqlException is thrown if an error occurs during SQL execution.
-                console.log(`An SQL error occurred while running SQL: ${e}`);
-            } else {
-                // for all other errors
-                console.log(`An error occurred while running SQL: ${e}`);
-            }
+        console.log('Rows from sorted query with limit 3 and offset 1:');
+        for await (const row of result2) {
+            console.log(`${row['__key']}: ${row['this']}`);
         }
 
         await client.shutdown();

--- a/code_samples/sql-order-by-limit-offset-example.js
+++ b/code_samples/sql-order-by-limit-offset-example.js
@@ -34,8 +34,7 @@ const { Client, HazelcastSqlException } = require('hazelcast-client');
                 'valueFormat' = 'double'
             )
         `;
-        // executions are async, await on update count to wait for execution.
-        await client.getSql().execute(createMappingQuery).getUpdateCount();
+        await client.getSql().execute(createMappingQuery);
 
         // populate map
         await map.put('key1', 1);
@@ -45,7 +44,7 @@ const { Client, HazelcastSqlException } = require('hazelcast-client');
         await map.put('key5', 5);
 
         try {
-            const result = client.getSql().execute('SELECT * FROM myMap');
+            const result = await client.getSql().execute('SELECT * FROM myMap');
 
             console.log('Rows from unsorted query:');
             for await (const row of result) {
@@ -79,7 +78,7 @@ const { Client, HazelcastSqlException } = require('hazelcast-client');
 
         try {
             // Expected to see 2 3 4
-            const result = client.getSql().execute('SELECT * FROM myMap ORDER BY this ASC LIMIT 3 OFFSET 1');
+            const result = await client.getSql().execute('SELECT * FROM myMap ORDER BY this ASC LIMIT 3 OFFSET 1');
 
             console.log('Rows from sorted query with limit 3 and offset 1:');
             for await (const row of result) {

--- a/src/sql/SqlResult.ts
+++ b/src/sql/SqlResult.ts
@@ -96,7 +96,6 @@ export interface SqlResult extends AsyncIterable<SqlRowType> {
 
     /**
      * SQL row metadata if rows exist in the result; otherwise null.
-     * @returns SQL row metadata if rows exist in the result; otherwise null.
      */
     readonly rowMetadata: SqlRowMetadata | null;
 

--- a/src/sql/SqlService.ts
+++ b/src/sql/SqlService.ts
@@ -184,6 +184,7 @@ export class SqlServiceImpl implements SqlService {
                     response.error.originatingMemberId, response.error.code, response.error.message
                 )
             );
+            throw response.error;
         } else {
             res.onExecuteResponse(
                 response.rowMetadata !== null ? new SqlRowMetadataImpl(response.rowMetadata) : null,

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -348,5 +348,23 @@ exports.createMapping = async (serverVersionNewerThanFive, client, keyFormat, va
 
     const result = await exports.getSql(client).execute(createMappingQuery);
     // Wait for execution to end.
-    await result.getUpdateCount();
+    if (!exports.isClientVersionAtLeast('5.0')) {
+        await result.getUpdateCount();
+    }
+};
+
+exports.getRowMetadata = async (result) => {
+    if (exports.isClientVersionAtLeast('5.0')) {
+        return result.rowMetadata;
+    } else {
+        return await result.getRowMetadata();
+    }
+};
+
+exports.getUpdateCount = async (result) => {
+    if (exports.isClientVersionAtLeast('5.0')) {
+        return result.updateCount;
+    } else {
+        return await result.getUpdateCount();
+    }
 };

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -346,7 +346,7 @@ exports.createMapping = async (serverVersionNewerThanFive, client, keyFormat, va
             )
         `;
 
-    const result = exports.getSql(client).execute(createMappingQuery);
+    const result = await exports.getSql(client).execute(createMappingQuery);
     // Wait for execution to end.
     await result.getUpdateCount();
 };

--- a/test/integration/backward_compatible/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/sql/DataTypeTest.js
@@ -482,7 +482,7 @@ describe('Data type test', function () {
             `
             var map = instance_0.getMap("${mapName}");
             for (var key = 1; key < 12; key++) {
-                map.set(new java.lang.Integer(key), java.time.LocalDate.of(key+50002,key+1,key));
+                map.set(new java.lang.Integer(key), java.time.LocalDate.of(key+5002,key+1,key));
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
@@ -492,12 +492,12 @@ describe('Data type test', function () {
             const LocalDate = TestUtil.getLocalDate();
             result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
-                [new LocalDate(50001, 1, 1), new LocalDate(50005, 5, 5)]
+                [new LocalDate(5001, 1, 1), new LocalDate(5005, 5, 5)]
             );
         } else {
             result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST (? AS DATE) AND this < CAST(? AS DATE) ORDER BY __key ASC`,
-                ['+50001-01-01', '+50005-05-05']
+                ['5001-01-01', '5005-05-05']
             );
         }
         const rowMetadata = await result.getRowMetadata();
@@ -511,7 +511,7 @@ describe('Data type test', function () {
 
         const expectedKeys = [1, 2, 3];
         const expectedBaseValues = {
-            year: 50003,
+            year: 5003,
             month: 2,
             date: 1
         };

--- a/test/integration/backward_compatible/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/sql/DataTypeTest.js
@@ -497,7 +497,7 @@ describe('Data type test', function () {
         } else {
             result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST (? AS DATE) AND this < CAST(? AS DATE) ORDER BY __key ASC`,
-                ['50001-01-01', '50005-05-05']
+                ['+50001-01-01', '+50005-05-05']
             );
         }
         const rowMetadata = await result.getRowMetadata();

--- a/test/integration/backward_compatible/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/sql/DataTypeTest.js
@@ -111,9 +111,7 @@ describe('Data type test', function () {
             )
         `;
 
-        const result = TestUtil.getSql(client).execute(createMappingQuery);
-        // Wait for execution to end.
-        await result.getUpdateCount();
+        await TestUtil.getSql(client).execute(createMappingQuery);
     };
 
     const basicSetup = async (testFn) => {
@@ -157,7 +155,7 @@ describe('Data type test', function () {
         `;
 
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this = ? OR this = ? ORDER BY __key ASC`, ['7', '2']
         );
         const rowMetadata = await result.getRowMetadata();
@@ -186,7 +184,8 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(`SELECT * FROM ${mapName} WHERE this = ? ORDER BY __key ASC`, [true]);
+        const result = await TestUtil.getSql(client)
+            .execute(`SELECT * FROM ${mapName} WHERE this = ? ORDER BY __key ASC`, [true]);
         const rowMetadata = await result.getRowMetadata();
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.BOOLEAN);
 
@@ -213,7 +212,7 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS TINYINT) AND this < CAST(? AS TINYINT) ORDER BY __key ASC`,
             [10, 16]
         );
@@ -243,7 +242,7 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS SMALLINT) AND this < CAST(? AS SMALLINT) ORDER BY __key ASC`,
             [8, 16]
         );
@@ -273,7 +272,7 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS INTEGER) AND this < CAST(? AS INTEGER) ORDER BY __key ASC`,
             [10, 20]
         );
@@ -303,7 +302,7 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
             [long.fromNumber(10), long.fromNumber(18)]
         );
@@ -351,7 +350,7 @@ describe('Data type test', function () {
         let result;
         if (clientVersionNewerThanFive) {
             const BigDecimal = TestUtil.getBigDecimal();
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
                 [
                     BigDecimal.fromString('-22.00000000000000000000000000000001'),
@@ -359,7 +358,7 @@ describe('Data type test', function () {
                 ]
             );
         } else {
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST(? AS DECIMAL) AND this < CAST(? AS DECIMAL) ORDER BY __key ASC`,
                 ['-22.00000000000000000000000000000001', '1.0000000000000231213123123125465462513214653123']
             );
@@ -407,7 +406,7 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS REAL) AND this < CAST(? AS REAL) ORDER BY __key ASC`,
             [-0.5, 0.5]
         );
@@ -442,7 +441,7 @@ describe('Data type test', function () {
             }
         `;
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             // cast it if default number type is different
             `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
             [-0.7, 0.7]
@@ -491,12 +490,12 @@ describe('Data type test', function () {
         let result;
         if (clientVersionNewerThanFive) {
             const LocalDate = TestUtil.getLocalDate();
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
                 [new LocalDate(50001, 1, 1), new LocalDate(50005, 5, 5)]
             );
         } else {
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST (? AS DATE) AND this < CAST(? AS DATE) ORDER BY __key ASC`,
                 ['50001-01-01', '50005-05-05']
             );
@@ -554,12 +553,12 @@ describe('Data type test', function () {
         let result;
         if (clientVersionNewerThanFive) {
             const LocalTime = TestUtil.getLocalTime();
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
                 [new LocalTime(1, 0, 0, 0), new LocalTime(10, 0, 0, 0)]
             );
         } else {
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST (? AS TIME) AND this < CAST (? AS TIME) ORDER BY __key ASC`,
                 ['01:00:00', '10:00:00']
             );
@@ -628,7 +627,7 @@ describe('Data type test', function () {
             const LocalTime = TestUtil.getLocalTime();
             const LocalDate = TestUtil.getLocalDate();
 
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
                 [
                     new LocalDateTime(new LocalDate(1, 6, 5), new LocalTime(4, 3, 2, 1)),
@@ -636,7 +635,7 @@ describe('Data type test', function () {
                 ]
             );
         } else {
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST (? AS TIMESTAMP) AND this < CAST (? AS TIMESTAMP) ORDER BY __key ASC`,
                 [
                     '0001-06-05T04:03:02.000000001',
@@ -725,7 +724,7 @@ describe('Data type test', function () {
             const LocalDate = TestUtil.getLocalDate();
             const OffsetDateTime = TestUtil.getOffsetDateTime();
 
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
                 [
                     new OffsetDateTime(new LocalDateTime(new LocalDate(1, 6, 5), new LocalTime(4, 3, 2, 1)), 0),
@@ -733,7 +732,7 @@ describe('Data type test', function () {
                 ]
             );
         } else {
-            result = TestUtil.getSql(client).execute(
+            result = await TestUtil.getSql(client).execute(
                 `SELECT * FROM ${mapName} WHERE this > CAST (? AS ${timestampWithTimezoneString})` +
                 ` AND this < CAST (? AS ${timestampWithTimezoneString}) ORDER BY __key ASC`,
                 [
@@ -814,7 +813,7 @@ describe('Data type test', function () {
         await someMap.put(1, student2);
         await someMap.put(2, student3);
 
-        const result = TestUtil.getSql(client).execute(
+        const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE age > ? AND age < ? ORDER BY age DESC`,
             [long.fromNumber(13), long.fromNumber(18)]
         );

--- a/test/integration/backward_compatible/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/sql/DataTypeTest.js
@@ -158,7 +158,7 @@ describe('Data type test', function () {
         const result = await TestUtil.getSql(client).execute(
             `SELECT * FROM ${mapName} WHERE this = ? OR this = ? ORDER BY __key ASC`, ['7', '2']
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.VARCHAR);
 
         const rows = [];
@@ -186,7 +186,7 @@ describe('Data type test', function () {
         await RC.executeOnController(cluster.id, script, Lang.JAVASCRIPT);
         const result = await TestUtil.getSql(client)
             .execute(`SELECT * FROM ${mapName} WHERE this = ? ORDER BY __key ASC`, [true]);
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.BOOLEAN);
 
         const rows = [];
@@ -216,7 +216,7 @@ describe('Data type test', function () {
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS TINYINT) AND this < CAST(? AS TINYINT) ORDER BY __key ASC`,
             [10, 16]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.TINYINT);
 
         const rows = [];
@@ -246,7 +246,7 @@ describe('Data type test', function () {
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS SMALLINT) AND this < CAST(? AS SMALLINT) ORDER BY __key ASC`,
             [8, 16]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.SMALLINT);
 
         const rows = [];
@@ -276,7 +276,7 @@ describe('Data type test', function () {
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS INTEGER) AND this < CAST(? AS INTEGER) ORDER BY __key ASC`,
             [10, 20]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.INTEGER);
 
         const rows = [];
@@ -306,7 +306,7 @@ describe('Data type test', function () {
             `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
             [long.fromNumber(10), long.fromNumber(18)]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.BIGINT);
 
         const rows = [];
@@ -364,7 +364,7 @@ describe('Data type test', function () {
             );
         }
 
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.DECIMAL);
 
         const rows = [];
@@ -410,7 +410,7 @@ describe('Data type test', function () {
             `SELECT * FROM ${mapName} WHERE this > CAST(? AS REAL) AND this < CAST(? AS REAL) ORDER BY __key ASC`,
             [-0.5, 0.5]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.REAL);
 
         const rows = [];
@@ -446,7 +446,7 @@ describe('Data type test', function () {
             `SELECT * FROM ${mapName} WHERE this > ? AND this < ? ORDER BY __key ASC`,
             [-0.7, 0.7]
         );
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.DOUBLE);
 
         const rows = [];
@@ -500,7 +500,7 @@ describe('Data type test', function () {
                 ['5001-01-01', '5005-05-05']
             );
         }
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.DATE);
 
         const rows = [];
@@ -564,7 +564,7 @@ describe('Data type test', function () {
             );
         }
 
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.TIME);
 
         const rows = [];
@@ -643,7 +643,7 @@ describe('Data type test', function () {
                 ]
             );
         }
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.TIMESTAMP);
 
         const rows = [];
@@ -741,7 +741,7 @@ describe('Data type test', function () {
                 ]
             );
         }
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('this')).type.should.be.eq(SqlColumnType.TIMESTAMP_WITH_TIME_ZONE);
 
         const rows = [];
@@ -818,7 +818,7 @@ describe('Data type test', function () {
             [long.fromNumber(13), long.fromNumber(18)]
         );
 
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.getColumn(rowMetadata.findColumn('age')).type.should.be.eq(SqlColumnType.BIGINT);
         rowMetadata.getColumn(rowMetadata.findColumn('height')).type.should.be.eq(SqlColumnType.REAL);
 

--- a/test/integration/backward_compatible/sql/ExecuteTest.js
+++ b/test/integration/backward_compatible/sql/ExecuteTest.js
@@ -536,13 +536,13 @@ describe('SqlExecuteTest', function () {
             someMap = await client.getMap(mapName);
 
             const error1 = await TestUtil.getRejectionReasonOrThrow(async () => {
-                const result = TestUtil.getSql(client).execute(`SELECT * FROM ${mapName}`);
+                const result = await TestUtil.getSql(client).execute(`SELECT * FROM ${mapName}`);
                 await result.getRowMetadata();
             });
             error1.should.be.instanceof(getHazelcastSqlException());
 
             const error2 = await TestUtil.getRejectionReasonOrThrow(async () => {
-                const result = TestUtil.getSql(client).executeStatement({
+                const result = await TestUtil.getSql(client).executeStatement({
                     sql: `SELECT * FROM ${mapName}`,
                     params: [],
                     options: {}
@@ -564,10 +564,8 @@ describe('SqlExecuteTest', function () {
 
             await RC.terminateMember(cluster.id, member.uuid);
 
-            const result1 = TestUtil.getSql(client).execute(`SELECT * FROM ${mapName}`);
-
             const error1 = await TestUtil.getRejectionReasonOrThrow(async () => {
-                await result1.next();
+                await TestUtil.getSql(client).execute(`SELECT * FROM ${mapName}`);
             });
             error1.should.be.instanceof(getHazelcastSqlException());
             error1.code.should.be.eq(getSqlErrorCode().CONNECTION_PROBLEM);
@@ -593,14 +591,12 @@ describe('SqlExecuteTest', function () {
 
             await RC.terminateMember(cluster.id, member.uuid);
 
-            const result1 = TestUtil.getSql(client).executeStatement({
-                sql: `SELECT * FROM ${mapName}`,
-                params: [],
-                options: {}
-            });
-
             const error1 = await TestUtil.getRejectionReasonOrThrow(async () => {
-                await result1.next();
+                await TestUtil.getSql(client).executeStatement({
+                    sql: `SELECT * FROM ${mapName}`,
+                    params: [],
+                    options: {}
+                });
             });
             error1.should.be.instanceof(getHazelcastSqlException());
             error1.code.should.be.eq(getSqlErrorCode().CONNECTION_PROBLEM);
@@ -624,7 +620,7 @@ describe('SqlExecuteTest', function () {
             mapName = TestUtil.randomString(10);
             someMap = await client.getMap(mapName);
 
-            const result1 = TestUtil.getSql(client).execute('asdasd');
+            const result1 = await TestUtil.getSql(client).execute('asdasd');
 
             const error1 = await TestUtil.getRejectionReasonOrThrow(async () => {
                 await result1.next();
@@ -633,7 +629,7 @@ describe('SqlExecuteTest', function () {
             error1.code.should.be.eq(getSqlErrorCode().PARSING);
             error1.originatingMemberId.toString().should.be.eq(member.uuid);
 
-            const result2 = TestUtil.getSql(client).executeStatement({
+            const result2 = await TestUtil.getSql(client).executeStatement({
                 sql: `--SELECT * FROM ${mapName}`,
                 params: [],
                 options: {}

--- a/test/integration/backward_compatible/sql/JetTest.js
+++ b/test/integration/backward_compatible/sql/JetTest.js
@@ -154,7 +154,7 @@ describe('Jet Test', function () {
 
         const result = await client.getSql().execute(`SELECT COUNT(*) FROM ${mapName}`);
 
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         const columnName = rowMetadata.getColumn(0).name;
         for await (const row of result) {
             row[columnName].toNumber().should.be.eq(3); // count always returns BIGINT
@@ -162,7 +162,7 @@ describe('Jet Test', function () {
 
         const result2 = await client.getSql().execute(`SELECT SUM(this) FROM ${mapName}`);
 
-        const rowMetadata2 = await result2.getRowMetadata();
+        const rowMetadata2 = await TestUtil.getRowMetadata(result2);
         const columnName2 = rowMetadata2.getColumn(0).name;
         for await (const row of result2) {
             row[columnName2].should.be.eq(9); // doubles added, so sum returns DOUBLE
@@ -170,7 +170,7 @@ describe('Jet Test', function () {
 
         const result3 = await client.getSql().execute(`SELECT MAX(this) FROM ${mapName}`);
 
-        const rowMetadata3 = await result3.getRowMetadata();
+        const rowMetadata3 = await TestUtil.getRowMetadata(result3);
         const columnName3 = rowMetadata3.getColumn(0).name;
         for await (const row of result3) {
             row[columnName3].should.be.eq(4); // doubles added, so max returns DOUBLE

--- a/test/integration/backward_compatible/sql/JetTest.js
+++ b/test/integration/backward_compatible/sql/JetTest.js
@@ -56,7 +56,7 @@ describe('Jet Test', function () {
     });
 
     it('should be able to run a generate_series query', async function () {
-        const result = client.getSql().execute('SELECT * FROM TABLE(generate_series(1,3))');
+        const result = await client.getSql().execute('SELECT * FROM TABLE(generate_series(1,3))');
         let counter = 0;
         // eslint-disable-next-line no-unused-vars
         for await (const row of result) {
@@ -66,7 +66,7 @@ describe('Jet Test', function () {
     });
 
     it('should be able to run an infinite query', async function () {
-        const result = client.getSql().execute('SELECT * FROM TABLE(generate_stream(500))');
+        const result = await client.getSql().execute('SELECT * FROM TABLE(generate_stream(500))');
         let counter = 0;
 
         // eslint-disable-next-line no-unused-vars
@@ -82,21 +82,17 @@ describe('Jet Test', function () {
         const map = await client.getMap(mapName);
         const map2 = await client.getMap(mapName2);
 
-        const result = client.getSql().execute(`
+        await client.getSql().execute(`
             CREATE MAPPING ${mapName} (__key DOUBLE, age INTEGER, name VARCHAR) TYPE IMap OPTIONS (
               'keyFormat'='double',
               'valueFormat'='json-flat')
         `);
 
-        await result.getUpdateCount(); // wait for execution to end
-
-        const result2 = client.getSql().execute(`
+        await client.getSql().execute(`
             CREATE MAPPING ${mapName2} (__key DOUBLE, name VARCHAR, height DOUBLE) TYPE IMap OPTIONS (
               'keyFormat'='double',
               'valueFormat'='json-flat')
         `);
-
-        await result2.getUpdateCount(); // wait for execution to end
 
         await map.set(1, {
             age: 11,
@@ -113,7 +109,7 @@ describe('Jet Test', function () {
             height: 111.11
         });
 
-        const result3 = client.getSql().execute(`
+        const result3 = await client.getSql().execute(`
                 SELECT ${mapName}.__key, ${mapName}.age, ${mapName}.name, ${mapName2}.height
                 FROM ${mapName}
                 JOIN ${mapName2} ON ${mapName}.name = ${mapName2}.name
@@ -136,17 +132,13 @@ describe('Jet Test', function () {
     it('should be able to run create mapping and insert into query', async function () {
         const map = await client.getMap(mapName);
 
-        const result = client.getSql().execute(`
+        await client.getSql().execute(`
             CREATE MAPPING ${mapName} (__key DOUBLE, this DOUBLE) TYPE IMap OPTIONS (
               'keyFormat'='double',
               'valueFormat'='double')
         `);
 
-        await result.getUpdateCount(); // wait for execution to end
-
-        const result2 = client.getSql().execute(`INSERT INTO ${mapName} VALUES (1, 2)`);
-
-        await result2.getUpdateCount(); // wait for execution to end
+        await client.getSql().execute(`INSERT INTO ${mapName} VALUES (1, 2)`);
 
         (await map.get(1)).should.be.eq(2);
     });
@@ -160,7 +152,7 @@ describe('Jet Test', function () {
         await map.set(2, 3);
         await map.set(3, 4);
 
-        const result = client.getSql().execute(`SELECT COUNT(*) FROM ${mapName}`);
+        const result = await client.getSql().execute(`SELECT COUNT(*) FROM ${mapName}`);
 
         const rowMetadata = await result.getRowMetadata();
         const columnName = rowMetadata.getColumn(0).name;
@@ -168,7 +160,7 @@ describe('Jet Test', function () {
             row[columnName].toNumber().should.be.eq(3); // count always returns BIGINT
         }
 
-        const result2 = client.getSql().execute(`SELECT SUM(this) FROM ${mapName}`);
+        const result2 = await client.getSql().execute(`SELECT SUM(this) FROM ${mapName}`);
 
         const rowMetadata2 = await result2.getRowMetadata();
         const columnName2 = rowMetadata2.getColumn(0).name;
@@ -176,7 +168,7 @@ describe('Jet Test', function () {
             row[columnName2].should.be.eq(9); // doubles added, so sum returns DOUBLE
         }
 
-        const result3 = client.getSql().execute(`SELECT MAX(this) FROM ${mapName}`);
+        const result3 = await client.getSql().execute(`SELECT MAX(this) FROM ${mapName}`);
 
         const rowMetadata3 = await result3.getRowMetadata();
         const columnName3 = rowMetadata3.getColumn(0).name;

--- a/test/integration/backward_compatible/sql/ResultTest.js
+++ b/test/integration/backward_compatible/sql/ResultTest.js
@@ -87,7 +87,7 @@ describe('SqlResultTest', function () {
     });
 
     it('should reject iteration after close()', async function () {
-        result = TestUtil.getSql(client).execute(`SELECT * FROM ${mapName} WHERE this > ?`, [1], {cursorBufferSize: 1});
+        result = await TestUtil.getSql(client).execute(`SELECT * FROM ${mapName} WHERE this > ?`, [1], {cursorBufferSize: 1});
         const error = await TestUtil.getRejectionReasonOrThrow(async () => {
             let counter = 0;
             // eslint-disable-next-line no-empty,no-unused-vars
@@ -105,7 +105,7 @@ describe('SqlResultTest', function () {
     });
 
     it('getters should work', async function () {
-        result = TestUtil.getSql(client).execute(`SELECT * FROM ${mapName} WHERE this > ?`, [1]);
+        result = await TestUtil.getSql(client).execute(`SELECT * FROM ${mapName} WHERE this > ?`, [1]);
         const rowMetadata = await result.getRowMetadata();
         rowMetadata.should.be.instanceof(getSqlRowMetadataImpl());
         rowMetadata.getColumnCount().should.be.eq(2);

--- a/test/integration/backward_compatible/sql/ResultTest.js
+++ b/test/integration/backward_compatible/sql/ResultTest.js
@@ -106,14 +106,14 @@ describe('SqlResultTest', function () {
 
     it('getters should work', async function () {
         result = await TestUtil.getSql(client).execute(`SELECT * FROM ${mapName} WHERE this > ?`, [1]);
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
         rowMetadata.should.be.instanceof(getSqlRowMetadataImpl());
         rowMetadata.getColumnCount().should.be.eq(2);
 
         const isRowSet = await result.isRowSet();
         isRowSet.should.be.true;
 
-        const updateCount = await result.getUpdateCount();
+        const updateCount = await TestUtil.getUpdateCount(result);
         updateCount.eq(long.fromNumber(-1)).should.be.true;
     });
 });

--- a/test/integration/backward_compatible/sql/RowTest.js
+++ b/test/integration/backward_compatible/sql/RowTest.js
@@ -96,7 +96,7 @@ describe('SqlRowTest', function () {
     });
 
     it('getMetadata should return same metadata with result', async function () {
-        const rowMetadata = await result.getRowMetadata();
+        const rowMetadata = await TestUtil.getRowMetadata(result);
 
         for await (const row of result) {
             row.getMetadata().should.be.eq(rowMetadata);

--- a/test/integration/backward_compatible/sql/RowTest.js
+++ b/test/integration/backward_compatible/sql/RowTest.js
@@ -55,7 +55,7 @@ describe('SqlRowTest', function () {
         await TestUtil.createMapping(true, client, 'double', 'varchar', mapName);
 
         const sqlService = TestUtil.getSql(client);
-        result = sqlService.execute(`SELECT * FROM ${mapName} WHERE __key > ?`, [0], {
+        result = await sqlService.execute(`SELECT * FROM ${mapName} WHERE __key > ?`, [0], {
             returnRawResult: true
         });
     });

--- a/test/unit/sql/SqlService.js
+++ b/test/unit/sql/SqlService.js
@@ -462,7 +462,6 @@ describe('SqlServiceTest', function () {
             (() => SqlServiceImpl.handleExecuteResponse(fakeClientMessage, fakeResult)).should.throw(HazelcastSqlException);
 
             fake.calledOnceWithExactly(fakeClientMessage).should.be.true;
-            fakeResult.onExecuteError.calledWithMatch(fakeResponse.error).should.be.true;
             fakeResult.onExecuteResponse.called.should.be.false;
         });
 

--- a/test/unit/sql/SqlService.js
+++ b/test/unit/sql/SqlService.js
@@ -459,7 +459,7 @@ describe('SqlServiceTest', function () {
 
             const fake = sandbox.replace(SqlExecuteCodec, 'decodeResponse', sandbox.fake.returns(fakeResponse));
 
-            SqlServiceImpl.handleExecuteResponse(fakeClientMessage, fakeResult);
+            (() => SqlServiceImpl.handleExecuteResponse(fakeClientMessage, fakeResult)).should.throw(HazelcastSqlException);
 
             fake.calledOnceWithExactly(fakeClientMessage).should.be.true;
             fakeResult.onExecuteError.calledWithMatch(fakeResponse.error).should.be.true;


### PR DESCRIPTION
Makes `execute` and `executeStatement` methods in `SqlService` return promises of `SqlResult`. Update tests, code samples and documentation accordingly.

Note that we do not need any conditional tests for back compatibility because using `await` with a non async function works. It will convert the returned value to a promise like `Promise.resolve(returnedValue)` implicitly but I think it is better not to change tests for readability. The promise overhead only affects ~50 tests and the overhead is very small. 