### PR TITLE
Delete linting from nigthly runner that run on master

### DIFF
--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -28,8 +28,6 @@ jobs:
               run: |
                   npm install
                   npm run compile
-            - name: Lint
-              run: npm run lint
             - name: Validate User Code
               run: npm run validate-user-code
             - name: Run tests


### PR DESCRIPTION
This is needed since eslint is updated and works with Node 12.
We should be ok without eslint since linting is done in CI process
in every PR.

Failing nightly test run:  https://github.com/hazelcast/hazelcast-nodejs-client/runs/4671287085?check_suite_focus=true