### PR TITLE
Change schedule of nightly tests

### DIFF
--- a/.github/workflows/nightly_runner_maintenance.yml
+++ b/.github/workflows/nightly_runner_maintenance.yml
@@ -2,7 +2,7 @@ name: Runs nightly tests on maintenance branches
 on:
     workflow_dispatch:
     schedule:
-        - cron: '0 2 */2 * *'
+        - cron: '0 5 */2 * *'
 jobs:
     run-tests:
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/nightly_runner_maintenance.yml
+++ b/.github/workflows/nightly_runner_maintenance.yml
@@ -14,6 +14,9 @@ jobs:
                 nodejs_version: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
             fail-fast: false
         steps:
+            - name: Get current date
+              id: date
+              run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
             - name: Setup Java
               uses: actions/setup-java@v2
               with:
@@ -38,6 +41,11 @@ jobs:
               run: npm run lint
             - name: Validate User Code
               run: npm run validate-user-code
+            - name: Cache/Restore Dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-enterprise-${{ hashFiles('**/download-rc*') }}-${{ steps.date.outputs.date }}
             - name: Run tests
               env:
                   HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -13,6 +13,9 @@ jobs:
                 nodejs_version: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
             fail-fast: false
         steps:
+            - name: Get current date
+              id: date
+              run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
             - name: Setup Java
               uses: actions/setup-java@v2
               with:
@@ -35,6 +38,11 @@ jobs:
               run: npm run lint
             - name: Validate User Code
               run: npm run validate-user-code
+            - name: Cache/Restore Dependencies
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-enterprise-${{ hashFiles('**/download-rc*') }}-${{ steps.date.outputs.date }}
             - name: Run tests
               env:
                   HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}

--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -2,7 +2,7 @@ name: Runs nightly tests on master
 on:
     workflow_dispatch:
     schedule:
-        - cron: '0 2 * * *'
+        - cron: '0 0 * * *'
 jobs:
     run-tests:
         runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Tests fail to download 5.0 snapshot server jars. As an easy possible fix, I changed the time the tests run to reduce load on sonatype repositories. Note that python client uses 2AM. Hazelcast repos might be using the same runners, causing the sonatype to block downloads.

If the issue stills same after this, we can introduce retry mechanism to downloader script. But that can be hard for 4.x since they still use .sh files. 