### PR TITLE
Increase timeouts in MapProxyTest [4.1.x] API-1200

### DIFF
--- a/test/integration/map/MapProxyTest.js
+++ b/test/integration/map/MapProxyTest.js
@@ -110,29 +110,29 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl removes value after ttl', async function () {
-                await map.put('key10', 'val10', 1000);
+                await map.put('key10', 'val10', 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('put with maxIdle removes value after maxIdle', async function () {
-                await map.put('key10', 'val10', undefined, 1000);
+                await map.put('key10', 'val10', undefined, 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('setTtl updates ttl for entry', async function () {
-                await map.put('key10', 'val10', 1000);
+                await map.put('key10', 'val10', 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
 
                 await map.setTtl('key10', 60000);
 
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.equal('val10');
             });
 
@@ -325,18 +325,18 @@ describe('MapProxyTest', function () {
             });
 
             it('putIfAbsent_with_ttl', async function () {
-                await map.putIfAbsent('key10', 'new-val', 1000);
+                await map.putIfAbsent('key10', 'new-val', 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('new-val');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('putIfAbsent_with_maxIdle', async function () {
-                await map.putIfAbsent('key10', 'new-val', undefined, 1000);
+                await map.putIfAbsent('key10', 'new-val', undefined, 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('new-val');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
@@ -347,18 +347,18 @@ describe('MapProxyTest', function () {
             });
 
             it('putTransient_with_ttl', async function () {
-                await map.putTransient('key10', 'val10', 1000);
+                await map.putTransient('key10', 'val10', 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('putTransient_with_maxIdle', async function () {
-                await map.putTransient('key10', 'val10', undefined, 1000);
+                await map.putTransient('key10', 'val10', undefined, 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
@@ -390,18 +390,18 @@ describe('MapProxyTest', function () {
             });
 
             it('set_with_ttl', async function () {
-                await map.set('key10', 'val10', 1000);
+                await map.set('key10', 'val10', 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('set_with_maxIdle', async function () {
-                await map.set('key10', 'val10', undefined, 1000);
+                await map.set('key10', 'val10', undefined, 2000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(1100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 

--- a/test/integration/map/MapProxyTest.js
+++ b/test/integration/map/MapProxyTest.js
@@ -110,10 +110,8 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl removes value after ttl', async function () {
-                await map.put('key10', 'val10', 20000);
-                let val = await map.get('key10');
-                expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
+                await map.put('key10', 'val10', 2000);
+                const val = await TestUtil.promiseLater(3000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 

--- a/test/integration/map/MapProxyTest.js
+++ b/test/integration/map/MapProxyTest.js
@@ -104,35 +104,35 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl puts value to map', async function () {
-                await map.put('key-with-ttl', 'val-with-ttl', 3000);
+                await map.put('key-with-ttl', 'val-with-ttl', 20000);
                 const val = await map.get('key-with-ttl');
                 expect(val).to.equal('val-with-ttl');
             });
 
             it('put with ttl removes value after ttl', async function () {
-                await map.put('key10', 'val10', 2000);
+                await map.put('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('put with maxIdle removes value after maxIdle', async function () {
-                await map.put('key10', 'val10', undefined, 2000);
+                await map.put('key10', 'val10', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('setTtl updates ttl for entry', async function () {
-                await map.put('key10', 'val10', 2000);
+                await map.put('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
 
                 await map.setTtl('key10', 60000);
 
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.equal('val10');
             });
 
@@ -325,18 +325,18 @@ describe('MapProxyTest', function () {
             });
 
             it('putIfAbsent_with_ttl', async function () {
-                await map.putIfAbsent('key10', 'new-val', 2000);
+                await map.putIfAbsent('key10', 'new-val', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('new-val');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('putIfAbsent_with_maxIdle', async function () {
-                await map.putIfAbsent('key10', 'new-val', undefined, 2000);
+                await map.putIfAbsent('key10', 'new-val', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('new-val');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
@@ -347,18 +347,18 @@ describe('MapProxyTest', function () {
             });
 
             it('putTransient_with_ttl', async function () {
-                await map.putTransient('key10', 'val10', 2000);
+                await map.putTransient('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('putTransient_with_maxIdle', async function () {
-                await map.putTransient('key10', 'val10', undefined, 2000);
+                await map.putTransient('key10', 'val10', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
@@ -390,18 +390,18 @@ describe('MapProxyTest', function () {
             });
 
             it('set_with_ttl', async function () {
-                await map.set('key10', 'val10', 2000);
+                await map.set('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('set_with_maxIdle', async function () {
-                await map.set('key10', 'val10', undefined, 2000);
+                await map.set('key10', 'val10', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 


### PR DESCRIPTION
Increased the timeouts that we increased through https://github.com/hazelcast/hazelcast-nodejs-client/pull/725 and https://github.com/hazelcast/hazelcast-nodejs-client/pull/1104

The test did not fail in master for a long time we must ensure the same happens in maintenance branches too.  Increases ttls to 20 seconds because according to Yuce and Sancar in go and java 20 seconds is used.

fixes #724 
