### PR TITLE
Fix ListenersOnReconnect test's one fail scenario API-1196

### DIFF
--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -152,6 +152,37 @@ exports.getRandomConnection = function(client) {
     }
 };
 
+exports.getConnections = function(client) {
+    if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
+        return client.connectionRegistry.getConnections();
+    } else {
+        return client.getConnectionManager().getConnections();
+    }
+};
+
+/**
+ * @param client Client instance
+ * @param registrationId Registration id of the listener as a string
+ * @returns a Map<Connection, ConnectionRegistration> in 5.1 and above,
+ * a Map<ClientConnection, ClientEventRegistration> before 5.1
+ */
+exports.getActiveRegistrations = function(client, registrationId) {
+    const listenerService = client.getListenerService();
+    if (exports.isClientVersionAtLeast('5.1')) {
+        const registration = listenerService.registrations.get(registrationId);
+        if (registration === undefined) {
+            return new Map();
+        }
+        return registration.connectionRegistrations;
+    } else {
+        const registrationMap = listenerService.activeRegistrations.get(registrationId);
+        if (registrationMap === undefined) {
+            return new Map();
+        }
+        return registrationMap;
+    }
+};
+
 exports.isServerVersionAtLeast = function(client, version) {
     let actual = BuildInfo.UNKNOWN_VERSION_ID;
     if (process.env['SERVER_VERSION']) {

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -49,7 +49,8 @@ describe('ListenersOnReconnectTest', function () {
                 smartRouting: isSmart
             },
             properties: {
-                'hazelcast.client.heartbeat.interval': 1000
+                'hazelcast.client.heartbeat.interval': 1000,
+                'hazelcast.client.heartbeat.timeout': 3000
             }
         }, members);
         map = await client.getMap('testmap');
@@ -77,10 +78,13 @@ describe('ListenersOnReconnectTest', function () {
 
         // Assert that connections are closed and the listener is reregistered.
         await TestUtil.assertTrueEventually(async () => {
-            const activeConnectionsCount = TestUtil.getConnections(client).length;
-            expect(activeConnectionsCount).to.be.equal(1);
+            const activeConnections = TestUtil.getConnections(client);
+            expect(activeConnections.length).to.be.equal(1);
             const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
-            expect([...activeRegistrations.keys()].length).to.be.equal(1);
+
+            const connectionsThatHasListener = [...activeRegistrations.keys()];
+            expect(connectionsThatHasListener.length).to.be.equal(1);
+            expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
         });
 
         await map.put('keyx', 'valx');

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -80,8 +80,8 @@ describe('ListenersOnReconnectTest', function () {
         await TestUtil.assertTrueEventually(async () => {
             const activeConnections = TestUtil.getConnections(client);
             expect(activeConnections.length).to.be.equal(1);
-            const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
 
+            const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
             const connectionsThatHasListener = [...activeRegistrations.keys()];
             expect(connectionsThatHasListener.length).to.be.equal(1);
             expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -47,9 +47,6 @@ describe('ListenersOnReconnectTest', function () {
             clusterName: cluster.id,
             network: {
                 smartRouting: isSmart
-            },
-            properties: {
-                'hazelcast.client.heartbeat.interval': 1000
             }
         }, members);
         map = await client.getMap('testmap');

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -49,8 +49,7 @@ describe('ListenersOnReconnectTest', function () {
                 smartRouting: isSmart
             },
             properties: {
-                'hazelcast.client.heartbeat.interval': 1000,
-                'hazelcast.client.heartbeat.timeout': 3000
+                'hazelcast.client.heartbeat.interval': 1000
             }
         }, members);
         map = await client.getMap('testmap');

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -69,13 +69,20 @@ describe('ListenersOnReconnectTest', function () {
                 }
             }
         };
-        await map.addEntryListener(listener, 'keyx', true);
+        const registrationId = await map.addEntryListener(listener, 'keyx', true);
         await Promise.all([
             turnoffMember(cluster.id, members[membersToClose[0]].uuid),
             turnoffMember(cluster.id, members[membersToClose[1]].uuid)
         ]);
 
-        await TestUtil.promiseWaitMilliseconds(8000);
+        // Assert that connections are closed and the listener is reregistered.
+        await TestUtil.assertTrueEventually(async () => {
+            const activeConnectionsCount = TestUtil.getConnections(client).length;
+            expect(activeConnectionsCount).to.be.equal(1);
+            const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+            expect([...activeRegistrations.keys()].length).to.be.equal(1);
+        });
+
         await map.put('keyx', 'valx');
         await deferred;
     }


### PR DESCRIPTION
Partially fixes the issue #1114 therefore I won't close the issue upon merging this pr. 

### The fail

The error is thrown at
`InvocationService.scheduleCleanResourcesTask` in 

```js
if (!connection.isAlive()) {
    this.notifyError(invocation, new core_1.TargetDisconnectedError(connection.getClosedReason()));
    continue;
}
```

So the connection is closed and the map.put invocation is rejected. Fail happens regardless of smartMode is true or false. Fail happens when member 0 and member 2 are closed, don't know why combinations don't fail. The same fail happens on other branches as well as master:

- 4.0.x https://github.com/hazelcast/hazelcast-nodejs-client/runs/5347783005?check_suite_focus=true#step:9:2239
- 4.1.x https://github.com/hazelcast/hazelcast-nodejs-client/runs/5347782683?check_suite_focus=true#step:9:2848
- 5.0.x https://github.com/hazelcast/hazelcast-nodejs-client/runs/5347781751?check_suite_focus=true#step:9:2694
- master https://github.com/hazelcast/hazelcast-nodejs-client/runs/5358544171?check_suite_focus=true#step:6:8934

**Note**: Somehow the fail does not happen on 4.2.x

### Logs

Logs of failure on windows and client 4.0.x with node 12 with TRACE logging level: 

```
[DefaultLogger] INFO at LifecycleService: HazelcastClient is STARTING
[DefaultLogger] INFO at LifecycleService: HazelcastClient is STARTED
[DefaultLogger] INFO at ConnectionManager: Trying to connect to localhost:5701
[DefaultLogger] INFO at LifecycleService: HazelcastClient is CONNECTED
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5701:4b2ebd1d-f694-469e-929c-c18aef932c5f, server version: 4.0.4-SNAPSHOT, local address: 127.0.0.1:58225
[DefaultLogger] TRACE at ClusterViewListenerService: Register attempt of cluster view handler to ClientConnection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] TRACE at ClusterService: Resetting the member list version
[DefaultLogger] INFO at ClusterService: 

Members [3] {
	Member [localhost]:5701 - 4b2ebd1d-f694-469e-929c-c18aef932c5f
	Member [localhost]:5702 - 886bbac3-b8aa-4765-87ea-c855337ff4c1
	Member [localhost]:5703 - b45aa6bb-d994-4813-a5ee-268f66780b16
}

[DefaultLogger] TRACE at ClusterViewListenerService: Registered cluster view handler to ClientConnection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5702:886bbac3-b8aa-4765-87ea-c855337ff4c1, server version: 4.0.4-SNAPSHOT, local address: 127.0.0.1:58226
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5703:b45aa6bb-d994-4813-a5ee-268f66780b16, server version: 4.0.4-SNAPSHOT, local address: 127.0.0.1:58227
[DefaultLogger] DEBUG at ListenerService: Listener 8d3e2a9d-23d3-e35f-546f-0e78e5df0695 registered on ClientConnection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] DEBUG at ListenerService: Listener 8d3e2a9d-23d3-e35f-546f-0e78e5df0695 registered on ClientConnection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] DEBUG at ListenerService: Listener 8d3e2a9d-23d3-e35f-546f-0e78e5df0695 registered on ClientConnection{alive=true, connectionId=2, remoteAddress=localhost:5703}
[DefaultLogger] DEBUG at ListenerService: Listener e75cf740-134d-b745-23c0-032054842340 registered on ClientConnection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] DEBUG at ListenerService: Listener e75cf740-134d-b745-23c0-032054842340 registered on ClientConnection{alive=true, connectionId=2, remoteAddress=localhost:5703}
[DefaultLogger] DEBUG at ListenerService: Listener e75cf740-134d-b745-23c0-032054842340 registered on ClientConnection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] WARN at Connection: ClientConnection{alive=false, connectionId=0, remoteAddress=localhost:5701} closed. Reason: Connection closed by the other side. - Connection closed by the other side.
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5701:4b2ebd1d-f694-469e-929c-c18aef932c5f, connection: ClientConnection{alive=false, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] TRACE at ClusterViewListenerService: Register attempt of cluster view handler to ClientConnection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] TRACE at ClusterService: Resetting the member list version
[DefaultLogger] TRACE at ClusterViewListenerService: Registered cluster view handler to ClientConnection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] WARN at Connection: ClientConnection{alive=false, connectionId=2, remoteAddress=localhost:5703} closed. Reason: Connection closed by the other side. - Connection closed by the other side.
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5703:b45aa6bb-d994-4813-a5ee-268f66780b16, connection: ClientConnection{alive=false, connectionId=2, remoteAddress=localhost:5703}
[DefaultLogger] TRACE at InvocationService: Partition owner is not assigned yet
[DefaultLogger] WARN at HeartbeatManager: Heartbeat failed over connection: ClientConnection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] WARN at Connection: ClientConnection{alive=false, connectionId=1, remoteAddress=localhost:5702} closed. Reason: Socket explicitly closed - Heartbeat timed out to connection ClientConnection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5702:886bbac3-b8aa-4765-87ea-c855337ff4c1, connection: ClientConnection{alive=false, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] INFO at LifecycleService: HazelcastClient is DISCONNECTED
[DefaultLogger] INFO at ConnectionManager: Trying to connect to localhost:5702
[DefaultLogger] INFO at LifecycleService: HazelcastClient is CONNECTED
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5702:886bbac3-b8aa-4765-87ea-c855337ff4c1, server version: 4.0.4-SNAPSHOT, local address: 127.0.0.1:58258
[DefaultLogger] TRACE at ClusterViewListenerService: Register attempt of cluster view handler to ClientConnection{alive=true, connectionId=3, remoteAddress=localhost:5702}
[DefaultLogger] TRACE at ClusterService: Resetting the member list version
[DefaultLogger] DEBUG at ListenerService: Listener 8d3e2a9d-23d3-e35f-546f-0e78e5df0695 re-registered on ClientConnection{alive=true, connectionId=3, remoteAddress=localhost:5702}
[DefaultLogger] TRACE at ClusterViewListenerService: Registered cluster view handler to ClientConnection{alive=true, connectionId=3, remoteAddress=localhost:5702}
[DefaultLogger] DEBUG at ListenerService: Listener e75cf740-134d-b745-23c0-032054842340 re-registered on ClientConnection{alive=true, connectionId=3, remoteAddress=localhost:5702}
    1) kill two members [0,2], listener still receives map.put event [smart=true]
[DefaultLogger] INFO at ClusterService: 

Members [1] {
	Member [localhost]:5702 - 886bbac3-b8aa-4765-87ea-c855337ff4c1
}

[DefaultLogger] INFO at LifecycleService: HazelcastClient is SHUTTING_DOWN
[DefaultLogger] TRACE at Connection: ClientConnection{alive=false, connectionId=3, remoteAddress=localhost:5702} closed. Reason: Hazelcast client is shutting down
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5702:886bbac3-b8aa-4765-87ea-c855337ff4c1, connection: ClientConnection{alive=false, connectionId=3, remoteAddress=localhost:5702}
[DefaultLogger] INFO at LifecycleService: HazelcastClient is DISCONNECTED
[DefaultLogger] INFO at LifecycleService: HazelcastClient is SHUTDOWN

1) ListenersOnReconnectTest
  kill two members [0,2], listener still receives map.put event [smart=true]:
Error: null
at new TargetDisconnectedError (lib\core\HazelcastError.js:237:9)
at Timeout._onTimeout (lib\invocation\InvocationService.js:200:50)
at listOnTimeout (internal/timers.js:554:17)
at processTimers (internal/timers.js:497:7)
```

Client state switches to disconnected state and the fail happens. The connection to the member that is not killed or terminated is closed with this message: `Socket explicitly closed - Heartbeat timed out to connection`. This means there is a heartbeat timeout. 

I don't know why but we set heartbeat timeout to 3 seconds in this test. We don't need to set it because the other two connections are closed via `socket.once('end')` handler that is registered in connection manager. To fix the issue, I delete the property for heartbeat timeout.


Backports will be sent later. 


### I have tested this fix

 I tested my fix on my fork. I have nightly for maintenance branches workflow  and CI workflow that can run only a single test based on a workflow input. I have run this test with heartbeat timeout removed and here is the results on master and other branches:

master https://github.com/srknzl/hazelcast-nodejs-client/runs/5359593057?check_suite_focus=true
nightly https://github.com/srknzl/hazelcast-nodejs-client/actions/runs/1910257912

As you can see there are unrelated failures, not the fail this PR is about. Out of 64 tests in nightly run, one of them is stuck somehow, some of them are failed due to RC being not able to start, and some of them failed since `done` is called twice. done being called twice is another part of `ListenersOnReconnectTest` and was happening before. We should fix it seperately. In order to fix it, we should make the test stop using `done` approach and use deferred promise approach just like we did for master.