### PR TITLE
[API-1018] Introduce security configuration

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -135,7 +135,10 @@
     * [9.1.1. TLS/SSL for Hazelcast Members](#911-tlsssl-for-hazelcast-members)
     * [9.1.2. TLS/SSL for Hazelcast Node.js Clients](#912-tlsssl-for-hazelcast-nodejs-clients)
     * [9.1.3. Mutual Authentication](#913-mutual-authentication)
-  * [9.2. Credentials](#92-credentials)
+  * [9.2. Authentication](#92-authentication)
+    * [9.2.1. Username Password Authentication](#921-username-password-authentication)
+    * [9.2.2. Token Authentication](#922-token-authentication)
+    * [9.2.3. Custom Authentication](#923-custom-authentication)
 * [10. Development and Testing](#10-development-and-testing)
   * [10.1. Building and Using Client From Sources](#101-building-and-using-client-from-sources)
   * [10.2. Testing](#102-testing)
@@ -1368,6 +1371,7 @@ connection attempts done by the client is 4 x 2 = 8.
 be exactly the same except the following configuration options:
   - `clusterName`
   - `customCredentials`
+  - `security`
   - `network.clusterMembers`
   - `network.ssl`
   - `network.hazelcastCloud`
@@ -3929,22 +3933,172 @@ const cfg = {
 The client calls the `init()` method with the `properties` configuration option. Then the client calls the `getSSLOptions()`
 method of `SSLOptionsFactory` to create the `options` object.
 
-## 9.2. Credentials
+## 9.2 Authentication
 
-One of the key elements in Hazelcast security is the `Credentials` object, which can be used to carry all security attributes of
-the Hazelcast Node.js client to Hazelcast members. Then, Hazelcast members can authenticate the clients and perform access
-control checks on the client operations using this `Credentials` object.
+By default, the client does not use any authentication method and just uses the configured cluster name to connect to members.
 
-With Hazelcast's extensible, `JAAS` based security features you can do much more than just authentication.
-See the [JAAS code sample](code_samples/jaas_sample) to learn how to perform access control checks on the client operations based
-on user groups.
+Hazelcast Node.js client has more ways to authenticate the client against the members, using the ``security`` configuration.
+Please note that, the security configuration requires **Hazelcast Enterprise** edition.
+
+The ``security`` configuration lets you specify different kinds of authentication mechanisms which are
+described in the following sub-sections.
 
 > **NOTE: It is almost always a bad idea to write the credentials to wire in a clear-text format. Therefore, using TLS/SSL
-> encryption is highly recommended while using the custom credentials as described in [TLS/SSL section](#91-tlsssl).**
+> encryption is highly recommended while using the security configuration as described in [TLS/SSL section](#91-tlsssl).**
 
 Also, see the [Security section](https://docs.hazelcast.com/hazelcast/latest/security/overview.html) of Hazelcast Reference
 Manual for more information.
 
+### 9.2.1. Username Password Authentication
+
+The client can authenticate with username and password against the members with the following configuration.
+The properties are ``username`` and ``password`` strings.
+
+```js
+const config = {
+    security: {
+        usernamePassword: {
+            username: 'admin',
+            password: 'some-strong-password'
+        }
+    }
+}
+```
+
+One can use the following default authentication configuration on the member-side.
+
+```xml
+<hazelcast>
+    <security enabled="true">
+        <realms>
+            <realm name="username-password">
+                <identity>
+                    <username-password username="admin" password="some-strong-password" />
+                </identity>
+            </realm>
+        </realms>
+        <member-authentication realm="username-password"/>
+        <!--
+        This is not `client-authentication` to use default authentication.
+        See https://docs.hazelcast.com/hazelcast/latest/security/default-authentication
+         -->
+    </security>
+</hazelcast>
+```
+
+Alternatively, you could provide your custom login module in the member configuration and use that.
+
+```xml
+<hazelcast>
+    <security enabled="true">
+        <realms>
+            <realm name="username-password-with-login-module">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="org.example.CustomLoginModule"/>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
+        <client-authentication realm="username-password-with-login-module"/>
+    </security>
+</hazelcast>
+```
+
+See [Hazelcast Reference Manual](https://docs.hazelcast.com/hazelcast/latest/security/jaas-authentication)
+for details of custom login modules.
+
+### 9.2.2. Token Authentication
+
+The client can authenticate with a token against the members with the following configuration.
+The properties are ``token`` and ``encoding`` strings. The ``token`` must be the string representation of the token
+encoded with the given ``encoding``. The possible values for ``encoding`` are case-insensitive values of ``ascii``
+and ``base64``, and when not provided, defaults to ``ascii``. Supported encodings are provided in the
+``TokenEncoding`` enum.
+
+```js
+const config = {
+    security: {
+        token: {
+            token: 'bXktdG9rZW4=',
+            encoding: TokenEncoding.BASE64 // Or, 'base64' string.
+        }
+    }
+}
+```
+
+There is no out-of-the-box support token-based authentication on the member side, so you have to provide
+your login module to use in the member configuration. The login module will be responsible for performing
+the authentication against the decoded version of the token sent by the client.
+
+```xml
+<hazelcast>
+    <security enabled="true">
+        <realms>
+            <realm name="token-authentication">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="org.example.CustomTokenLoginModule"/>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
+        <client-authentication realm="token-with-login-module"/>
+    </security>
+</hazelcast>
+```
+
+See [Hazelcast Reference Manual](https://docs.hazelcast.com/hazelcast/latest/security/jaas-authentication)
+for details of custom login modules.
+
+### 9.2.3. Custom Authentication
+
+The client can use a custom object during the authentication against the members with the following configuration.
+
+The properties of the object depends entirely on the serialization mechanism that will be used. The example below
+uses Portable serialization to demonstrate the concept.
+
+```js
+const config = {
+    security: {
+        custom: {
+            someField: 'someValue',
+            factoryId: 1,
+            classId: 1,
+            readPortable: function (reader) {
+                this.someField = reader.readString('someField');
+            },
+            writePortable: function (writer) {
+                writer.writeString('someField', this.someField);
+            }
+        }
+    }
+}
+```
+
+You have to write your login module and provide that in the member configuration to use custom authentication.
+The login module will be responsible for performing the authentication against the deserialized version of the
+credentials sent by the client.
+
+```xml
+<hazelcast>
+    <security enabled="true">
+        <realms>
+            <realm name="custom-credentials">
+                <authentication>
+                    <jaas>
+                        <login-module class-name="org.example.CustomCredentialsLoginModule"/>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
+        <client-authentication realm="custom-credentials"/>
+    </security>
+</hazelcast>
+```
+
+See [Hazelcast Reference Manual](https://docs.hazelcast.com/hazelcast/latest/security/jaas-authentication)
+for details of custom login modules.
 
 # 10. Development and Testing
 

--- a/code_samples/jaas_sample/hazelcast-member/README.md
+++ b/code_samples/jaas_sample/hazelcast-member/README.md
@@ -1,5 +1,5 @@
 Make sure you have
-* [Java 8+](https://www.java.com/en/download/) installed on your system.
+* [Java 8+](https://openjdk.java.net/) installed on your system.
 * [Hazelcast Enterprise JAR](https://hazelcast.com/download/) available in your system.
 
 Then, put your Hazelcast Enterprise license key into the [hazelcast.xml](src/main/resources/hazelcast.xml).

--- a/code_samples/security/README.md
+++ b/code_samples/security/README.md
@@ -1,0 +1,33 @@
+# Security
+
+To be able to use security configuration, you must have
+Hazelcast Enterprise edition, and enable security in
+the member configuration.
+
+An example XML member configuration is shared below,
+for the code sample that uses username password credentials.
+
+```xml
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+
+    <security enabled="true">
+        <realms>
+            <realm name="usernamePasswordCredentials">
+                <identity>
+                    <username-password username="admin" password="some-strong-password"/>
+                </identity>
+            </realm>
+        </realms>
+        <member-authentication realm="usernamePasswordCredentials"/>
+        <!--
+        Not defining client-authentication to use the identity config of the member realm with
+        default authentication.
+        See https://docs.hazelcast.com/hazelcast/latest/security/default-authentication
+        -->
+    </security>
+
+</hazelcast>
+```

--- a/code_samples/security/security.js
+++ b/code_samples/security/security.js
@@ -13,22 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** @ignore *//** */
+'use strict';
 
-/**
- * Public API re-exports.
- */
+const { Client } = require('hazelcast-client');
 
-export * from './aggregation';
-export * from './config';
-export * from './connection';
-export * from './core';
-export * from './logging';
-export * from './proxy';
-export * from './serialization';
-export {HazelcastClient as Client} from './HazelcastClient';
-export * from './LifecycleService';
-export * from './PartitionService';
-export * from './CPSubsystem';
-export * from './sql';
-export * from './security';
+(async () => {
+    try {
+        const client = await Client.newHazelcastClient({
+            security: {
+                usernamePassword: {
+                    username: 'admin',
+                    password: 'some-strong-password',
+                }
+            }
+        });
+        console.log('The client is authenticated using username password credentials');
+
+        await client.shutdown();
+    } catch (err) {
+        console.error('Error occurred:', err);
+        process.exit(1);
+    }
+})();
+

--- a/scripts/code-sample-checker.js
+++ b/scripts/code-sample-checker.js
@@ -11,6 +11,7 @@ const ignoredNames = [
     'hazelcast_cloud_discovery.js', // needs a token
     'jaas_sample', // this example is hard to run
     'paging_predicate_sample', // this example is hard to run
+    'security', // needs a special server configuration
 ];
 
 // Recursively walks inside a directory, returning all the JavaScript files inside of it

--- a/src/ClusterFailoverService.ts
+++ b/src/ClusterFailoverService.ts
@@ -16,7 +16,7 @@
 /** @ignore *//** */
 
 import {AddressProvider} from './connection/AddressProvider';
-import {ClientConfigImpl} from './config';
+import {ClientConfigImpl, SecurityConfigImpl} from './config';
 import {IllegalStateError} from './core';
 import {LifecycleService} from './LifecycleService';
 import {HazelcastCloudAddressProvider} from './discovery/HazelcastCloudAddressProvider';
@@ -81,13 +81,16 @@ export class CandidateClusterContext {
     readonly clusterName: string;
     readonly addressProvider: AddressProvider;
     readonly customCredentials: any;
+    readonly securityConfig: SecurityConfigImpl;
 
     constructor(clusterName: string,
                 addressProvider: AddressProvider,
-                customCredentials: any) {
+                customCredentials: any,
+                securityConfig: SecurityConfigImpl) {
         this.clusterName = clusterName;
         this.addressProvider = addressProvider;
         this.customCredentials = customCredentials;
+        this.securityConfig = securityConfig;
     }
 }
 
@@ -114,7 +117,7 @@ export class ClusterFailoverServiceBuilder {
         for (const config of this.clientConfigs) {
             const addressProvider = this.createAddressProvider(config);
             const context = new CandidateClusterContext(
-                config.clusterName, addressProvider, config.customCredentials);
+                config.clusterName, addressProvider, config.customCredentials, config.security);
             contexts.push(context);
         }
         return new ClusterFailoverService(this.maxTryCount, contexts, this.lifecycleService);

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -27,6 +27,7 @@ import {Statistics} from '../statistics/Statistics';
 import {ILogger} from '../logging/ILogger';
 import {ConnectionStrategyConfig, ConnectionStrategyConfigImpl} from './ConnectionStrategyConfig';
 import {LoadBalancerConfig, LoadBalancerConfigImpl} from './LoadBalancerConfig';
+import {SecurityConfig, SecurityConfigImpl} from './SecurityConfig';
 
 /**
  * Top level configuration object of Hazelcast client.
@@ -134,6 +135,8 @@ export interface ClientConfig {
     /**
      * Custom credentials to be used as a part of authentication on
      * the cluster.
+     *
+     * @deprecated Since version 5.1. Use {@link security} element instead.
      */
     customCredentials?: any;
 
@@ -151,6 +154,13 @@ export interface ClientConfig {
      * User-defined properties.
      */
     properties?: Properties;
+
+    /**
+     * Contains configuration for the client to use different kinds
+     * of credential types during authentication, such as username/password,
+     * token, or custom credentials.
+     */
+    security?: SecurityConfig;
 
 }
 
@@ -200,6 +210,7 @@ export class ClientConfigImpl implements ClientConfig {
     clientLabels: string[] = [];
     loadBalancer = new LoadBalancerConfigImpl();
     backupAckToClientEnabled = true;
+    security = new SecurityConfigImpl();
 
     private configPatternMatcher = new ConfigPatternMatcher();
 

--- a/src/config/ConfigBuilder.ts
+++ b/src/config/ConfigBuilder.ts
@@ -23,7 +23,8 @@ import {
     tryGetBoolean,
     tryGetEnum,
     tryGetNumber,
-    tryGetString
+    tryGetString,
+    tryGetStringOrNull
 } from '../util/Util';
 import {ClientConfig, ClientConfigImpl} from './Config';
 import {EvictionPolicy} from './EvictionPolicy';
@@ -36,6 +37,7 @@ import {JsonStringDeserializationPolicy} from './JsonStringDeserializationPolicy
 import {ReconnectMode} from './ConnectionStrategyConfig';
 import {LoadBalancerType} from './LoadBalancerConfig';
 import {LogLevel} from '../logging';
+import {TokenCredentialsImpl, TokenEncoding, UsernamePasswordCredentialsImpl,} from '../security';
 
 /**
  * Responsible for user-defined config validation. Builds the effective config with necessary defaults.
@@ -60,6 +62,8 @@ export class ConfigBuilder {
     }
 
     private handleConfig(jsonObject: any): void {
+        ConfigBuilder.validateSecurityConfiguration(jsonObject);
+
         for (const key in jsonObject) {
             const value = jsonObject[key];
             if (key === 'clusterName') {
@@ -91,13 +95,83 @@ export class ConfigBuilder {
             } else if (key === 'customLogger') {
                 this.handleLogger(value);
             } else if (key === 'customCredentials') {
-                this.handleCredentials(value);
+                this.handleCustomCredentials(value);
             } else if (key === 'backupAckToClientEnabled') {
                 this.effectiveConfig.backupAckToClientEnabled = tryGetBoolean(value);
+            } else if (key === 'security') {
+                this.handleSecurity(value);
             } else {
                 throw new RangeError(`Unexpected config key '${key}' is passed to the Hazelcast Client`);
             }
         }
+    }
+
+    private static validateSecurityConfiguration(jsonObject: any): void {
+        if ('security' in jsonObject && 'customCredentials' in jsonObject) {
+            throw new RangeError('Ambiguous security configuration is found. ' +
+                'Use one of \'security\' or \'customCredentials\' elements, not both.')
+        }
+    }
+
+    private handleSecurity(jsonObject: any): void {
+        let isCredentialsSet = false;
+        for (const key in jsonObject) {
+            if (isCredentialsSet) {
+                throw new RangeError('Security configuration may only contain one of the supported credential types. ' +
+                    'Multiple credential types are passed to the Hazelcast Client.');
+            }
+
+            const value = jsonObject[key];
+            if (key === 'usernamePassword') {
+                this.handleUsernamePasswordCredentials(value);
+            } else if (key === 'token') {
+                this.handleTokenCredentials(value);
+            } else if (key === 'custom') {
+                this.effectiveConfig.security.custom = value;
+            } else {
+                throw new RangeError(`Unexpected security config ${key} is passed to the Hazelcast Client`);
+            }
+
+            isCredentialsSet = true;
+        }
+    }
+
+    private handleUsernamePasswordCredentials(jsonObject: any): void {
+        let username: string;
+        let password: string;
+        for (const key in jsonObject) {
+            const value = jsonObject[key];
+            if (key === 'username') {
+                username = tryGetStringOrNull(value);
+            } else if (key === 'password') {
+                password = tryGetStringOrNull(value);
+            } else {
+                throw new RangeError(`Unexpected username password credentials option '${key}' is passed to the Hazelcast Client`)
+            }
+        }
+
+        this.effectiveConfig.security.usernamePassword = new UsernamePasswordCredentialsImpl(username, password);
+    }
+
+    private handleTokenCredentials(jsonObject: any): void {
+        let token: string;
+        let encoding: TokenEncoding;
+        for (const key in jsonObject) {
+            const value = jsonObject[key];
+            if (key === 'token') {
+                token = tryGetString(value);
+            } else if (key === 'encoding') {
+                encoding = tryGetEnum(TokenEncoding, value);
+            } else {
+                throw new RangeError(`Unexpected token credentials option '${key}' is passed to the Hazelcast Client`)
+            }
+        }
+
+        if (token == null) {
+            return;
+        }
+
+        this.effectiveConfig.security.token = new TokenCredentialsImpl(token, encoding);
     }
 
     private handleConnectionStrategy(jsonObject: any): void {
@@ -437,7 +511,7 @@ export class ConfigBuilder {
         this.effectiveConfig.customLogger = jsonObject;
     }
 
-    private handleCredentials(jsonObject: any): void {
+    private handleCustomCredentials(jsonObject: any): void {
         this.effectiveConfig.customCredentials = jsonObject;
     }
 }

--- a/src/config/FailoverConfig.ts
+++ b/src/config/FailoverConfig.ts
@@ -49,6 +49,7 @@ export interface ClientFailoverConfig {
      * The client configurations must be exactly the same except the following configuration options:
      * - `clusterName`
      * - `customCredentials`
+     * - `security`
      * - `network.clusterMembers`
      * - `network.ssl`
      * - `network.hazelcastCloud`

--- a/src/config/FailoverConfigBuilder.ts
+++ b/src/config/FailoverConfigBuilder.ts
@@ -90,7 +90,7 @@ export class FailoverConfigBuilder {
             'Alternative config with cluster name ' + alternative.clusterName
                 + ' must have the same config as the initial config with cluster name '
                 + main.clusterName + ' except for the following options: '
-                + 'clusterName, customCredentials, network.clusterMembers, '
+                + 'clusterName, customCredentials, security, network.clusterMembers, '
                 + 'network.ssl, network.hazelcastCloud'
         );
     }
@@ -109,6 +109,7 @@ export class FailoverConfigBuilder {
         //       when this list changes
         delete copy.clusterName;
         delete copy.customCredentials;
+        delete copy.security;
         delete copy.network.clusterMembers;
         delete copy.network.ssl;
         delete copy.network.hazelcastCloud;

--- a/src/config/SecurityConfig.ts
+++ b/src/config/SecurityConfig.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TokenCredentials, TokenCredentialsImpl, UsernamePasswordCredentials, UsernamePasswordCredentialsImpl} from '../security';
+
+/**
+ * Contains configuration for the client to use different kinds
+ * of credential types during authentication, such as username/password,
+ * token, or custom credentials.
+ */
+export interface SecurityConfig {
+    /**
+     * Credentials to be used with username and password authentication.
+     */
+    usernamePassword?: UsernamePasswordCredentials
+
+    /**
+     * Credentials to be used with token-based authentication.
+     */
+    token?: TokenCredentials,
+
+    /**
+     * Credentials to be used with custom authentication.
+     */
+    custom?: any,
+}
+
+/** @internal */
+export class SecurityConfigImpl implements SecurityConfig {
+    usernamePassword = new UsernamePasswordCredentialsImpl(null, null);
+    token: TokenCredentialsImpl = null;
+    custom: any = null;
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -38,3 +38,4 @@ export * from './Properties';
 export * from './ReliableTopicConfig';
 export * from './SerializationConfig';
 export * from './SSLConfig';
+export * from  './SecurityConfig';

--- a/src/security/TokenCredentials.ts
+++ b/src/security/TokenCredentials.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {TokenEncoding} from './TokenEncoding';
+
+/**
+ * Token-based credentials for custom authentication.
+ */
+export interface TokenCredentials {
+
+    /**
+     * String representation of the encoded form of the
+     * token.
+     */
+    token: string,
+
+    /**
+     * Encoding that should be used to decode the token.
+     * Defaults to {@link TokenEncoding.ASCII}.
+     */
+    encoding?: TokenEncoding,
+}
+
+/** @internal */
+export class TokenCredentialsImpl implements TokenCredentials {
+    token: string;
+    encoding: TokenEncoding;
+
+    constructor(token: string, encoding = TokenEncoding.ASCII) {
+        this.token = token;
+        this.encoding = encoding;
+    }
+}

--- a/src/security/TokenEncoding.ts
+++ b/src/security/TokenEncoding.ts
@@ -13,22 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** @ignore *//** */
 
 /**
- * Public API re-exports.
+ * Supported token encodings.
  */
-
-export * from './aggregation';
-export * from './config';
-export * from './connection';
-export * from './core';
-export * from './logging';
-export * from './proxy';
-export * from './serialization';
-export {HazelcastClient as Client} from './HazelcastClient';
-export * from './LifecycleService';
-export * from './PartitionService';
-export * from './CPSubsystem';
-export * from './sql';
-export * from './security';
+export enum TokenEncoding {
+    ASCII = 'ASCII',
+    BASE64 = 'BASE64',
+}

--- a/src/security/UsernamePasswordCredentials.ts
+++ b/src/security/UsernamePasswordCredentials.ts
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** @ignore *//** */
 
 /**
- * Public API re-exports.
+ * Username and password based credentials for custom authentication.
  */
+export interface UsernamePasswordCredentials {
+    username: string | null,
+    password: string | null,
+}
 
-export * from './aggregation';
-export * from './config';
-export * from './connection';
-export * from './core';
-export * from './logging';
-export * from './proxy';
-export * from './serialization';
-export {HazelcastClient as Client} from './HazelcastClient';
-export * from './LifecycleService';
-export * from './PartitionService';
-export * from './CPSubsystem';
-export * from './sql';
-export * from './security';
+/** @internal */
+export class UsernamePasswordCredentialsImpl implements UsernamePasswordCredentials {
+    username: string | null;
+    password: string | null;
+
+    constructor(username: string | null, password: string | null) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/security/index.ts
+++ b/src/security/index.ts
@@ -19,16 +19,6 @@
  * Public API re-exports.
  */
 
-export * from './aggregation';
-export * from './config';
-export * from './connection';
-export * from './core';
-export * from './logging';
-export * from './proxy';
-export * from './serialization';
-export {HazelcastClient as Client} from './HazelcastClient';
-export * from './LifecycleService';
-export * from './PartitionService';
-export * from './CPSubsystem';
-export * from './sql';
-export * from './security';
+export * from './UsernamePasswordCredentials';
+export * from './TokenCredentials';
+export * from './TokenEncoding';

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -146,6 +146,14 @@ export function tryGetString(val: any): string {
 }
 
 /** @internal */
+export function tryGetStringOrNull(val: any): string {
+    if (val === null || typeof val === 'string') {
+        return val;
+    }
+    throw new RangeError(val + ' is not a string or null.');
+}
+
+/** @internal */
 export function getStringOrUndefined(val: any): string {
     try {
         return tryGetString(val);

--- a/test/integration/backward_compatible/security/CustomCredentialsTest.js
+++ b/test/integration/backward_compatible/security/CustomCredentialsTest.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const TestUtil = require('../../../TestUtil');
+const fs = require('fs');
+const RC = require('../../RC');
+const {SimpleCredentials} = require('./SimpleCredentials');
+const {IllegalStateError} = require('../../../../lib');
+const {Client} = require('../../../../lib');
+
+describe('CustomCredentialsTest', function () {
+    let cluster;
+    let client;
+
+    before(async function () {
+        TestUtil.markEnterprise(this);
+
+        cluster = await RC.createCluster(null,
+            fs.readFileSync(__dirname + '/hazelcast_custom_credentials.xml', 'utf8'));
+        await RC.startMember(cluster.id);
+    });
+
+    after(async function () {
+        if (!cluster) {
+            return;
+        }
+        await RC.terminateCluster(cluster.id);
+    });
+
+    afterEach(async function () {
+        if (!client) {
+            return;
+        }
+        await client.shutdown();
+        client = null;
+    });
+
+    it('should connect with valid custom credentials', async function () {
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id,
+            customCredentials: new SimpleCredentials('dummy-username', 'dummy-password')
+        });
+        expect(client.getLifecycleService().isRunning()).to.be.true;
+    });
+
+    it('should not connect with invalid custom credentials', async function () {
+        await expect(Client.newHazelcastClient({
+            clusterName: cluster.id,
+            customCredentials: new SimpleCredentials('dummy-username', 'not-a-dummy-password'),
+            connectionStrategy: {
+                connectionRetry: {
+                    clusterConnectTimeoutMillis: 1000
+                }
+            }
+        })).to.be.rejectedWith(IllegalStateError);
+    });
+});

--- a/test/integration/backward_compatible/security/SecurityTest.js
+++ b/test/integration/backward_compatible/security/SecurityTest.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const TestUtil = require('../../../TestUtil');
+const fs = require('fs');
+const RC = require('../../RC');
+const {IllegalStateError} = require('../../../../lib');
+const {SimpleCredentials} = require('./SimpleCredentials');
+const {TokenEncoding} = require('../../../../lib/security/TokenEncoding');
+const {Client} = require('../../../../lib');
+
+describe('SecurityTest', function () {
+    describe('username password credentials', function () {
+        let cluster;
+        let client;
+
+        before(async function () {
+            TestUtil.markEnterprise(this);
+            TestUtil.markClientVersionAtLeast(this, '5.0.2');
+
+            cluster = await RC.createCluster(null,
+                fs.readFileSync(__dirname + '/hazelcast_username_password_credentials.xml', 'utf8'));
+            await RC.startMember(cluster.id);
+        });
+
+        after(async function () {
+            if (!cluster) {
+                return;
+            }
+            await RC.terminateCluster(cluster.id);
+        });
+
+        afterEach(async function () {
+            if (!client) {
+                return;
+            }
+            await client.shutdown();
+            client = null;
+        });
+
+        it('should connect with valid username and password', async function () {
+            client = await Client.newHazelcastClient({
+                clusterName: cluster.id,
+                security: {
+                    usernamePassword: {
+                        username: 'dummy-username',
+                        password: 'dummy-password',
+                    }
+                }
+            });
+            expect(client.getLifecycleService().isRunning()).to.be.true;
+        });
+
+        it('should not connect with invalid username and password', async function () {
+            await expect(Client.newHazelcastClient({
+                clusterName: cluster.id,
+                security: {
+                    usernamePassword: {
+                        username: 'dummy-username',
+                        password: 'not-a-dummy-password',
+                    }
+                },
+                connectionStrategy: {
+                    connectionRetry: {
+                        clusterConnectTimeoutMillis: 1000
+                    }
+                }
+            })).to.be.rejectedWith(IllegalStateError);
+        });
+    });
+
+    describe('token credentials', function () {
+        let cluster;
+        let client;
+
+        before(async function () {
+            TestUtil.markEnterprise(this);
+            TestUtil.markClientVersionAtLeast(this, '5.0.2');
+
+            cluster = await RC.createCluster(null,
+                fs.readFileSync(__dirname + '/hazelcast_token_credentials.xml', 'utf8'));
+            await RC.startMember(cluster.id);
+        });
+
+        after(async function () {
+            if (!cluster) {
+                return;
+            }
+            await RC.terminateCluster(cluster.id);
+        });
+
+        afterEach(async function () {
+            if (!client) {
+                return;
+            }
+            await client.shutdown();
+            client = null;
+        });
+
+        it('should connect with valid token', async function () {
+            client = await Client.newHazelcastClient({
+                clusterName: cluster.id,
+                security: {
+                    token: {
+                        token: 'dG9rZW4=',
+                        encoding: TokenEncoding.BASE64
+                    }
+                }
+            });
+            expect(client.getLifecycleService().isRunning()).to.be.true;
+        });
+
+        it('should not connect with invalid token', async function () {
+            await expect(Client.newHazelcastClient({
+                clusterName: cluster.id,
+                security: {
+                    token: {
+                        token: 'dG9rZW4=',
+                        encoding: TokenEncoding.ASCII
+                    }
+                },
+                connectionStrategy: {
+                    connectionRetry: {
+                        clusterConnectTimeoutMillis: 1000
+                    }
+                }
+            })).to.be.rejectedWith(IllegalStateError);
+        });
+    });
+
+    describe('custom credentials', function () {
+        let cluster;
+        let client;
+
+        before(async function () {
+            TestUtil.markEnterprise(this);
+            TestUtil.markClientVersionAtLeast(this, '5.0.2');
+
+            cluster = await RC.createCluster(null,
+                fs.readFileSync(__dirname + '/hazelcast_custom_credentials.xml', 'utf8'));
+            await RC.startMember(cluster.id);
+        });
+
+        after(async function () {
+            if (!cluster) {
+                return;
+            }
+            await RC.terminateCluster(cluster.id);
+        });
+
+        afterEach(async function () {
+            if (!client) {
+                return;
+            }
+            await client.shutdown();
+            client = null;
+        });
+
+        it('should connect with valid custom credentials', async function () {
+            client = await Client.newHazelcastClient({
+                clusterName: cluster.id,
+                security: {
+                    custom: new SimpleCredentials('dummy-username', 'dummy-password'),
+                }
+            });
+            expect(client.getLifecycleService().isRunning()).to.be.true;
+        });
+
+        it('should not connect with invalid custom credentials', async function () {
+            await expect(Client.newHazelcastClient({
+                clusterName: cluster.id,
+                security: {
+                    custom: new SimpleCredentials('dummy-username', 'not-a-dummy-password'),
+                },
+                connectionStrategy: {
+                    connectionRetry: {
+                        clusterConnectTimeoutMillis: 1000
+                    }
+                }
+            })).to.be.rejectedWith(IllegalStateError);
+        });
+    });
+});

--- a/test/integration/backward_compatible/security/SimpleCredentials.js
+++ b/test/integration/backward_compatible/security/SimpleCredentials.js
@@ -13,22 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** @ignore *//** */
+'use strict';
 
-/**
- * Public API re-exports.
- */
+class SimpleCredentials {
+    constructor(username, password) {
+        this.username = username;
+        this.password = password;
+        this.factoryId = 1;
+        this.classId = 1;
+    }
 
-export * from './aggregation';
-export * from './config';
-export * from './connection';
-export * from './core';
-export * from './logging';
-export * from './proxy';
-export * from './serialization';
-export {HazelcastClient as Client} from './HazelcastClient';
-export * from './LifecycleService';
-export * from './PartitionService';
-export * from './CPSubsystem';
-export * from './sql';
-export * from './security';
+    readData(input) {
+        this.username = input.readString();
+        this.password = input.readString();
+    }
+
+    writeData(output) {
+        output.writeString(this.username);
+        output.writeString(this.password);
+    }
+}
+
+exports.SimpleCredentials = SimpleCredentials;

--- a/test/integration/backward_compatible/security/hazelcast_custom_credentials.xml
+++ b/test/integration/backward_compatible/security/hazelcast_custom_credentials.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+
+    <security enabled="true">
+        <realms>
+            <realm name="customCredentials">
+                <authentication>
+                    <jaas>
+                        <!-- This class is defined in the Remote Controller -->
+                        <login-module class-name="com.hazelcast.security.SimpleLoginModule">
+                            <properties>
+                                <property name="username">dummy-username</property>
+                                <property name="password">dummy-password</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
+        <client-authentication realm="customCredentials"/>
+    </security>
+
+    <serialization>
+        <data-serializable-factories>
+            <data-serializable-factory factory-id="1">
+                <!-- This class is defined in the Remote Controller -->
+                com.hazelcast.security.SimpleCredentialsFactory
+            </data-serializable-factory>
+        </data-serializable-factories>
+    </serialization>
+
+</hazelcast>

--- a/test/integration/backward_compatible/security/hazelcast_token_credentials.xml
+++ b/test/integration/backward_compatible/security/hazelcast_token_credentials.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+
+    <security enabled="true">
+        <realms>
+            <realm name="tokenCredentials">
+                <authentication>
+                    <jaas>
+                        <!-- This class is defined in the Remote Controller -->
+                        <login-module class-name="com.hazelcast.security.TokenCredentialsLoginModule">
+                            <properties>
+                                <property name="token">dG9rZW4=</property>
+                                <property name="encoding">base64</property>
+                            </properties>
+                        </login-module>
+                    </jaas>
+                </authentication>
+            </realm>
+        </realms>
+        <client-authentication realm="tokenCredentials"/>
+    </security>
+
+</hazelcast>

--- a/test/integration/backward_compatible/security/hazelcast_username_password_credentials.xml
+++ b/test/integration/backward_compatible/security/hazelcast_username_password_credentials.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+
+    <security enabled="true">
+        <realms>
+            <realm name="usernamePasswordCredentials">
+                <identity>
+                    <username-password username="dummy-username" password="dummy-password"/>
+                </identity>
+            </realm>
+        </realms>
+        <member-authentication realm="usernamePasswordCredentials"/>
+        <!--
+        Not defining client-authentication to use the identity config of the member realm with
+        default authentication.
+        See https://docs.hazelcast.com/hazelcast/latest/security/default-authentication
+        -->
+    </security>
+
+</hazelcast>

--- a/test/unit/config/ConfigBuilderTest.js
+++ b/test/unit/config/ConfigBuilderTest.js
@@ -32,6 +32,7 @@ const {
     createAddressFromString
 } = require('../../../lib/util/AddressUtil');
 const { ReconnectMode } = require('../../../lib/config/ConnectionStrategyConfig');
+const {TokenEncoding} = require('../../../lib/security/TokenEncoding');
 
 describe('ConfigBuilderTest', function () {
     let fullConfig;
@@ -239,6 +240,13 @@ describe('ConfigBuilderTest', function () {
         const loadBalancer = fullConfig.loadBalancer;
         expect(loadBalancer.type).to.equal(LoadBalancerType.RANDOM);
         expect(loadBalancer.customLoadBalancer).to.equal(customLoadBalancer);
+    });
+
+    it('security', function () {
+        const security = fullConfig.security;
+        const usernamePasswordCredentials = security.usernamePassword;
+        expect(usernamePasswordCredentials.username).to.equal('username');
+        expect(usernamePasswordCredentials.password).to.equal('password');
     });
 });
 
@@ -504,5 +512,144 @@ describe('ConfigBuilderValidationTest', function () {
                 }
             ]
         }).build()).to.throw(InvalidConfigurationError);
+    });
+
+    it('should validate security config', function () {
+        const invalidConfigs = [
+            {
+                'security': {
+                    'somethingElse': false
+                }
+            },
+            {
+                'security': {
+                    'usernamePassword': {
+                        'username': false,
+                        'password': 'password'
+                    }
+                }
+            },
+            {
+                'security': {
+                    'usernamePassword': {
+                        'username': 'username',
+                        'password': false
+                    }
+                }
+            },
+            {
+                'security': {
+                    'usernamePassword': {
+                        'username': 'username',
+                        'password': 'password',
+                        'extraField': true
+                    }
+                }
+            },
+            {
+                'security': {
+                    'token': {
+                        'token': 'token',
+                        'encoding': 'not-a-valid-encoding'
+                    }
+                }
+            },
+            {
+                'security': {
+                    'token': {
+                        'token': 123,
+                        'encoding': TokenEncoding.ASCII
+                    }
+                }
+            },
+            {
+                'security': {
+                    'token': {
+                        'token': 'token',
+                        'encoding': 123
+                    }
+                }
+            },
+            {
+                'security': {
+                    'token': {
+                        'token': 'token',
+                        'encoding': TokenEncoding.ASCII,
+                        'extraField': true
+                    }
+                }
+            }
+        ];
+
+        for (const config of invalidConfigs) {
+            expect(() => new ConfigBuilder(config).build()).to.throw(InvalidConfigurationError);
+        }
+    });
+
+    it('should throw when customCredentials and security are used together', function () {
+        expect(() => new ConfigBuilder({
+            'customCredentials': {},
+            'security': {
+                'username': {
+                    'username': 'username',
+                    'password': 'password',
+                }
+            }
+        }).build()).to.throw(InvalidConfigurationError, 'Ambiguous security configuration is found');
+    });
+
+    it('should throw when multiple security configurations are used together', function () {
+        const invalidConfigs = [
+            {
+                'security': {
+                    'usernamePassword': {
+                        'username': 'username',
+                        'password': 'password',
+                    },
+                    'token': {
+                        'token': 'token',
+                    }
+                }
+            },
+            {
+                'security': {
+                    'usernamePassword': {
+                        'username': 'username',
+                        'password': 'password',
+                    },
+                    'custom': {
+                        'field': 'value',
+                    }
+                }
+            },
+            {
+                'security': {
+                    'token': {
+                        'token': 'token',
+                    },
+                    'custom': {
+                        'field': 'value',
+                    }
+                }
+            },
+            {
+                'security': {
+                    'usernamePassword': {
+                        'username': 'username',
+                        'password': 'password',
+                    },
+                    'token': {
+                        'token': 'token',
+                    },
+                    'custom': {
+                        'field': 'value',
+                    }
+                }
+            }
+        ];
+
+        for (const config of invalidConfigs) {
+            expect(() => new ConfigBuilder(config).build()).to.throw(InvalidConfigurationError, 'Multiple credential types');
+        }
     });
 });

--- a/test/unit/config/configurations/full.json
+++ b/test/unit/config/configurations/full.json
@@ -105,5 +105,11 @@
     },
     "loadBalancer": {
         "type": "random"
+    },
+    "security": {
+        "usernamePassword": {
+            "username": "username",
+            "password": "password"
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a new configuration element called `security`
which enables users to use username-password, token, or custom
authentication.

Formerly, we had a configuration element called `customCredentials`.
We were serializing it using the serialization service, and sending
it as it is.

The problem with that is, the users were not able to use username-password
or token based authentication.

Instead of that element, we introduced a new configuration element and
deprecated it.

The users are still able to provide a custom credentials with this new
element.

* Simplify the secuirty configuration

This commit gets rid of the `type` and `credentials` and introduces
`usernamePassword`, `token`, and `custom` sub-elements.

* ignore security code samples from the code sample checker

* make username/password text more clear

* use enums instead of string constants