### PR TITLE
Add CI workflow for gh actions due to Jenkins's removal

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Run tests
+on:
+    push:
+        branches-ignore:
+            - 'gh-pages'
+        tags-ignore:
+            - '*'
+    pull_request:
+
+jobs:
+    run-tests:
+        name: Run Tests on (${{ matrix.os }})
+        runs-on: ${{ matrix.os }}
+
+        strategy:
+            matrix:
+                os: [ ubuntu-latest, windows-latest ]
+
+        steps:
+            - name: Setup Java
+              uses: actions/setup-java@v1
+              with:
+                  java-version: 8
+            - name: Setup Node.js
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 10
+            - name: Checkout code
+              uses: actions/checkout@v2
+            - name: Install dependencies and compile client
+              run: |
+                  npm install
+                  npm run compile
+            - name: Run OS tests
+              if: ${{ github.event_name == 'pull_request' }}
+              run: |
+                  npm run coverage
+            - name: Run Enterprise tests
+              if: ${{ github.event_name == 'push' }}
+              env:
+                  HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY }}
+              run: |
+                  npm run coverage
+            - name: Publish to Codecov
+              if: ${{ matrix.os == 'ubuntu-latest' }}
+              uses: codecov/codecov-action@v2
+              with:
+                  files: coverage/lcov.info

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "eslint": "^7.7.0",
         "jsonschema": "^1.2.6",
         "mocha": "^8.1.1",
-        "mocha-junit-reporter": "^2.0.0",
         "mousse": "^0.3.1",
         "nyc": "^15.1.0",
         "rimraf": "^3.0.2",
@@ -38,7 +37,7 @@
         "test": "mocha 'test/**/*.js'",
         "validate-user-code": "tsc --build test/user_code/tsconfig.json",
         "precoverage": "node download-remote-controller.js",
-        "coverage": "rimraf coverage && nyc node_modules/mocha/bin/_mocha 'test/**/*.js' -- --reporter-options mochaFile=report.xml --reporter mocha-junit-reporter",
+        "coverage": "rimraf coverage && nyc node_modules/mocha/bin/_mocha 'test/**/*.js'",
         "pregenerate-docs": "rimraf docs",
         "generate-docs": "typedoc --options typedoc.json",
         "lint": "eslint --ext .ts ."


### PR DESCRIPTION
- Adds CI yaml. After we switch to github actions we did not add workflow files to older branches.
- Remove junit reporter, it was making `nyc` fail somehow with no output. 