### PR TITLE
Increase timeouts in MapProxyTest [4.0.x] API-1200

### DIFF
--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -113,7 +113,7 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl puts value to map', function () {
-                return map.put('key-with-ttl', 'val-with-ttl', 3000).then(function () {
+                return map.put('key-with-ttl', 'val-with-ttl', 20000).then(function () {
                     return map.get('key-with-ttl').then(function (val) {
                         return expect(val).to.equal('val-with-ttl');
                     });
@@ -121,12 +121,12 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl removes value after ttl', function () {
-                return map.put('key10', 'val10', 2000).then(function () {
+                return map.put('key10', 'val10', 20000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('val10');
                 }).then(function () {
-                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(21000, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });
@@ -361,12 +361,12 @@ describe('MapProxyTest', function () {
             });
 
             it('putIfAbsent_with_ttl', function () {
-                return map.putIfAbsent('key10', 'new-val', 2000).then(function () {
+                return map.putIfAbsent('key10', 'new-val', 20000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('new-val');
                 }).then(function () {
-                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(21000, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });
@@ -382,12 +382,12 @@ describe('MapProxyTest', function () {
             });
 
             it('putTransient_withTTL', function () {
-                return map.putTransient('key10', 'val10', 2000).then(function () {
+                return map.putTransient('key10', 'val10', 20000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('val10');
                 }).then(function () {
-                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(21000, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });
@@ -432,12 +432,12 @@ describe('MapProxyTest', function () {
             });
 
             it('set_withTTL', function () {
-                return map.set('key10', 'val10', 2000).then(function () {
+                return map.set('key10', 'val10', 20000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('val10');
                 }).then(function () {
-                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(21000, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 })

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -121,12 +121,12 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl removes value after ttl', function () {
-                return map.put('key10', 'val10', 1000).then(function () {
+                return map.put('key10', 'val10', 2000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('val10');
                 }).then(function () {
-                    return Util.promiseLater(1100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });
@@ -361,12 +361,12 @@ describe('MapProxyTest', function () {
             });
 
             it('putIfAbsent_with_ttl', function () {
-                return map.putIfAbsent('key10', 'new-val', 1000).then(function () {
+                return map.putIfAbsent('key10', 'new-val', 2000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('new-val');
                 }).then(function () {
-                    return Util.promiseLater(1100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });
@@ -382,12 +382,12 @@ describe('MapProxyTest', function () {
             });
 
             it('putTransient_withTTL', function () {
-                return map.putTransient('key10', 'val10', 1000).then(function () {
+                return map.putTransient('key10', 'val10', 2000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('val10');
                 }).then(function () {
-                    return Util.promiseLater(1100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });
@@ -432,12 +432,12 @@ describe('MapProxyTest', function () {
             });
 
             it('set_withTTL', function () {
-                return map.set('key10', 'val10', 1000).then(function () {
+                return map.set('key10', 'val10', 2000).then(function () {
                     return map.get('key10');
                 }).then(function (val) {
                     return expect(val).to.equal('val10');
                 }).then(function () {
-                    return Util.promiseLater(1100, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(2100, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 })
@@ -525,7 +525,7 @@ describe('MapProxyTest', function () {
             it('tryLock_success with timeout', function () {
                 return RC.executeOnController(cluster.id, generateLockScript(map.getName(), '"key0"'), 1)
                     .then(function () {
-                        const promise = map.tryLock('key0', 1000);
+                        const promise = map.tryLock('key0', 2000);
                         RC.executeOnController(cluster.id, generateUnlockScript(map.getName(), '"key0"'), 1);
                         return promise;
                     })

--- a/test/map/MapProxyTest.js
+++ b/test/map/MapProxyTest.js
@@ -121,12 +121,9 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl removes value after ttl', function () {
-                return map.put('key10', 'val10', 20000).then(function () {
-                    return map.get('key10');
-                }).then(function (val) {
-                    return expect(val).to.equal('val10');
+                return map.put('key10', 'val10', 2000).then(function () {
                 }).then(function () {
-                    return Util.promiseLater(21000, map.get.bind(map, 'key10'));
+                    return Util.promiseLater(3000, map.get.bind(map, 'key10'));
                 }).then(function (val) {
                     return expect(val).to.be.null;
                 });


### PR DESCRIPTION
Increased the timeouts that we increased through https://github.com/hazelcast/hazelcast-nodejs-client/pull/725 and https://github.com/hazelcast/hazelcast-nodejs-client/pull/1104

The test did not fail in master for a long time we must ensure the same happens in maintenance branches too.  Increases ttls to 20 seconds because according to Yuce and Sancar in go and java 20 seconds is used.

fixes #724 
