### PR TITLE
[4.2.x] Fix address util test for loopback of ipv6 API-1193

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,10 +40,6 @@
                 "before": true
             }
         ],
-        "linebreak-style": [
-            "warn",
-            "unix"
-        ],
         "max-len": [
             "warn",
             {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Run tests
+on:
+    push:
+        branches-ignore:
+            - 'gh-pages'
+        tags-ignore:
+            - '*'
+    pull_request:
+
+jobs:
+    run-tests:
+        name: Run Tests on (${{ matrix.os }})
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                os: [ ubuntu-latest, windows-latest ]
+
+        steps:
+            - name: Setup Java
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 8
+            - name: Setup Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 10
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: Install dependencies and compile client
+              run: |
+                  npm install
+                  npm run compile
+            - name: Run OS tests
+              if: ${{ github.event_name == 'pull_request' }}
+              run: |
+                  npm run coverage
+            - name: Run Enterprise tests
+              if: ${{ github.event_name == 'push' }}
+              env:
+                  HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+              run: |
+                  npm run coverage
+            - name: Publish to Codecov
+              if: ${{ matrix.os == 'ubuntu-latest' }}
+              uses: codecov/codecov-action@v2
+              with:
+                  files: coverage/lcov.info

--- a/test/unit/util/AddressUtilTest.js
+++ b/test/unit/util/AddressUtilTest.js
@@ -150,14 +150,14 @@ describe('AddressUtilTest', function () {
         expect(result).to.be.false;
     });
 
-    it('resolveAddress: returns IPv4 for localhost with port', async function () {
+    it('resolveAddress: returns loopback address for localhost with port', async function () {
         const result = await resolveAddress('localhost:5701');
-        expect(result).to.be.equal('127.0.0.1');
+        expect(result).to.satisfy(ip => ip === '127.0.0.1' || ip === '::1');
     });
 
-    it('resolveAddress: returns IPv4 for localhost without port', async function () {
+    it('resolveAddress: returns loopback address for localhost without port', async function () {
         const result = await resolveAddress('localhost');
-        expect(result).to.be.equal('127.0.0.1');
+        expect(result).to.satisfy(ip => ip === '127.0.0.1' || ip === '::1');
     });
 
     it('resolveAddress: returns IPv4 for IPv4 address with port', async function () {

--- a/test/unit/util/AddressUtilTest.js
+++ b/test/unit/util/AddressUtilTest.js
@@ -15,7 +15,9 @@
  */
 'use strict';
 
-const { expect } = require('chai');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-as-promised'));
 const net = require('net');
 const {
     createAddressFromString,


### PR DESCRIPTION
- Clean cherry-pick backport of #1095 . The original PR was fixing a unit test so we need to backport it to all branches. 
- Also adds CI yaml. After we switch to github actions we did not add workflow files to older branches.
- Also add `chai as promised` plugin to the test. I think it was working since chai plugins are cached inside so that using it in one test is enough, so this test passed since other tests included the plugin. It was failing when run solely.