### PR TITLE
API-1263 HeartbeatfromServer flaky test fix [4.1.x]

### DIFF
--- a/src/core/MembershipListener.ts
+++ b/src/core/MembershipListener.ts
@@ -62,14 +62,14 @@ export interface MembershipListener {
      *
      * @param {MembershipEvent} event event object
      */
-    memberAdded(event: MembershipEvent): void;
+    memberAdded?(event: MembershipEvent): void;
 
     /**
      * Invoked when an existing member leaves the cluster.
      *
      * @param {MembershipEvent} event event object
      */
-    memberRemoved(event: MembershipEvent): void;
+    memberRemoved?(event: MembershipEvent): void;
 
 }
 

--- a/test/integration/heartbeat/HeartbeatFromServerTest.js
+++ b/test/integration/heartbeat/HeartbeatFromServerTest.js
@@ -31,7 +31,23 @@ describe('HeartbeatFromServerTest', function () {
 
     function simulateHeartbeatLost(client, address, timeout) {
         const connection = client.getConnectionManager().getConnectionForAddress(address);
-        connection.lastReadTimeMillis = connection.getLastReadTimeMillis() - timeout;
+        /*
+        Run more than once to avoid the following case:
+
+        As a result of ping requests, lastReadTime of a connection is continuously updated.
+        Let's say we called simulateHeartbeatLost and then
+        before the heartbeatFunction() has a chance to run some
+        data may be received on the socket, which updates the lastReadTime. Then, when heartbeatFunction
+        runs, it won't close the connection because lastReadTime is updated.
+         */
+        for (let i = 0; i < 5; i++) {
+            setTimeout(
+                () => {
+                    connection.lastReadTimeMillis = connection.getLastReadTimeMillis() - timeout;
+                },
+                100 * i
+            );
+        }
     }
 
     async function warmUpConnectionToAddressWithRetry(client, address, retryCount) {
@@ -90,8 +106,6 @@ describe('HeartbeatFromServerTest', function () {
             member2 = m2;
             return memberAddedPromise.promise;
         }).then(() => {
-            simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000);
-        }).then(() => {
             client.getConnectionManager().once('connectionRemoved', (connection) => {
                 const remoteAddress = connection.getRemoteAddress();
                 if (remoteAddress.host === member2.host && remoteAddress.port === member2.port) {
@@ -106,6 +120,7 @@ describe('HeartbeatFromServerTest', function () {
                         + member2.host + ':' + member2.port));
                 }
             });
+            simulateHeartbeatLost(client, new AddressImpl(member2.host, member2.port), 2000);
         }).catch(done);
     });
 


### PR DESCRIPTION
Backporting https://github.com/hazelcast/hazelcast-nodejs-client/pull/1006 since the fail happens in older branches too

fixes #820