### PR TITLE
Fix NearCachedMapTest

### DIFF
--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -96,16 +96,15 @@ describe('NearCachedMapTest', function () {
                 expectStats(map1, 0, 2, 1);
             });
 
-            it('get returns null eventually after the entry is removed by another client', async function () {
+            it('get returns null if the entry was removed by another client', async function () {
                 if (!invalidateOnChange) {
                     this.skip();
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
-                await TestUtil.assertTrueEventually(async () => {
-                    const val = await map1.get('key1');
-                    expect(val).to.be.null;
-                }, 1000);
+                const val = await TestUtil.promiseLater(5000, map1.get.bind(map1, 'key1'));
+                expectStats(map1, 0, 2, 1);
+                expect(val).to.be.null;
             });
 
             it('clear clears nearcache', async function () {

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -96,15 +96,17 @@ describe('NearCachedMapTest', function () {
                 expectStats(map1, 0, 2, 1);
             });
 
-            it('get returns null if the entry was removed by another client', async function () {
+            it('get returns null eventually after the entry is removed by another client', async function () {
                 if (!invalidateOnChange) {
                     this.skip();
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
-                const val = await TestUtil.promiseLater(1000, map1.get.bind(map1, 'key1'));
-                expectStats(map1, 0, 2, 1);
-                expect(val).to.be.null;
+                await TestUtil.assertTrueEventually(async () => {
+                    const val = await map1.get('key1');
+                    expectStats(map1, 0, 2, 1);
+                    expect(val).to.be.null;
+                }, 1000);
             });
 
             it('clear clears nearcache', async function () {

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -102,8 +102,8 @@ describe('NearCachedMapTest', function () {
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
+                const val = await map1.get('key1');
                 await TestUtil.assertTrueEventually(async () => {
-                    const val = await map1.get('key1');
                     expectStats(map1, 0, 2, 1);
                     expect(val).to.be.null;
                 }, 1000);

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -102,9 +102,8 @@ describe('NearCachedMapTest', function () {
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
-                const val = await map1.get('key1');
                 await TestUtil.assertTrueEventually(async () => {
-                    expectStats(map1, 0, 2, 1);
+                    const val = await map1.get('key1');
                     expect(val).to.be.null;
                 }, 1000);
             });


### PR DESCRIPTION
This PR fixes a near cached map test race condition. My understanding is the following. If the delayed map1.get() call finishes before invalidation, the test fails with 1 hit count and 1 miss count where it should be 0 hit count and 2 miss counts. Increased timeout to be 5 seconds.

fixes #1176