### PR TITLE
[BACKPORT 4.0.x] Close connection on socket `end` as well as `error` (#1098)

### DIFF
--- a/src/network/ClientConnectionManager.ts
+++ b/src/network/ClientConnectionManager.ts
@@ -266,7 +266,7 @@ export class ClientConnectionManager extends EventEmitter {
                     this.client, translatedAddress, socket, this.connectionIdCounter++);
                 // close the connection proactively on errors
                 socket.once('error', (err: NodeJS.ErrnoException) => {
-                        clientConnection.close('Socket error.', err);
+                    clientConnection.close('Socket error.', err);
                 });
                 // close the connection if socket is not readable anymore
                 socket.once('end', () => {


### PR DESCRIPTION
Backport of 77149be

Not a clean cherry-pick, but the change is simple.