### PR TITLE
Make simple credentials back compatible

### DIFF
--- a/test/integration/backward_compatible/parallel/security/SimpleCredentials.js
+++ b/test/integration/backward_compatible/parallel/security/SimpleCredentials.js
@@ -25,25 +25,13 @@ class SimpleCredentials {
     }
 
     readData(input) {
-        // readString is added in 4.2 https://github.com/hazelcast/hazelcast-nodejs-client/pull/802
-        if (TestUtil.isClientVersionAtLeast('4.2')) {
-            this.username = input.readString();
-            this.password = input.readString();
-        } else {
-            this.username = input.readUTF();
-            this.password = input.readUTF();
-        }
+        this.username = TestUtil.readStringFromInput(input);
+        this.password = TestUtil.readStringFromInput(input);
     }
 
     writeData(output) {
-        // writeString is added in 4.2 https://github.com/hazelcast/hazelcast-nodejs-client/pull/802
-        if (TestUtil.isClientVersionAtLeast('4.2')) {
-            output.writeString(this.username);
-            output.writeString(this.password);
-        } else {
-            output.writeUTF(this.username);
-            output.writeUTF(this.password);
-        }
+        TestUtil.writeStringToOutput(output, this.username);
+        TestUtil.writeStringToOutput(output, this.password);
     }
 }
 

--- a/test/integration/backward_compatible/parallel/security/SimpleCredentials.js
+++ b/test/integration/backward_compatible/parallel/security/SimpleCredentials.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 'use strict';
+const TestUtil = require('../../../../TestUtil');
 
 class SimpleCredentials {
     constructor(username, password) {
@@ -24,13 +25,25 @@ class SimpleCredentials {
     }
 
     readData(input) {
-        this.username = input.readString();
-        this.password = input.readString();
+        // readString is added in 4.2 https://github.com/hazelcast/hazelcast-nodejs-client/pull/802
+        if (TestUtil.isClientVersionAtLeast('4.2')) {
+            this.username = input.readString();
+            this.password = input.readString();
+        } else {
+            this.username = input.readUTF();
+            this.password = input.readUTF();
+        }
     }
 
     writeData(output) {
-        output.writeString(this.username);
-        output.writeString(this.password);
+        // writeString is added in 4.2 https://github.com/hazelcast/hazelcast-nodejs-client/pull/802
+        if (TestUtil.isClientVersionAtLeast('4.2')) {
+            output.writeString(this.username);
+            output.writeString(this.password);
+        } else {
+            output.writeUTF(this.username);
+            output.writeUTF(this.password);
+        }
     }
 }
 


### PR DESCRIPTION
Back compat test fail is due to unexistant writeString and readString prior to 4.2. 

https://github.com/hazelcast/client-compatibility-suites/runs/4782247986?check_suite_focus=true