### PR TITLE
Close connection on socket `end` as well as `error`

### DIFF
--- a/src/network/ConnectionManager.ts
+++ b/src/network/ConnectionManager.ts
@@ -311,7 +311,7 @@ export class ConnectionManager extends EventEmitter {
                 });
                 // close the connection if socket is not readable anymore
                 socket.once('end', () => {
-                    const reason = 'Connection might be closed by other side.';
+                    const reason = 'Connection closed by the other side.';
                     connection.close(reason, new IOError(reason));
                 });
                 return this.initiateCommunication(socket);


### PR DESCRIPTION
Java code does this when a socket is not readable anymore:

https://github.com/hazelcast/hazelcast/blob/21b2a92edab24f952a68fe018604feb6c8f9a65e/hazelcast/src/main/java/com/hazelcast/client/impl/connection/tcp/TcpClientConnectionManager.java#L1142 

I did the same in this pr. In node 15 and above, no error event is emitted if we write to a socket after it is closed, see the nodejs issue for reference: https://github.com/nodejs/node/issues/35313

I think they changed the logic so that no error event is emitted after a close event

I suspect that we write to the socket after it is closed and since we don't get an 'error' event, we cannot close connections. Leading to long pauses until heartbeat timeouts and connection is finally closed. I listened to 'end' event, but we can also listen for 'close' events as an alternative, please share your ideas. However, I think 'close' is emitted when we get a FIN packet and send a FIN packet and get an acknowledgement. So I rather keeping 'end' event. 

This is the root cause of several nightly test failures when node version is 15+. The tests were simply timing out in assertTrueEventually

Also sqlexecute test were not getting closed connection due to same reason, leading to wrong error code.

closes #1097 
closes #1096
closes #1099