### PR TITLE
[5.0.x] Promisify ListenersOnReconnectTest & fix a test scenario API-1196

### DIFF
--- a/src/invocation/InvocationService.ts
+++ b/src/invocation/InvocationService.ts
@@ -307,7 +307,6 @@ export class InvocationService {
                 }
                 if (!connection.isAlive()) {
                     this.notifyError(invocation, new TargetDisconnectedError(connection.getClosedReason()));
-                    console.log(invocation.request.getMessageType());
                     continue;
                 }
                 if (this.backupAckToClientEnabled) {

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -152,7 +152,7 @@ exports.getConnections = function(client) {
     if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
         return client.connectionRegistry.getConnections();
     } else {
-        return client.getConnectionManager().getConnections();
+        return client.getConnectionManager().getActiveConnections();
     }
 };
 

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -30,37 +30,6 @@ exports.promiseLater = function (time, func) {
     }));
 };
 
-exports.getConnections = function(client) {
-    if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
-        return client.connectionRegistry.getConnections();
-    } else {
-        return client.getConnectionManager().getActiveConnections();
-    }
-};
-
-/**
- * @param client Client instance
- * @param registrationId Registration id of the listener as a string
- * @returns a Map<Connection, ConnectionRegistration> in 5.1 and above,
- * a Map<ClientConnection, ClientEventRegistration> before 5.1
- */
-exports.getActiveRegistrations = function(client, registrationId) {
-    const listenerService = client.getListenerService();
-    if (exports.isClientVersionAtLeast('5.1')) {
-        const registration = listenerService.registrations.get(registrationId);
-        if (registration === undefined) {
-            return new Map();
-        }
-        return registration.connectionRegistrations;
-    } else {
-        const registrationMap = listenerService.activeRegistrations.get(registrationId);
-        if (registrationMap === undefined) {
-            return new Map();
-        }
-        return registrationMap;
-    }
-};
-
 /**
  * Returns rejection reason if rejected, otherwise throws an error.
  */

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -179,37 +179,6 @@ exports.getRandomConnection = function(client) {
     }
 };
 
