### PR TITLE
Convert RestValueTest to async await [4.0.x] API-1197

### DIFF
--- a/test/rest_value/RestValueTest.js
+++ b/test/rest_value/RestValueTest.js
@@ -30,75 +30,60 @@ describe('RestValueTest', function () {
     let client;
     let member;
 
-    before(function () {
-        return RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_rest.xml', 'utf8'))
-            .then(c => {
-                cluster = c;
-                return RC.startMember(cluster.id);
-            }).then(m => {
-                member = m;
-                return Client.newHazelcastClient({ clusterName: cluster.id });
-            }).then(c => {
-                client = c;
-            });
+    before(async function () {
+        cluster = await RC.createCluster(null, fs.readFileSync(__dirname + '/hazelcast_rest.xml', 'utf8'));
+        member = await RC.startMember(cluster.id);
+        client = await Client.newHazelcastClient({
+            clusterName: cluster.id
+        });
     });
 
-    after(function () {
-        return client.shutdown()
-            .then(() => RC.terminateCluster(cluster.id));
+    after(async function () {
+        await client.shutdown();
+        await RC.terminateCluster(cluster.id);
     });
 
-    it('client should receive REST events from server as RestValue', function (done) {
+    it('client should receive REST events from server as RestValue', async function () {
         const contentType = 'text/plain';
         const value = {
             'key': 'value'
         };
         const postData = querystring.stringify(value);
+        const deferred = deferredPromise();
 
-        client.getQueue('test')
-            .then((queue) => {
-                const itemListener = {
-                    itemAdded: (event) => {
-                        const item = event.item;
-                        expect(item.contentType).to.equal(contentType);
-                        expect(item.value).to.equal(postData);
-                        done();
-                    }
-                };
-                return queue.addItemListener(itemListener, true);
-            })
-            .then(() => {
-                const deferred = deferredPromise();
+        const queue = await client.getQueue('test');
+        await queue.addItemListener({
+            itemAdded: (event) => {
+                const item = event.item;
+                expect(item.contentType).to.equal(contentType);
+                expect(item.value).to.equal(postData);
+                deferred.resolve();
+            }
+        }, true);
 
-                const options = {
-                    hostname: member.host,
-                    port: member.port,
-                    path: '/hazelcast/rest/queues/test',
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': contentType,
-                        'Content-Length': Buffer.byteLength(postData)
-                    }
-                };
+        const options = {
+            hostname: member.host,
+            port: member.port,
+            path: '/hazelcast/rest/queues/test',
+            method: 'POST',
+            headers: {
+                'Content-Type': contentType,
+                'Content-Length': Buffer.byteLength(postData)
+            }
+        };
 
-                const request = http.request(options, res => {
-                    if (res.statusCode === 200) {
-                        deferred.resolve();
-                    } else {
-                        deferred.reject(res.statusCode);
-                    }
-                });
+        const request = http.request(options, res => {
+            if (res.statusCode !== 200) {
+                deferred.reject(res.statusCode);
+            }
+        });
 
-                request.on('error', e => {
-                    deferred.reject(e);
-                });
+        request.on('error', e => {
+            deferred.reject(e);
+        });
 
-                request.write(postData);
-                request.end();
-                return deferred.promise;
-            })
-            .catch(e => {
-                done(e);
-            })
+        request.write(postData);
+        request.end();
+        await deferred.promise;
     });
 });


### PR DESCRIPTION
The test fail happens due to `done` being called twice. There is a 'socket hang up' error during http call.

According to https://stackoverflow.com/a/27835115, socket hang up means: 

> When you, as a client, send a request to a remote server, and receive no timely response. Your socket is ended which throws this error. You should catch this error and decide how to handle it: whether retry the request, queue it for later, etc.

since we are the client here. So, the server does not respond in time, however the queue item listener gets the item.

I am not sure how to fix the test actually. However, looks like after the test is converted async await, test does not fail anymore. https://github.com/hazelcast/hazelcast-nodejs-client/pull/824

At least, I did not see it failing in client versions that is newer than 4.1. Therefore the fix will be converting the test to async await syntax.

fixes #1105