### PR TITLE
[4.2.x] Promisify ListenersOnReconnect & Fix ListenersOnReconnect test's one fail scenario API-1196

### DIFF
--- a/src/listener/ListenerService.ts
+++ b/src/listener/ListenerService.ts
@@ -85,6 +85,7 @@ export class ListenerService {
         this.activeRegistrations.forEach((registrationsOnUserKey) => {
             const eventRegistration = registrationsOnUserKey.get(connection);
             if (eventRegistration !== undefined) {
+                registrationsOnUserKey.delete(connection);
                 this.invocationService.removeEventHandler(eventRegistration.correlationId);
             }
         });

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -160,7 +160,7 @@ exports.getConnections = function(client) {
     if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
         return client.connectionRegistry.getConnections();
     } else {
-        return client.getConnectionManager().getConnections();
+        return client.getConnectionManager().getActiveConnections();
     }
 };
 

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -156,37 +156,6 @@ exports.getRandomConnection = function(client) {
     }
 };
 
-exports.getConnections = function(client) {
-    if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
-        return client.connectionRegistry.getConnections();
-    } else {
-        return client.getConnectionManager().getActiveConnections();
-    }
-};
-
-/**
- * @param client Client instance
- * @param registrationId Registration id of the listener as a string
- * @returns a Map<Connection, ConnectionRegistration> in 5.1 and above,
- * a Map<ClientConnection, ClientEventRegistration> before 5.1
- */
-exports.getActiveRegistrations = function(client, registrationId) {
-    const listenerService = client.getListenerService();
-    if (exports.isClientVersionAtLeast('5.1')) {
-        const registration = listenerService.registrations.get(registrationId);
-        if (registration === undefined) {
-            return new Map();
-        }
-        return registration.connectionRegistrations;
-    } else {
-        const registrationMap = listenerService.activeRegistrations.get(registrationId);
-        if (registrationMap === undefined) {
-            return new Map();
-        }
-        return registrationMap;
-    }
-};
-
 exports.isServerVersionAtLeast = function(client, version) {
     let actual = BuildInfo.UNKNOWN_VERSION_ID;
     if (process.env['SERVER_VERSION']) {

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -156,6 +156,37 @@ exports.getRandomConnection = function(client) {
     }
 };
 
+exports.getConnections = function(client) {
+    if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
+        return client.connectionRegistry.getConnections();
+    } else {
+        return client.getConnectionManager().getConnections();
+    }
+};
+
+/**
+ * @param client Client instance
+ * @param registrationId Registration id of the listener as a string
+ * @returns a Map<Connection, ConnectionRegistration> in 5.1 and above,
+ * a Map<ClientConnection, ClientEventRegistration> before 5.1
+ */
+exports.getActiveRegistrations = function(client, registrationId) {
+    const listenerService = client.getListenerService();
+    if (exports.isClientVersionAtLeast('5.1')) {
+        const registration = listenerService.registrations.get(registrationId);
+        if (registration === undefined) {
+            return new Map();
+        }
+        return registration.connectionRegistrations;
+    } else {
+        const registrationMap = listenerService.activeRegistrations.get(registrationId);
+        if (registrationMap === undefined) {
+            return new Map();
+        }
+        return registrationMap;
+    }
+};
+
 exports.isServerVersionAtLeast = function(client, version) {
     let actual = BuildInfo.UNKNOWN_VERSION_ID;
     if (process.env['SERVER_VERSION']) {

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -19,6 +19,7 @@ const { expect } = require('chai');
 const RC = require('../RC');
 const { Client } = require('../../../');
 const TestUtil = require('../../TestUtil');
+const { deferredPromise } = require('../../../lib/util/Util');
 
 describe('ListenersOnReconnectTest', function () {
 
@@ -36,7 +37,9 @@ describe('ListenersOnReconnectTest', function () {
         return RC.terminateCluster(cluster.id);
     });
 
-    async function closeTwoMembersOutOfThreeAndTestListener(done, isSmart, membersToClose, turnoffMember) {
+    async function closeTwoMembersOutOfThreeAndTestListener(isSmart, membersToClose, turnoffMember) {
+        const deferred = deferredPromise();
+
         const members = await Promise.all([
             RC.startMember(cluster.id),
             RC.startMember(cluster.id),
@@ -46,10 +49,6 @@ describe('ListenersOnReconnectTest', function () {
             clusterName: cluster.id,
             network: {
                 smartRouting: isSmart
-            },
-            properties: {
-                'hazelcast.client.heartbeat.interval': 1000,
-                'hazelcast.client.heartbeat.timeout': 3000
             }
         });
         map = await client.getMap('testmap');
@@ -63,20 +62,31 @@ describe('ListenersOnReconnectTest', function () {
                     expect(entryEvent.oldValue).to.be.equal(null);
                     expect(entryEvent.mergingValue).to.be.equal(null);
                     expect(entryEvent.member).to.not.be.equal(null);
-                    done();
+                    deferred.resolve();
                 } catch (err) {
-                    done(err);
+                    deferred.reject(err);
                 }
             }
         };
-        await map.addEntryListener(listener, 'keyx', true);
+        const registrationId = await map.addEntryListener(listener, 'keyx', true);
         await Promise.all([
             turnoffMember(cluster.id, members[membersToClose[0]].uuid),
             turnoffMember(cluster.id, members[membersToClose[1]].uuid)
         ]);
 
-        await TestUtil.promiseWaitMilliseconds(8000);
-        return map.put('keyx', 'valx');
+        // Assert that connections are closed and the listener is reregistered.
+        await TestUtil.assertTrueEventually(async () => {
+            const activeConnections = TestUtil.getConnections(client);
+            expect(activeConnections.length).to.be.equal(1);
+
+            const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+            const connectionsThatHasListener = [...activeRegistrations.keys()];
+            expect(connectionsThatHasListener.length).to.be.equal(1);
+            expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
+        });
+
+        await map.put('keyx', 'valx');
+        await deferred;
     }
 
     [true, false].forEach((isSmart) => {
@@ -88,69 +98,67 @@ describe('ListenersOnReconnectTest', function () {
          *  - the other unrelated connection
          */
 
-        it('kill two members [1,2], listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [1, 2], RC.terminateMember).catch(done);
+        it('kill two members [1,2], listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            await closeTwoMembersOutOfThreeAndTestListener(isSmart, [1, 2], RC.terminateMember);
         });
 
-        it('kill two members [0,1], listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [0, 1], RC.terminateMember).catch(done);
+        it('kill two members [0,1], listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            await closeTwoMembersOutOfThreeAndTestListener(isSmart, [0, 1], RC.terminateMember);
         });
 
-        it('kill two members [0,2], listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [0, 2], RC.terminateMember).catch(done);
+        it('kill two members [0,2], listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            await closeTwoMembersOutOfThreeAndTestListener(isSmart, [0, 2], RC.terminateMember);
         });
 
-        it('shutdown two members [1,2], listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [1, 2], RC.shutdownMember).catch(done);
+        it('shutdown two members [1,2], listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            await closeTwoMembersOutOfThreeAndTestListener(isSmart, [1, 2], RC.shutdownMember);
         });
 
-        it('shutdown two members [0,1], listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [0, 1], RC.shutdownMember).catch(done);
+        it('shutdown two members [0,1], listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            await closeTwoMembersOutOfThreeAndTestListener(isSmart, [0, 1], RC.shutdownMember);
         });
 
-        it('shutdown two members [0,2], listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            closeTwoMembersOutOfThreeAndTestListener(done, isSmart, [0, 2], RC.shutdownMember).catch(done);
+        it('shutdown two members [0,2], listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            await closeTwoMembersOutOfThreeAndTestListener(isSmart, [0, 2], RC.shutdownMember);
         });
 
-        it('restart member, listener still receives map.put event [smart=' + isSmart + ']', function (done) {
-            async function testListener(done) {
-                const member = await RC.startMember(cluster.id);
-                client = await Client.newHazelcastClient({
-                    clusterName: cluster.id,
-                    network: {
-                        smartRouting: isSmart
-                    },
-                    properties: {
-                        'hazelcast.client.heartbeat.interval': 1000
+        it('restart member, listener still receives map.put event [smart=' + isSmart + ']', async function () {
+            const deferred = deferredPromise();
+            const member = await RC.startMember(cluster.id);
+            client = await Client.newHazelcastClient({
+                clusterName: cluster.id,
+                network: {
+                    smartRouting: isSmart
+                },
+                properties: {
+                    'hazelcast.client.heartbeat.interval': 1000
+                }
+            });
+            map = await client.getMap('testmap');
+
+            const listener = {
+                added: (entryEvent) => {
+                    try {
+                        expect(entryEvent.name).to.equal('testmap');
+                        expect(entryEvent.key).to.equal('keyx');
+                        expect(entryEvent.value).to.equal('valx');
+                        expect(entryEvent.oldValue).to.be.equal(null);
+                        expect(entryEvent.mergingValue).to.be.equal(null);
+                        expect(entryEvent.member).to.not.be.equal(null);
+                        deferred.resolve();
+                    } catch (err) {
+                        deferred.reject(err);
                     }
-                });
-                map = await client.getMap('testmap');
+                }
+            };
+            await map.addEntryListener(listener, 'keyx', true);
 
-                const listener = {
-                    added: (entryEvent) => {
-                        try {
-                            expect(entryEvent.name).to.equal('testmap');
-                            expect(entryEvent.key).to.equal('keyx');
-                            expect(entryEvent.value).to.equal('valx');
-                            expect(entryEvent.oldValue).to.be.equal(null);
-                            expect(entryEvent.mergingValue).to.be.equal(null);
-                            expect(entryEvent.member).to.not.be.equal(null);
-                            done();
-                        } catch (err) {
-                            done(err);
-                        }
-                    }
-                };
-                await map.addEntryListener(listener, 'keyx', true);
+            await RC.terminateMember(cluster.id, member.uuid);
+            await RC.startMember(cluster.id);
 
-                await RC.terminateMember(cluster.id, member.uuid);
-                await RC.startMember(cluster.id);
-
-                await TestUtil.promiseWaitMilliseconds(8000);
-                return map.put('keyx', 'valx');
-            }
-
-            testListener(done).catch(done);
+            await TestUtil.promiseWaitMilliseconds(8000);
+            await map.put('keyx', 'valx');
+            await deferred.promise;
         });
     });
 });

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -138,9 +138,6 @@ describe('ListenersOnReconnectTest', function () {
                 clusterName: cluster.id,
                 network: {
                     smartRouting: isSmart
-                },
-                properties: {
-                    'hazelcast.client.heartbeat.interval': 1000
                 }
             });
             map = await client.getMap('testmap');

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -160,8 +160,7 @@ describe('ListenersOnReconnectTest', function () {
                 expect(activeConnections.length).to.be.equal(0);
 
                 const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
-                const connectionsThatHasListener = [...activeRegistrations.keys()];
-                expect(connectionsThatHasListener.length).to.be.equal(0);
+                expect(activeRegistrations.size).to.be.equal(0);
             });
             await RC.startMember(cluster.id);
 

--- a/test/integration/backward_compatible/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/ListenersOnReconnectTest.js
@@ -27,6 +27,15 @@ describe('ListenersOnReconnectTest', function () {
     let cluster;
     let map;
 
+    const getActiveRegistrations = (client, registrationId) => {
+        const listenerService = client.getListenerService();
+        const registrationMap = listenerService.activeRegistrations.get(registrationId);
+        if (registrationMap === undefined) {
+            return new Map();
+        }
+        return registrationMap;
+    };
+
     beforeEach(async function () {
         cluster = await RC.createCluster(null, null);
     });
@@ -76,10 +85,10 @@ describe('ListenersOnReconnectTest', function () {
 
         // Assert that connections are closed and the listener is reregistered.
         await TestUtil.assertTrueEventually(async () => {
-            const activeConnections = TestUtil.getConnections(client);
+            const activeConnections = client.connectionRegistry.getConnections();
             expect(activeConnections.length).to.be.equal(1);
 
-            const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+            const activeRegistrations = getActiveRegistrations(client, registrationId);
             const connectionsThatHasListener = [...activeRegistrations.keys()];
             expect(connectionsThatHasListener.length).to.be.equal(1);
             expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
@@ -156,20 +165,20 @@ describe('ListenersOnReconnectTest', function () {
             await RC.terminateMember(cluster.id, member.uuid);
             // Assert that the connection is closed and the listener is removed.
             await TestUtil.assertTrueEventually(async () => {
-                const activeConnections = TestUtil.getConnections(client);
+                const activeConnections = client.connectionRegistry.getConnections();
                 expect(activeConnections.length).to.be.equal(0);
 
-                const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+                const activeRegistrations = getActiveRegistrations(client, registrationId);
                 expect(activeRegistrations.size).to.be.equal(0);
             });
             await RC.startMember(cluster.id);
 
             // Assert that the connection reestablished and the listener is reregistered.
             await TestUtil.assertTrueEventually(async () => {
-                const activeConnections = TestUtil.getConnections(client);
+                const activeConnections = client.connectionRegistry.getConnections();
                 expect(activeConnections.length).to.be.equal(1);
 
-                const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+                const activeRegistrations = getActiveRegistrations(client, registrationId);
                 const connectionsThatHasListener = [...activeRegistrations.keys()];
                 expect(connectionsThatHasListener.length).to.be.equal(1);
                 expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);


### PR DESCRIPTION
The same description at https://github.com/hazelcast/hazelcast-nodejs-client/pull/1203 applies to this pr as well