### PR TITLE
Fix nearcachedmaptest 2nd attempt

### DIFF
--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -65,6 +65,7 @@ exports.promiseWaitMilliseconds = function (milliseconds) {
 };
 
 exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutMs = 60000) {
+    let errorString = '';
     return new Promise(((resolve, reject) => {
         let intervalTimer;
         function scheduleNext() {
@@ -75,7 +76,7 @@ exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutM
                         resolve();
                     })
                     .catch(e => {
-                        console.error(e);
+                        errorString += e.stack + '\n';
                         scheduleNext();
                     });
             }, intervalMs);
@@ -84,7 +85,7 @@ exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutM
 
         const timeoutTimer = setTimeout(() => {
             clearInterval(intervalTimer);
-            reject(new Error('Rejected due to timeout of ' + timeoutMs + 'ms'));
+            reject(new Error('Rejected due to timeout of ' + timeoutMs + 'ms. Errors occurred in order: \n\n' + errorString));
         }, timeoutMs);
     }));
 };

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -74,7 +74,8 @@ exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutM
                         clearInterval(timeoutTimer);
                         resolve();
                     })
-                    .catch(() => {
+                    .catch(e => {
+                        console.error(e);
                         scheduleNext();
                     });
             }, intervalMs);

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -96,16 +96,15 @@ describe('NearCachedMapTest', function () {
                 expectStats(map1, 0, 2, 1);
             });
 
-            it('get returns null eventually after the entry is removed by another client', async function () {
+            it('get returns null if the entry was removed by another client', async function () {
                 if (!invalidateOnChange) {
                     this.skip();
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
-                await TestUtil.assertTrueEventually(async () => {
-                    const val = await map1.get('key1');
-                    expect(val).to.be.null;
-                }, 1000);
+                const val = await TestUtil.promiseLater(5000, map1.get.bind(map1, 'key1'));
+                expectStats(map1, 0, 2, 1);
+                expect(val).to.be.null;
             });
 
             it('clear clears nearcache', async function () {

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -105,13 +105,10 @@ describe('NearCachedMapTest', function () {
                 await map1.get('key1');
                 await map2.remove('key1');
 
-                let previousHitCount;
-
                 await assertTrueEventually(async () => {
-                    previousHitCount = getNearCacheStats(map1).hitCount;
                     const val = await map1.get('key1');
-                    // Client should eventually use near cache
-                    expect(getNearCacheStats(map1).hitCount).to.be.greaterThan(previousHitCount);
+                    // Client should eventually fetch invalidated entry from cluster due to invalidation
+                    expect(getNearCacheStats(map1).missCount).to.be.greaterThan(1);
                     expect(val).to.be.null;
                 }, 1000);
             });

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -110,10 +110,10 @@ describe('NearCachedMapTest', function () {
                 await assertTrueEventually(async () => {
                     previousHitCount = getNearCacheStats(map1).hitCount;
                     const val = await map1.get('key1');
-                    expect(getNearCacheStats(map1).hitCount).to.be.greaterThan(previousHitCount);
                     // Client should eventually use near cache
+                    expect(getNearCacheStats(map1).hitCount).to.be.greaterThan(previousHitCount);
                     expect(val).to.be.null;
-                }, 1000, 4000);
+                }, 1000);
             });
 
             it('clear clears nearcache', async function () {

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -96,15 +96,17 @@ describe('NearCachedMapTest', function () {
                 expectStats(map1, 0, 2, 1);
             });
 
-            it('get returns null if the entry was removed by another client', async function () {
+            it('get returns null eventually after the entry is removed by another client', async function () {
                 if (!invalidateOnChange) {
                     this.skip();
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
-                const val = await TestUtil.promiseLater(1000, map1.get.bind(map1, 'key1'));
-                expectStats(map1, 0, 2, 1);
-                expect(val).to.be.null;
+                await TestUtil.assertTrueEventually(async () => {
+                    const val = await map1.get('key1');
+                    expectStats(map1, 0, 2, 1);
+                    expect(val).to.be.null;
+                }, 1000);
             });
 
             it('clear clears nearcache', async function () {

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -102,8 +102,8 @@ describe('NearCachedMapTest', function () {
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
+                const val = await map1.get('key1');
                 await TestUtil.assertTrueEventually(async () => {
-                    const val = await map1.get('key1');
                     expectStats(map1, 0, 2, 1);
                     expect(val).to.be.null;
                 }, 1000);

--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -102,9 +102,8 @@ describe('NearCachedMapTest', function () {
                 }
                 await map1.get('key1');
                 await map2.remove('key1');
-                const val = await map1.get('key1');
                 await TestUtil.assertTrueEventually(async () => {
-                    expectStats(map1, 0, 2, 1);
+                    const val = await map1.get('key1');
                     expect(val).to.be.null;
                 }, 1000);
             });


### PR DESCRIPTION
Second attempt to fix near cached map test. The test failed again on master during nigthly tests with the same exception. 

In order to fix it I removed expectStats call as Metin thinks that it's not needed. Also now I assert that the client does not go to cluster after some point and uses the near cache. I achieve that by adding a spy(a thing that counts call count to a function) to `MapProxy.getInternal`. `NearCachedMapProxy` calls `MapProxy.getInternal` via `super.getInternal()` only when near cache doesnt not have the entry.

Along with the test I added error stack trace logging to test errors originated from assertTrueEventually since it will be easier to reason test failures.

Example output with my change:

```
Error: Rejected due to timeout of 3000ms. Errors occurred in order: 

AssertionError: expected 1 to equal 0
    at /var/git/forked/hazelcast-nodejs-client/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js:120:60
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
AssertionError: expected null not to be null
    at /var/git/forked/hazelcast-nodejs-client/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js:121:42

    at Timeout._onTimeout (test/TestUtil.js:88:20)
    at listOnTimeout (internal/timers.js:557:17)
    at processTimers (internal/timers.js:500:7)
```

This output is only seen in the test results not in the output, so I don't expect the test duration will increase.

fixes #1177 

EDIT: Since public API usage will make the test more resilient to back compat test failure hit count increase is asserted now. 