### PR TITLE
[BACKPORT 4.1.x] Close connection on socket `end` as well as `error` (#1098)

### DIFF
--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -303,7 +303,12 @@ export class ClientConnectionManager extends EventEmitter {
                     this.client, translatedAddress, socket, this.connectionIdCounter++);
                 // close the connection proactively on errors
                 socket.once('error', (err: NodeJS.ErrnoException) => {
-                    clientConnection.close('Socket error. Connection might be closed by other side', err);
+                    clientConnection.close('Socket error.', err);
+                });
+                // close the connection if socket is not readable anymore
+                socket.once('end', () => {
+                    const reason = 'Connection closed by the other side.';
+                    clientConnection.close(reason, new IOError(reason));
                 });
                 return this.initiateCommunication(socket);
             })


### PR DESCRIPTION
Backport of 77149be036f0f87c666b592dc9c3e7c1c4d3a2d8

Not a clean cherry-pick, but the change is simple.