### PR TITLE
Fix typo in the token authentication documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4033,7 +4033,7 @@ the authentication against the decoded version of the token sent by the client.
 <hazelcast>
     <security enabled="true">
         <realms>
-            <realm name="token-authentication">
+            <realm name="token">
                 <authentication>
                     <jaas>
                         <login-module class-name="org.example.CustomTokenLoginModule"/>
@@ -4041,7 +4041,7 @@ the authentication against the decoded version of the token sent by the client.
                 </authentication>
             </realm>
         </realms>
-        <client-authentication realm="token-with-login-module"/>
+        <client-authentication realm="token"/>
     </security>
 </hazelcast>
 ```


### PR DESCRIPTION
We mistakenly defined two different realm names in the token
authentication documentation. This PR fixes that by providing the
same name to both of these.