### PR TITLE
Add caused by for more verbose errors

### DIFF
--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -63,6 +63,9 @@ export class HazelcastError extends Error {
         this.cause = cause;
         this.serverStackTrace = serverStackTrace;
         Error.captureStackTrace(this, HazelcastError);
+        if (cause !== undefined) {
+            this.stack += '\nCaused by ' + cause.stack.toString();
+        }
     }
 }
 

--- a/src/core/HazelcastError.ts
+++ b/src/core/HazelcastError.ts
@@ -63,7 +63,7 @@ export class HazelcastError extends Error {
         this.cause = cause;
         this.serverStackTrace = serverStackTrace;
         Error.captureStackTrace(this, HazelcastError);
-        if (cause !== undefined) {
+        if (cause !== undefined && cause !== null) {
             this.stack += '\nCaused by ' + cause.stack.toString();
         }
     }


### PR DESCRIPTION
Adds caused by information to hazelcast errors for more verbose errors. Without this we need to often debug to find the cause of the thrown error. 

Example output:

```
Error: IOException is not expected from BufferObjectDataOutput 
    at new IllegalStateError (src/core/HazelcastError.ts:140:9)
    at Function.toIllegalStateException (src/serialization/compact/DefaultCompactWriter.ts:83:16)
    at DefaultCompactWriter.writeVariableSizeField (src/serialization/compact/DefaultCompactWriter.ts:116:40)
    at DefaultCompactWriter.writeCompact (src/serialization/compact/DefaultCompactWriter.ts:340:21)
    at MainDTOSerializer.write (test/unit/serialization/compact/CompactUtil.js:359:16)
    at CompactStreamSerializer.writeSchemaAndObject (src/serialization/compact/CompactStreamSerializer.ts:156:27)
    at CompactStreamSerializer.writeObject (src/serialization/compact/CompactStreamSerializer.ts:172:14)
    at CompactStreamSerializer.write (src/serialization/compact/CompactStreamSerializer.ts:97:18)
    at CompactStreamSerializerAdapter.write (src/serialization/compact/CompactStreamSerializerAdapter.ts:36:32)
    at SerializationServiceV1.toData (src/serialization/SerializationService.ts:161:36)
    at Context.<anonymous> (test/unit/serialization/compact/GenericRecordTest.js:31:43)
    at processImmediate (internal/timers.js:464:21)
Caused by Error: Explicit compact serializer is needed for obj: [object Object]
    at new HazelcastSerializationError (src/core/HazelcastError.ts:76:9)
    at CompactStreamSerializer.getSerializerFromObject (src/serialization/compact/CompactStreamSerializer.ts:188:15)
    at CompactStreamSerializer.writeObject (src/serialization/compact/CompactStreamSerializer.ts:161:40)
    at /var/git/forked/hazelcast-nodejs-client/src/serialization/compact/DefaultCompactWriter.ts:341:36
    at DefaultCompactWriter.writeVariableSizeField (src/serialization/compact/DefaultCompactWriter.ts:113:17)
    at DefaultCompactWriter.writeCompact (src/serialization/compact/DefaultCompactWriter.ts:340:21)
    at MainDTOSerializer.write (test/unit/serialization/compact/CompactUtil.js:359:16)
    at CompactStreamSerializer.writeSchemaAndObject (src/serialization/compact/CompactStreamSerializer.ts:156:27)
    at CompactStreamSerializer.writeObject (src/serialization/compact/CompactStreamSerializer.ts:172:14)
    at CompactStreamSerializer.write (src/serialization/compact/CompactStreamSerializer.ts:97:18)
    at CompactStreamSerializerAdapter.write (src/serialization/compact/CompactStreamSerializerAdapter.ts:36:32)
    at SerializationServiceV1.toData (src/serialization/SerializationService.ts:161:36)
    at Context.<anonymous> (test/unit/serialization/compact/GenericRecordTest.js:31:43)
    at processImmediate (internal/timers.js:464:21)

```

instead of just 
```
Error: IOException is not expected from BufferObjectDataOutput 
    at new IllegalStateError (src/core/HazelcastError.ts:140:9)
    at Function.toIllegalStateException (src/serialization/compact/DefaultCompactWriter.ts:83:16)
    at DefaultCompactWriter.writeVariableSizeField (src/serialization/compact/DefaultCompactWriter.ts:116:40)
    at DefaultCompactWriter.writeCompact (src/serialization/compact/DefaultCompactWriter.ts:340:21)
    at MainDTOSerializer.write (test/unit/serialization/compact/CompactUtil.js:359:16)
    at CompactStreamSerializer.writeSchemaAndObject (src/serialization/compact/CompactStreamSerializer.ts:156:27)
    at CompactStreamSerializer.writeObject (src/serialization/compact/CompactStreamSerializer.ts:172:14)
    at CompactStreamSerializer.write (src/serialization/compact/CompactStreamSerializer.ts:97:18)
    at CompactStreamSerializerAdapter.write (src/serialization/compact/CompactStreamSerializerAdapter.ts:36:32)
    at SerializationServiceV1.toData (src/serialization/SerializationService.ts:161:36)
    at Context.<anonymous> (test/unit/serialization/compact/GenericRecordTest.js:31:43)
    at processImmediate (internal/timers.js:464:21)
```
