### PR TITLE
Change server version calculation to allow more flexible versions

### DIFF
--- a/src/BuildInfo.ts
+++ b/src/BuildInfo.ts
@@ -24,25 +24,32 @@ export class BuildInfo {
     public static readonly UNKNOWN_VERSION_ID = -1;
     private static readonly MAJOR_VERSION_MULTIPLIER = 10000;
     private static readonly MINOR_VERSION_MULTIPLIER = 100;
-    private static readonly PATTERN = /^([\d]+)\.([\d]+)(?:\.([\d]+))?(-[\w]+)?(-SNAPSHOT)?(-BETA-.)?$/;
 
     public static calculateServerVersionFromString(versionString: string): number {
         if (versionString == null) {
             return BuildInfo.UNKNOWN_VERSION_ID;
         }
-        const info = BuildInfo.PATTERN.exec(versionString);
-        if (info === null) {
+        const mainParts = versionString.split('-');
+        const tokens = mainParts[0].split('.');
+
+        if (tokens.length < 2) {
             return BuildInfo.UNKNOWN_VERSION_ID;
         }
-        const major = Number.parseInt(info[1]);
-        const minor = Number.parseInt(info[2]);
+
+        const major = +tokens[0];
+        const minor = +tokens[1];
         let patch: number;
-        if (info[3] === undefined) {
+        if (tokens.length === 2) {
             patch = 0;
         } else {
-            patch = Number.parseInt(info[3]);
+            patch = +tokens[2];
         }
-        return this.calculateServerVersion(major, minor, patch);
+        const version = this.calculateServerVersion(major, minor, patch);
+        if (isNaN(version)) {
+            return BuildInfo.UNKNOWN_VERSION_ID;
+        } else {
+            return version;
+        }
     }
 
     public static calculateServerVersion(major: number, minor: number, patch: number): number {

--- a/src/BuildInfo.ts
+++ b/src/BuildInfo.ts
@@ -38,18 +38,12 @@ export class BuildInfo {
 
         const major = +tokens[0];
         const minor = +tokens[1];
-        let patch: number;
-        if (tokens.length === 2) {
-            patch = 0;
-        } else {
-            patch = +tokens[2];
-        }
+        const patch = (tokens.length === 2) ? 0 : +tokens[2];
+
         const version = this.calculateServerVersion(major, minor, patch);
-        if (isNaN(version)) {
-            return BuildInfo.UNKNOWN_VERSION_ID;
-        } else {
-            return version;
-        }
+
+        // version is NaN when one of major, minor and patch is not a number.
+        return isNaN(version) ? BuildInfo.UNKNOWN_VERSION_ID : version;
     }
 
     public static calculateServerVersion(major: number, minor: number, patch: number): number {

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -560,7 +560,7 @@ exports.calculateServerVersionFromString = (versionString) => {
     const minor = +tokens[1];
     const patch = (tokens.length === 2) ? 0 : +tokens[2];
 
-    const version = this.calculateServerVersion(major, minor, patch);
+    const version = BuildInfo.MAJOR_VERSION_MULTIPLIER * major + BuildInfo.MINOR_VERSION_MULTIPLIER * minor + patch;
 
     // version is NaN when one of major, minor and patch is not a number.
     return isNaN(version) ? BuildInfo.UNKNOWN_VERSION_ID : version;

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -153,11 +153,11 @@ exports.getRandomConnection = function(client) {
 exports.isServerVersionAtLeast = function(client, version) {
     let actual = BuildInfo.UNKNOWN_VERSION_ID;
     if (process.env['SERVER_VERSION']) {
-        actual = BuildInfo.calculateServerVersionFromString(process.env['SERVER_VERSION']);
+        actual = exports.calculateServerVersionFromString(process.env['SERVER_VERSION']);
     } else if (client != null) {
         actual = exports.getRandomConnection(client).getConnectedServerVersion();
     }
-    const expected = BuildInfo.calculateServerVersionFromString(version);
+    const expected = exports.calculateServerVersionFromString(version);
     return actual === BuildInfo.UNKNOWN_VERSION_ID || expected <= actual;
 };
 
@@ -171,21 +171,21 @@ exports.compareServerVersionWithRC = async function (rc, version) {
     const script = 'result=com.hazelcast.instance.GeneratedBuildProperties.VERSION;';
     const result = await rc.executeOnController(null, script, Lang.JAVASCRIPT);
 
-    const rcServerVersion = BuildInfo.calculateServerVersionFromString(result.result.toString());
-    const comparedVersion = BuildInfo.calculateServerVersionFromString(version);
+    const rcServerVersion = exports.calculateServerVersionFromString(result.result.toString());
+    const comparedVersion = exports.calculateServerVersionFromString(version);
 
     return rcServerVersion - comparedVersion;
 };
 
 exports.isClientVersionAtLeast = function(version) {
-    const actual = BuildInfo.calculateServerVersionFromString(BuildInfo.getClientVersion());
-    const expected = BuildInfo.calculateServerVersionFromString(version);
+    const actual = exports.calculateServerVersionFromString(BuildInfo.getClientVersion());
+    const expected = exports.calculateServerVersionFromString(version);
     return actual === BuildInfo.UNKNOWN_VERSION_ID || expected <= actual;
 };
 
 exports.isClientVersionAtMost = function(version) {
-    const actual = BuildInfo.calculateServerVersionFromString(BuildInfo.getClientVersion());
-    const expected = BuildInfo.calculateServerVersionFromString(version);
+    const actual = exports.calculateServerVersionFromString(BuildInfo.getClientVersion());
+    const expected = exports.calculateServerVersionFromString(version);
     return actual === BuildInfo.UNKNOWN_VERSION_ID || expected >= actual;
 };
 
@@ -540,3 +540,35 @@ exports.TestFactory = class TestFactory {
         this.clients.clear();
     }
 };
+
+/**
+ * Duplicated this from BuildInfo because the logic of it is changed in 5.1, and in backward compatibility tests older
+ * versions won't be able to access the new logic if we keep the new logic only in src/.
+ */
+exports.calculateServerVersionFromString = (versionString) => {
+    if (versionString == null) {
+        return BuildInfo.UNKNOWN_VERSION_ID;
+    }
+    const mainParts = versionString.split('-');
+    const tokens = mainParts[0].split('.');
+
+    if (tokens.length < 2) {
+        return BuildInfo.UNKNOWN_VERSION_ID;
+    }
+
+    const major = +tokens[0];
+    const minor = +tokens[1];
+    let patch;
+    if (tokens.length === 2) {
+        patch = 0;
+    } else {
+        patch = +tokens[2];
+    }
+    const version = BuildInfo.MAJOR_VERSION_MULTIPLIER * major + BuildInfo.MINOR_VERSION_MULTIPLIER * minor + patch;
+    if (isNaN(version)) {
+        return BuildInfo.UNKNOWN_VERSION_ID;
+    } else {
+        return version;
+    }
+};
+

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -558,17 +558,11 @@ exports.calculateServerVersionFromString = (versionString) => {
 
     const major = +tokens[0];
     const minor = +tokens[1];
-    let patch;
-    if (tokens.length === 2) {
-        patch = 0;
-    } else {
-        patch = +tokens[2];
-    }
-    const version = BuildInfo.MAJOR_VERSION_MULTIPLIER * major + BuildInfo.MINOR_VERSION_MULTIPLIER * minor + patch;
-    if (isNaN(version)) {
-        return BuildInfo.UNKNOWN_VERSION_ID;
-    } else {
-        return version;
-    }
+    const patch = (tokens.length === 2) ? 0 : +tokens[2];
+
+    const version = this.calculateServerVersion(major, minor, patch);
+
+    // version is NaN when one of major, minor and patch is not a number.
+    return isNaN(version) ? BuildInfo.UNKNOWN_VERSION_ID : version;
 };
 

--- a/test/unit/BuildInfoTest.js
+++ b/test/unit/BuildInfoTest.js
@@ -40,5 +40,6 @@ describe('BuildInfo', function () {
         assert.equal(19930, BuildInfo.calculateServerVersionFromString('1.99.30'));
         assert.equal(109930, BuildInfo.calculateServerVersionFromString('10.99.30-SNAPSHOT'));
         assert.equal(109900, BuildInfo.calculateServerVersionFromString('10.99-RC1'));
+        assert.equal(50100, BuildInfo.calculateServerVersionFromString('5.1-BETA-1-SNAPSHOT'));
     });
 });


### PR DESCRIPTION
Tests failed due to version parser cannot parse the new version 5.1-beta-1-snapshot-1. This PR fixes that to support more versions. Python client's approach is used.

https://github.com/hazelcast/client-compatibility-suites/runs/4782247432?check_suite_focus=true