-exports.getConnections = function(client) {
-    if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
-        return client.connectionRegistry.getConnections();
-    } else {
-        return client.getConnectionManager().getActiveConnections();
-    }
-};
-
-/**
- * @param client Client instance
- * @param registrationId Registration id of the listener as a string
- * @returns a Map<Connection, ConnectionRegistration> in 5.1 and above,
- * a Map<ClientConnection, ClientEventRegistration> before 5.1
- */
-exports.getActiveRegistrations = function(client, registrationId) {
-    const listenerService = client.getListenerService();
-    if (exports.isClientVersionAtLeast('5.1')) {
-        const registration = listenerService.registrations.get(registrationId);
-        if (registration === undefined) {
-            return new Map();
-        }
-        return registration.connectionRegistrations;
-    } else {
-        const registrationMap = listenerService.activeRegistrations.get(registrationId);
-        if (registrationMap === undefined) {
-            return new Map();
-        }
-        return registrationMap;
-    }
-};
-
 exports.isServerVersionAtLeast = function(client, version) {
     let actual = BuildInfo.UNKNOWN_VERSION_ID;
     if (process.env['SERVER_VERSION']) {

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -148,6 +148,37 @@ exports.getRandomConnection = function(client) {
     }
 };
 
+exports.getConnections = function(client) {
+    if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
+        return client.connectionRegistry.getConnections();
+    } else {
+        return client.getConnectionManager().getConnections();
+    }
+};
+
+/**
+ * @param client Client instance
+ * @param registrationId Registration id of the listener as a string
+ * @returns a Map<Connection, ConnectionRegistration> in 5.1 and above,
+ * a Map<ClientConnection, ClientEventRegistration> before 5.1
+ */
+exports.getActiveRegistrations = function(client, registrationId) {
+    const listenerService = client.getListenerService();
+    if (exports.isClientVersionAtLeast('5.1')) {
+        const registration = listenerService.registrations.get(registrationId);
+        if (registration === undefined) {
+            return new Map();
+        }
+        return registration.connectionRegistrations;
+    } else {
+        const registrationMap = listenerService.activeRegistrations.get(registrationId);
+        if (registrationMap === undefined) {
+            return new Map();
+        }
+        return registrationMap;
+    }
+};
+
 exports.isServerVersionAtLeast = function(client, version) {
     let actual = BuildInfo.UNKNOWN_VERSION_ID;
     if (process.env['SERVER_VERSION']) {

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -161,10 +161,18 @@ describe('ListenersOnReconnectTest', function () {
 
             // Assert that the connection reestablished and the listener is reregistered.
             await TestUtil.assertTrueEventually(async () => {
-                const activeConnections = TestUtil.getConnections(client);
+                const activeConnections = client.getConnectionManager().getActiveConnections();
                 expect(activeConnections.length).to.be.equal(1);
 
-                const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+                const listenerService = client.getListenerService();
+                let activeRegistrations;
+                const registrationMap = listenerService.activeRegistrations.get(registrationId);
+                if (registrationMap === undefined) {
+                    activeRegistrations = new Map();
+                } else {
+                    activeRegistrations = registrationMap;
+                }
+
                 const connectionsThatHasListener = [...activeRegistrations.keys()];
                 expect(connectionsThatHasListener.length).to.be.equal(1);
                 expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -26,6 +26,15 @@ describe('ListenersOnReconnectTest', function () {
     let cluster;
     let map;
 
+    const getActiveRegistrations = (client, registrationId) => {
+        const listenerService = client.getListenerService();
+        const registrationMap = listenerService.activeRegistrations.get(registrationId);
+        if (registrationMap === undefined) {
+            return new Map();
+        }
+        return registrationMap;
+    };
+
     beforeEach(async function () {
         cluster = await RC.createCluster(null, null);
     });
@@ -74,10 +83,10 @@ describe('ListenersOnReconnectTest', function () {
 
         // Assert that connections are closed and the listener is reregistered.
         await TestUtil.assertTrueEventually(async () => {
-            const activeConnections = TestUtil.getConnections(client);
+            const activeConnections = client.getConnectionManager().getActiveConnections();
             expect(activeConnections.length).to.be.equal(1);
 
-            const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+            const activeRegistrations = getActiveRegistrations(client, registrationId);
             const connectionsThatHasListener = [...activeRegistrations.keys()];
             expect(connectionsThatHasListener.length).to.be.equal(1);
             expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
@@ -150,10 +159,10 @@ describe('ListenersOnReconnectTest', function () {
             await RC.terminateMember(cluster.id, member.uuid);
             // Assert that the connection is closed and the listener is removed.
             await TestUtil.assertTrueEventually(async () => {
-                const activeConnections = TestUtil.getConnections(client);
+                const activeConnections = client.getConnectionManager().getActiveConnections();
                 expect(activeConnections.length).to.be.equal(0);
 
-                const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+                const activeRegistrations = getActiveRegistrations(client, registrationId);
                 expect(activeRegistrations.size).to.be.equal(0);
             });
 
@@ -164,14 +173,7 @@ describe('ListenersOnReconnectTest', function () {
                 const activeConnections = client.getConnectionManager().getActiveConnections();
                 expect(activeConnections.length).to.be.equal(1);
 
-                const listenerService = client.getListenerService();
-                let activeRegistrations;
-                const registrationMap = listenerService.activeRegistrations.get(registrationId);
-                if (registrationMap === undefined) {
-                    activeRegistrations = new Map();
-                } else {
-                    activeRegistrations = registrationMap;
-                }
+                const activeRegistrations = getActiveRegistrations(client, registrationId);
 
                 const connectionsThatHasListener = [...activeRegistrations.keys()];
                 expect(connectionsThatHasListener.length).to.be.equal(1);

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -83,7 +83,7 @@ describe('ListenersOnReconnectTest', function () {
 
         // Assert that connections are closed and the listener is reregistered.
         await TestUtil.assertTrueEventually(async () => {
-            const activeConnections = client.getConnectionManager().getActiveConnections();
+            const activeConnections = client.connectionRegistry.getConnections();
             expect(activeConnections.length).to.be.equal(1);
 
             const activeRegistrations = getActiveRegistrations(client, registrationId);
@@ -159,7 +159,7 @@ describe('ListenersOnReconnectTest', function () {
             await RC.terminateMember(cluster.id, member.uuid);
             // Assert that the connection is closed and the listener is removed.
             await TestUtil.assertTrueEventually(async () => {
-                const activeConnections = client.getConnectionManager().getActiveConnections();
+                const activeConnections = client.connectionRegistry.getConnections();
                 expect(activeConnections.length).to.be.equal(0);
 
                 const activeRegistrations = getActiveRegistrations(client, registrationId);
@@ -170,7 +170,7 @@ describe('ListenersOnReconnectTest', function () {
 
             // Assert that the connection reestablished and the listener is reregistered.
             await TestUtil.assertTrueEventually(async () => {
-                const activeConnections = client.getConnectionManager().getActiveConnections();
+                const activeConnections = client.connectionRegistry.getConnections();
                 expect(activeConnections.length).to.be.equal(1);
 
                 const activeRegistrations = getActiveRegistrations(client, registrationId);

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -154,8 +154,7 @@ describe('ListenersOnReconnectTest', function () {
                 expect(activeConnections.length).to.be.equal(0);
 
                 const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
-                const connectionsThatHasListener = [...activeRegistrations.keys()];
-                expect(connectionsThatHasListener.length).to.be.equal(0);
+                expect(activeRegistrations.size).to.be.equal(0);
             });
 
             await RC.startMember(cluster.id);


### PR DESCRIPTION
backports #1202 and #1217 and promisfies the test.

partially fixes the issue #1114 

The following is the reason of promisfying.

Done can be called twice while the client is shutting down. The `catch` in `closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [1, 2], RC.terminateMember).catch(done)` causes done to be called twice because the client notifies all promises with an error while it is closing. This happens after the test is passed, leading the test to fail after it passes.

Example run: 

https://github.com/srknzl/hazelcast-nodejs-client/runs/5359592149?check_suite_focus=true

The logs with trace level logging from https://github.com/srknzl/hazelcast-nodejs-client/runs/5359592149?check_suite_focus=true:

```

[DefaultLogger] INFO at LifecycleService: HazelcastClient is STARTING
[DefaultLogger] INFO at LifecycleService: HazelcastClient is STARTED
[DefaultLogger] INFO at ConnectionManager: Trying to connect to 127.0.0.1:5701
[DefaultLogger] INFO at LifecycleService: HazelcastClient is CONNECTED
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5701:2fb1bd6e-4053-46b5-bae5-2730fc1eb19d, server version: 5.0.1-SNAPSHOT, local address: 127.0.0.1:61660
[DefaultLogger] TRACE at ClusterViewListenerService: Register attempt of cluster view handler to Connection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] TRACE at ClusterService: Resetting the member list version.
[DefaultLogger] INFO at ClusterService: 

Members [3] {
	Member [localhost]:5701 - 2fb1bd6e-4053-46b5-bae5-2730fc1eb19d
	Member [localhost]:5702 - 405da6e3-6afd-4520-9e8b-4134e135bcfd
	Member [localhost]:5703 - 36a175a2-165d-46ba-b35c-7ee95e582192
}

[DefaultLogger] TRACE at ClusterViewListenerService: Registered cluster view handler to Connection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5702:405da6e3-6afd-4520-9e8b-4134e135bcfd, server version: 5.0.1-SNAPSHOT, local address: 127.0.0.1:61661
[DefaultLogger] INFO at ConnectionManager: Authenticated with server localhost:5703:36a175a2-165d-46ba-b35c-7ee95e582192, server version: 5.0.1-SNAPSHOT, local address: 127.0.0.1:61662
[DefaultLogger] DEBUG at ListenerService: Listener b7b06139-f438-6c25-e821-82a80b5e8c91 registered on Connection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] DEBUG at ListenerService: Listener b7b06139-f438-6c25-e821-82a80b5e8c91 registered on Connection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] DEBUG at ListenerService: Listener b7b06139-f438-6c25-e821-82a80b5e8c91 registered on Connection{alive=true, connectionId=2, remoteAddress=localhost:5703}
[DefaultLogger] DEBUG at ListenerService: Listener 4074290b-2e52-319a-8f37-f38b0a8838c9 registered on Connection{alive=true, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] DEBUG at ListenerService: Listener 4074290b-2e52-319a-8f37-f38b0a8838c9 registered on Connection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] DEBUG at ListenerService: Listener 4074290b-2e52-319a-8f37-f38b0a8838c9 registered on Connection{alive=true, connectionId=2, remoteAddress=localhost:5703}
[DefaultLogger] WARN at Connection: Connection{alive=false, connectionId=0, remoteAddress=localhost:5701} closed. Reason: Connection closed by the other side. - Connection closed by the other side.
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5701:2fb1bd6e-4053-46b5-bae5-2730fc1eb19d, connection: Connection{alive=false, connectionId=0, remoteAddress=localhost:5701}
[DefaultLogger] TRACE at ClusterViewListenerService: Register attempt of cluster view handler to Connection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] TRACE at ClusterService: Resetting the member list version.
[DefaultLogger] TRACE at ClusterViewListenerService: Registered cluster view handler to Connection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] INFO at ClusterService: 

Members [2] {
	Member [localhost]:5702 - 405da6e3-6afd-4520-9e8b-4134e135bcfd
	Member [localhost]:5703 - 36a175a2-165d-46ba-b35c-7ee95e582192
}

[DefaultLogger] WARN at Connection: Connection{alive=false, connectionId=2, remoteAddress=localhost:5703} closed. Reason: Connection closed by the other side. - Connection closed by the other side.
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5703:36a175a2-165d-46ba-b35c-7ee95e582192, connection: Connection{alive=false, connectionId=2, remoteAddress=localhost:5703}
[DefaultLogger] TRACE at InvocationService: Partition owner is not assigned yet
      √ shutdown two members [0,2], listener still receives map.put event [smart=true]: 39182ms
[DefaultLogger] DEBUG at PartitionService: Handling new partition table with partitionStateVersion: 1
[DefaultLogger] TRACE at PartitionService: Event coming from a new connection. Old connection: undefined, new connection Connection{alive=true, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] INFO at ClusterService: 

Members [1] {
	Member [localhost]:5702 - 405da6e3-6afd-4520-9e8b-4134e135bcfd
}

[DefaultLogger] INFO at LifecycleService: HazelcastClient is SHUTTING_DOWN
[DefaultLogger] TRACE at Connection: Connection{alive=false, connectionId=1, remoteAddress=localhost:5702} closed. Reason: Hazelcast client is shutting down
[DefaultLogger] INFO at ConnectionManager: Removed connection to endpoint: localhost:5702:405da6e3-6afd-4520-9e8b-4134e135bcfd, connection: Connection{alive=false, connectionId=1, remoteAddress=localhost:5702}
[DefaultLogger] INFO at LifecycleService: HazelcastClient is DISCONNECTED
[DefaultLogger] INFO at LifecycleService: HazelcastClient is SHUTDOWN
      1) shutdown two members [0,2], listener still receives map.put event [smart=true]

```