### PR TITLE
[5.0.x] Fix address util test for loopback of ipv6 API-1193

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,10 +40,6 @@
                 "before": true
             }
         ],
-        "linebreak-style": [
-            "warn",
-            "unix"
-        ],
         "max-len": [
             "warn",
             {

--- a/test/unit/util/AddressUtilTest.js
+++ b/test/unit/util/AddressUtilTest.js
@@ -149,14 +149,14 @@ describe('AddressUtilTest', function () {
         expect(result).to.be.false;
     });
 
-    it('resolveAddress: returns IPv4 for localhost with port', async function () {
+    it('resolveAddress: returns loopback address for localhost with port', async function () {
         const result = await resolveAddress('localhost:5701');
-        expect(result).to.be.equal('127.0.0.1');
+        expect(result).to.satisfy(ip => ip === '127.0.0.1' || ip === '::1');
     });
 
-    it('resolveAddress: returns IPv4 for localhost without port', async function () {
+    it('resolveAddress: returns loopback address for localhost without port', async function () {
         const result = await resolveAddress('localhost');
-        expect(result).to.be.equal('127.0.0.1');
+        expect(result).to.satisfy(ip => ip === '127.0.0.1' || ip === '::1');
     });
 
     it('resolveAddress: returns IPv4 for IPv4 address with port', async function () {


### PR DESCRIPTION
Clean cherry-pick backport of #1095 

The original PR was fixing a unit test so we need to backport it to all branches. 