### PR TITLE
Add 4.0.2 version check to MigratedDataTest

### DIFF
--- a/test/integration/backward_compatible/parallel/nearcache/MigratedDataTest.js
+++ b/test/integration/backward_compatible/parallel/nearcache/MigratedDataTest.js
@@ -61,6 +61,8 @@ describe('MigratedDataTest', function () {
     }
 
     before(async function () {
+        // Before https://github.com/hazelcast/hazelcast-nodejs-client/pull/704 this test is flaky.
+        TestUtil.markClientVersionAtLeast(this, '4.0.2');
         cluster = await testFactory.createClusterForParallelTests(null,
             fs.readFileSync(__dirname + '/hazelcast_eventual_nearcache.xml', 'utf8'));
         member1 = await RC.startMember(cluster.id);


### PR DESCRIPTION
For https://github.com/hazelcast/client-compatibility-suites/runs/3994505365?check_suite_focus=true


The test is flaky before the fix https://github.com/hazelcast/hazelcast-nodejs-client/pull/704.

If I increase the trial count from 20 to 200 the test passes after heartbeat times out (60 seconds). So it is having difficulty closing the connection. 