### PR TITLE
Fix flaky MapLockTest

### DIFF
--- a/test/integration/backward_compatible/parallel/map/MapLockTest.js
+++ b/test/integration/backward_compatible/parallel/map/MapLockTest.js
@@ -19,7 +19,6 @@ const { expect } = require('chai');
 
 const RC = require('../../../RC');
 const TestUtil = require('../../../../TestUtil');
-const { promiseWaitMilliseconds } = require('../../../../TestUtil');
 
 /**
  * Verifies lock operations behavior in advanced scenarios,
@@ -40,7 +39,7 @@ describe('MapLockTest', function () {
             if (uuid.toString() === member.uuid) {
                 return key;
             }
-            await promiseWaitMilliseconds(1000);
+            await TestUtil.promiseWaitMilliseconds(1000);
         }
         throw new Error('Could not generate key in ' + MAX_ATTEMPTS + ' seconds');
     }


### PR DESCRIPTION
The test fails when the key is tried to be generated before the second partition event including both members comes. Also fails on master on my local

fail:
https://github.com/hazelcast/hazelcast-nodejs-client/runs/4178339025?check_suite_focus=true
