### PR TITLE
Improve security config validation [master]

### DIFF
--- a/src/config/ConfigBuilder.ts
+++ b/src/config/ConfigBuilder.ts
@@ -137,8 +137,8 @@ export class ConfigBuilder {
     }
 
     private handleUsernamePasswordCredentials(jsonObject: any): void {
-        let username: string;
-        let password: string;
+        let username: string | null = null;
+        let password: string | null = null;
         for (const key in jsonObject) {
             const value = jsonObject[key];
             if (key === 'username') {
@@ -168,7 +168,7 @@ export class ConfigBuilder {
         }
 
         if (token == null) {
-            return;
+            throw new RangeError('\'token\' option must be provided in token credentials.');
         }
 
         this.effectiveConfig.security.token = new TokenCredentialsImpl(token, encoding);

--- a/test/unit/config/ConfigBuilderTest.js
+++ b/test/unit/config/ConfigBuilderTest.js
@@ -795,6 +795,14 @@ describe('ConfigBuilderValidationTest', function () {
                     }
                 }
             },
+            // token field is mandatory
+            {
+                'security': {
+                    'token': {
+                        'encoding': TokenEncoding.ASCII
+                    }
+                }
+            },
             {
                 'security': {
                     'token': {


### PR DESCRIPTION
1. Initialized username and password with null to avoid them being `undefined`. With `undefined` value it still works due to `CodecUtil.encodeNullable` logic but it may be confusing.

2. If `token` is not provided in token credentials we throw instead of ignoring.