### PR TITLE
[master] Fix bugs in listeneronreconnecttest  API-1196

### DIFF
--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -156,7 +156,7 @@ exports.getConnections = function(client) {
     if (Object.prototype.hasOwnProperty.call(client, 'connectionRegistry')) {
         return client.connectionRegistry.getConnections();
     } else {
-        return client.getConnectionManager().getConnections();
+        return client.getConnectionManager().getActiveConnections();
     }
 };
 

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -84,7 +84,7 @@ describe('ListenersOnReconnectTest', function () {
         });
 
         await map.put('keyx', 'valx');
-        await deferred;
+        await deferred.promise;
     }
 
     [true, false].forEach((isSmart) => {

--- a/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/parallel/ListenersOnReconnectTest.js
@@ -81,7 +81,7 @@ describe('ListenersOnReconnectTest', function () {
             const connectionsThatHasListener = [...activeRegistrations.keys()];
             expect(connectionsThatHasListener.length).to.be.equal(1);
             expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
-        });
+        }, undefined, 600 * 1000);
 
         await map.put('keyx', 'valx');
         await deferred.promise;

--- a/test/integration/backward_compatible/serial/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/serial/ListenersOnReconnectTest.js
@@ -73,8 +73,7 @@ describe('ListenersOnReconnectTest', function () {
                 expect(activeConnections.length).to.be.equal(0);
 
                 const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
-                const connectionsThatHasListener = [...activeRegistrations.keys()];
-                expect(connectionsThatHasListener.length).to.be.equal(0);
+                expect(activeRegistrations.size).to.be.equal(0);
             });
             await RC.startMember(cluster.id);
 

--- a/test/integration/backward_compatible/serial/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/serial/ListenersOnReconnectTest.js
@@ -89,7 +89,7 @@ describe('ListenersOnReconnectTest', function () {
                 expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
             });
             await map.put('keyx', 'valx');
-            await deferred;
+            await deferred.promise;
         });
     });
 });

--- a/test/integration/backward_compatible/serial/ListenersOnReconnectTest.js
+++ b/test/integration/backward_compatible/serial/ListenersOnReconnectTest.js
@@ -45,9 +45,6 @@ describe('ListenersOnReconnectTest', function () {
                 clusterName: cluster.id,
                 network: {
                     smartRouting: isSmart,
-                },
-                properties: {
-                    'hazelcast.client.heartbeat.interval': 1000
                 }
             });
             map = await client.getMap('testmap');
@@ -67,12 +64,30 @@ describe('ListenersOnReconnectTest', function () {
                     }
                 }
             };
-            await map.addEntryListener(listener, 'keyx', true);
+            const registrationId = await map.addEntryListener(listener, 'keyx', true);
 
             await RC.terminateMember(cluster.id, member.uuid);
+            // Assert that the connection is closed and the listener is removed.
+            await TestUtil.assertTrueEventually(async () => {
+                const activeConnections = TestUtil.getConnections(client);
+                expect(activeConnections.length).to.be.equal(0);
+
+                const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+                const connectionsThatHasListener = [...activeRegistrations.keys()];
+                expect(connectionsThatHasListener.length).to.be.equal(0);
+            });
             await RC.startMember(cluster.id);
 
-            await TestUtil.promiseWaitMilliseconds(8000);
+            // Assert that the connection reestablished and the listener is reregistered.
+            await TestUtil.assertTrueEventually(async () => {
+                const activeConnections = TestUtil.getConnections(client);
+                expect(activeConnections.length).to.be.equal(1);
+
+                const activeRegistrations = TestUtil.getActiveRegistrations(client, registrationId);
+                const connectionsThatHasListener = [...activeRegistrations.keys()];
+                expect(connectionsThatHasListener.length).to.be.equal(1);
+                expect(connectionsThatHasListener[0]).to.be.equal(activeConnections[0]);
+            });
             await map.put('keyx', 'valx');
             await deferred;
         });


### PR DESCRIPTION
We made a bug in TestUtils.getConnections(), I fixed that. This will fix back compatibility test failures that will happen otherwise. Also we were awaiting `deferred` instead of `deferred.promise` in both serial and parallel test. I fixed that. Also updated listeneronreconnecttest's serial test like the parallel test is modified in #1202