### PR TITLE
Fix flaky ClientReconnectTest [4.2.x] API-1241

### DIFF
--- a/test/integration/backward_compatible/ClientReconnectTest.js
+++ b/test/integration/backward_compatible/ClientReconnectTest.js
@@ -36,10 +36,9 @@ describe('ClientReconnectTest', function () {
      */
     const waitForDisconnection = async (client) => {
         const clientRegistry = client.connectionRegistry;
-        const getConnectionsFn = clientRegistry.getConnections.bind(clientRegistry);
 
         await TestUtil.assertTrueEventually(async () => {
-            expect(getConnectionsFn()).to.be.empty;
+            expect(clientRegistry.getConnections()).to.be.empty;
         });
     };
 


### PR DESCRIPTION
We merged three prs to fix this test before 5.0: 

https://github.com/hazelcast/hazelcast-nodejs-client/pull/972
https://github.com/hazelcast/hazelcast-nodejs-client/pull/954
https://github.com/hazelcast/hazelcast-nodejs-client/pull/1053

I backported their changes regarding the test itself. 

fixes #1200 