### PR TITLE
Isolate failing near cache test API-1161

### DIFF
--- a/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
+++ b/test/integration/backward_compatible/parallel/map/NearCachedMapTest.js
@@ -31,12 +31,15 @@ describe('NearCachedMapTest', function () {
             let client2;
             let map1;
             let map2;
+            let member;
 
             before(async function () {
                 cluster = await testFactory.createClusterForParallelTests(null,
                     fs.readFileSync(__dirname + '/hazelcast_nearcache_batchinvalidation_false.xml', 'utf8'));
-                const member = await RC.startMember(cluster.id);
+                member = await RC.startMember(cluster.id);
+            });
 
+            beforeEach(async function () {
                 const cfg = {
                     clusterName: cluster.id,
                     nearCaches: {
@@ -47,16 +50,13 @@ describe('NearCachedMapTest', function () {
                 };
                 client1 = await testFactory.newHazelcastClientForParallelTests(cfg, member);
                 client2 = await testFactory.newHazelcastClientForParallelTests(cfg, member);
-            });
-
-            beforeEach(async function () {
                 map1 = await client1.getMap('ncc-map');
                 map2 = await client2.getMap('ncc-map');
-                return TestUtil.fillMap(map1);
+                await TestUtil.fillMap(map1);
             });
 
             afterEach(async function () {
-                await map1.destroy();
+                await testFactory.shutdownAllClients();
             });
 
             after(async function () {
@@ -103,6 +103,7 @@ describe('NearCachedMapTest', function () {
                 }
 
                 await map1.get('key1');
+                expect(getNearCacheStats(map1).missCount).to.be.eq(1);
                 await map2.remove('key1');
 
                 await assertTrueEventually(async () => {

--- a/test/integration/backward_compatible/parallel/sql/DataTypeTest.js
+++ b/test/integration/backward_compatible/parallel/sql/DataTypeTest.js
@@ -822,7 +822,7 @@ describe('Data type test', function () {
             // JSON support is added in 5.1.
             TestUtil.markClientVersionAtLeast(this, '5.1');
             TestUtil.markServerVersionAtLeast(this, client, '5.1');
-            
+
             const SqlColumnType = TestUtil.getSqlColumnType();
 
             const createMappingQuery = `


### PR DESCRIPTION
I think the test logic is correct. I ran the test on its own several times and could not get a fail. https://github.com/srknzl/hazelcast-nodejs-client/actions/runs/1880356435/attempts/1  (You can see all attempts in the attempts selector.)

I think isolating the test can fix the flakiness. To do that, I create a client before each test.

fixes #1176