### PR TITLE
Fix SqlExeceuteTest for the older clients

### DIFF
--- a/code_samples/jaas_sample/hazelcast-member/README.md
+++ b/code_samples/jaas_sample/hazelcast-member/README.md
@@ -1,5 +1,5 @@
 Make sure you have
-* [Java 8+](https://www.java.com/en/download/) installed on your system.
+* [Java 8+](https://openjdk.java.net/) installed on your system.
 * [Hazelcast Enterprise JAR](https://hazelcast.com/download/) available in your system.
 
 Then, put your Hazelcast Enterprise license key into the [hazelcast.xml](src/main/resources/hazelcast.xml).


### PR DESCRIPTION
Recently, there was a change to close the connections immediately, once
the connection from the remote side is ended.

However, that is missing from the old clients, and it can cause some
tests to fail, as the connections are not closed/cleared from the active
connections fast enough.

The updated tests are an example of such problematic tests. In the test,
we terminate the member and expect the connection manager to not return
us a connection. But, that wasn't happening in the v4.2.0 client tests,
as the connection is not removed from the active connections fast enough.

To solve that problem, we added a lifecycle listener and after terminating
the member, wait until the client is disconnected, hence the connection
is removed.

Also, I have removed the faulty conditional check, as all client versions
from 4.2.0 fires connection related problems with the client UUID as the
originating member UUID.