### PR TITLE
[4.1.x] Fix address util test for loopback of ipv6 API-1193

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Run tests
+on:
+    push:
+        branches-ignore:
+            - 'gh-pages'
+        tags-ignore:
+            - '*'
+    pull_request:
+
+jobs:
+    run-tests:
+        name: Run Tests on (${{ matrix.os }})
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                os: [ ubuntu-latest, windows-latest ]
+
+        steps:
+            - name: Setup Java
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 8
+            - name: Setup Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 10
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: Install dependencies and compile client
+              run: |
+                  npm install
+                  npm run compile
+            - name: Run OS tests
+              if: ${{ github.event_name == 'pull_request' }}
+              run: |
+                  npm run coverage
+            - name: Run Enterprise tests
+              if: ${{ github.event_name == 'push' }}
+              env:
+                  HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+              run: |
+                  npm run coverage
+            - name: Publish to Codecov
+              if: ${{ matrix.os == 'ubuntu-latest' }}
+              uses: codecov/codecov-action@v2
+              with:
+                  files: coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
         "eslint-plugin-mocha": "^8.0.0",
         "jsonschema": "^1.2.6",
         "mocha": "^8.1.1",
-        "mocha-junit-reporter": "^2.0.0",
         "mousse": "^0.3.1",
         "nyc": "^15.1.0",
         "rimraf": "^3.0.2",
@@ -40,7 +39,7 @@
         "test:integration": "node download-remote-controller.js && mocha 'test/integration/**/*.js'",
         "validate-user-code": "tsc --build test/user_code/tsconfig.json",
         "precoverage": "node download-remote-controller.js",
-        "coverage": "rimraf coverage && nyc node_modules/mocha/bin/_mocha 'test/**/*.js' -- --reporter-options mochaFile=report.xml --reporter mocha-junit-reporter",
+        "coverage": "rimraf coverage && nyc node_modules/mocha/bin/_mocha 'test/**/*.js'",
         "pregenerate-docs": "rimraf docs",
         "generate-docs": "typedoc --options typedoc.json",
         "lint": "eslint --ext .ts src && eslint --plugin mocha test && eslint code_samples"

--- a/test/unit/util/AddressUtilTest.js
+++ b/test/unit/util/AddressUtilTest.js
@@ -150,14 +150,14 @@ describe('AddressUtilTest', function () {
         expect(result).to.be.false;
     });
 
-    it('resolveAddress: returns IPv4 for localhost with port', async function () {
+    it('resolveAddress: returns loopback address for localhost with port', async function () {
         const result = await resolveAddress('localhost:5701');
-        expect(result).to.be.equal('127.0.0.1');
+        expect(result).to.satisfy(ip => ip === '127.0.0.1' || ip === '::1');
     });
 
-    it('resolveAddress: returns IPv4 for localhost without port', async function () {
+    it('resolveAddress: returns loopback address for localhost without port', async function () {
         const result = await resolveAddress('localhost');
-        expect(result).to.be.equal('127.0.0.1');
+        expect(result).to.satisfy(ip => ip === '127.0.0.1' || ip === '::1');
     });
 
     it('resolveAddress: returns IPv4 for IPv4 address with port', async function () {

--- a/test/unit/util/AddressUtilTest.js
+++ b/test/unit/util/AddressUtilTest.js
@@ -15,7 +15,9 @@
  */
 'use strict';
 
-const { expect } = require('chai');
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-as-promised'));
 const net = require('net');
 const {
     createAddressFromString,


### PR DESCRIPTION
- Non clean cherry-pick backport of #1095. Linebreak style eslint change is omitted since it was not set already in this branch. The original PR was fixing a unit test so we need to backport it to all branches. 

- Also adds CI yaml. After we switch to github actions we did not add workflow files to older branches.
- Remove junit reporter, it was making `nyc` fail somehow with no output. 
- Also add `chai as promised` plugin to the test. I think it was working since chai plugins are cached inside so that using it in one test is enough, so this test passed since other tests included the plugin. It was failing when run solely.