### PR TITLE
ClientReconnectTest flaky test fix

### DIFF
--- a/test/integration/backward_compatible/ClientReconnectTest.js
+++ b/test/integration/backward_compatible/ClientReconnectTest.js
@@ -18,7 +18,7 @@
 const { expect } = require('chai');
 const RC = require('../RC');
 const { Client } = require('../../../');
-const { markClientVersionAtLeast, isClientVersionAtLeast, assertTrueEventually } = require('../../TestUtil');
+const { isClientVersionAtLeast, assertTrueEventually } = require('../../TestUtil');
 
 /**
  * Basic tests for reconnection to cluster scenarios.

--- a/test/integration/backward_compatible/ClientReconnectTest.js
+++ b/test/integration/backward_compatible/ClientReconnectTest.js
@@ -27,6 +27,12 @@ describe('ClientReconnectTest', function () {
     let cluster;
     let client;
 
+    before(function () {
+        // Before https://github.com/hazelcast/hazelcast-nodejs-client/pull/704, these tests are flaky.
+        // https://github.com/hazelcast/hazelcast-nodejs-client/issues/658#issuecomment-868970776
+        markClientVersionAtLeast(this, '4.0.2');
+    });
+
     beforeEach(function () {
        client = undefined;
        cluster = undefined;
@@ -89,9 +95,6 @@ describe('ClientReconnectTest', function () {
     });
 
     it('create proxy while member is down, member comes back', async function () {
-        // Before https://github.com/hazelcast/hazelcast-nodejs-client/pull/704, this test is flaky.
-        // https://github.com/hazelcast/hazelcast-nodejs-client/issues/658#issuecomment-868970776
-        markClientVersionAtLeast(this, '4.0.2');
         cluster = await RC.createCluster(null, null);
         const member = await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({

--- a/test/integration/backward_compatible/ClientReconnectTest.js
+++ b/test/integration/backward_compatible/ClientReconnectTest.js
@@ -18,7 +18,7 @@
 const { expect } = require('chai');
 const RC = require('../RC');
 const { Client } = require('../../../');
-const { markClientVersionAtLeast } = require('../../TestUtil');
+const { markClientVersionAtLeast, isClientVersionAtLeast, assertTrueEventually } = require('../../TestUtil');
 
 /**
  * Basic tests for reconnection to cluster scenarios.
@@ -27,11 +27,29 @@ describe('ClientReconnectTest', function () {
     let cluster;
     let client;
 
-    before(function () {
-        // Before https://github.com/hazelcast/hazelcast-nodejs-client/pull/704, these tests are flaky.
-        // https://github.com/hazelcast/hazelcast-nodejs-client/issues/658#issuecomment-868970776
-        markClientVersionAtLeast(this, '4.0.2');
-    });
+    /**
+     * Waits for disconnection. getMap(), map.put() messages are not retryable. If terminateMember does not
+     * close the client connection immediately it is possible for the client to realize that later when map.put
+     * or getMap invocation started. In that case, the connection will be closed with TargetDisconnectedError.
+     * Because these client messages are not retryable, the invocation will be rejected with an error, leading
+     * to flaky tests. To avoid that, this function will wait for the connections count to be zero.
+     * @param client
+     * @return {Promise<void>}
+     */
+    const waitForDisconnection = async (client) => {
+        let getConnectionsFn;
+        if (isClientVersionAtLeast('4.2')) {
+            const clientRegistry = client.connectionRegistry;
+            getConnectionsFn = clientRegistry.getConnections.bind(clientRegistry);
+        } else {
+            const connManager = client.getConnectionManager();
+            getConnectionsFn = connManager.getActiveConnections.bind(connManager);
+        }
+
+        await assertTrueEventually(async () => {
+            expect(getConnectionsFn()).to.be.empty;
+        });
+    };
 
     beforeEach(function () {
        client = undefined;
@@ -60,6 +78,7 @@ describe('ClientReconnectTest', function () {
         const map = await client.getMap('test');
 
         await RC.terminateMember(cluster.id, member.uuid);
+        await waitForDisconnection(client);
         await RC.startMember(cluster.id);
 
         await map.put('testkey', 'testvalue');
@@ -82,6 +101,7 @@ describe('ClientReconnectTest', function () {
         });
         const map = await client.getMap('test');
         await RC.terminateMember(cluster.id, member.uuid);
+        await waitForDisconnection(client);
 
         const promise = map.put('testkey', 'testvalue').then(() => {
             return map.get('testkey');
@@ -95,6 +115,9 @@ describe('ClientReconnectTest', function () {
     });
 
     it('create proxy while member is down, member comes back', async function () {
+        // Before https://github.com/hazelcast/hazelcast-nodejs-client/pull/704, this test is flaky.
+        // https://github.com/hazelcast/hazelcast-nodejs-client/issues/658#issuecomment-868970776
+        markClientVersionAtLeast(this, '4.0.2');
         cluster = await RC.createCluster(null, null);
         const member = await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({
@@ -105,6 +128,7 @@ describe('ClientReconnectTest', function () {
             }
         });
         await RC.terminateMember(cluster.id, member.uuid);
+        await waitForDisconnection(client);
 
         let map;
 

--- a/test/integration/backward_compatible/ClientReconnectTest.js
+++ b/test/integration/backward_compatible/ClientReconnectTest.js
@@ -33,8 +33,6 @@ describe('ClientReconnectTest', function () {
      * or getMap invocation started. In that case, the connection will be closed with TargetDisconnectedError.
      * Because these client messages are not retryable, the invocation will be rejected with an error, leading
      * to flaky tests. To avoid that, this function will wait for the connections count to be zero.
-     * @param client
-     * @return {Promise<void>}
      */
     const waitForDisconnection = async (client) => {
         let getConnectionsFn;

--- a/test/integration/backward_compatible/ClientReconnectTest.js
+++ b/test/integration/backward_compatible/ClientReconnectTest.js
@@ -113,9 +113,6 @@ describe('ClientReconnectTest', function () {
     });
 
     it('create proxy while member is down, member comes back', async function () {
-        // Before https://github.com/hazelcast/hazelcast-nodejs-client/pull/704, this test is flaky.
-        // https://github.com/hazelcast/hazelcast-nodejs-client/issues/658#issuecomment-868970776
-        markClientVersionAtLeast(this, '4.0.2');
         cluster = await RC.createCluster(null, null);
         const member = await RC.startMember(cluster.id);
         client = await Client.newHazelcastClient({

--- a/test/integration/backward_compatible/HazelcastClientTest.js
+++ b/test/integration/backward_compatible/HazelcastClientTest.js
@@ -102,6 +102,7 @@ configParams.forEach((cfg) => {
         });
 
         it('more than one call to shutdown returns same promise', async function () {
+            TestUtil.markClientVersionAtLeast(this, '5.0');
             const promise1 = client.shutdown();
             const promise2 = client.shutdown();
             expect(promise1).to.be.eq(promise2);


### PR DESCRIPTION
Fix for https://github.com/hazelcast/client-compatibility-suites/actions/runs/1251558570

I explained the fail in comments