### PR TITLE
Fix TranslateAddressProviderTest API-1111

### DIFF
--- a/test/unit/network/TranslateAddressProviderTest.js
+++ b/test/unit/network/TranslateAddressProviderTest.js
@@ -33,7 +33,8 @@ const { UuidUtil } = require('../../../lib/util/UuidUtil');
 describe('TranslateAddressProviderTest', function () {
     const PROPERTY_DISCOVERY_PUBLIC_IP_ENABLED = 'hazelcast.discovery.public.ip.enabled';
     const REACHABLE_HOST = '127.0.0.1';
-    const UNREACHABLE_HOST = '192.168.0.1';
+    // Test network ip, should be unreachable
+    const UNREACHABLE_HOST = '198.51.100.1';
 
     let loggerStub;
     let fakeMemberServer;

--- a/test/unit/network/TranslateAddressProviderTest.js
+++ b/test/unit/network/TranslateAddressProviderTest.js
@@ -33,7 +33,7 @@ const { UuidUtil } = require('../../../lib/util/UuidUtil');
 describe('TranslateAddressProviderTest', function () {
     const PROPERTY_DISCOVERY_PUBLIC_IP_ENABLED = 'hazelcast.discovery.public.ip.enabled';
     const REACHABLE_HOST = '127.0.0.1';
-    // Test network ip, should be unreachable
+    // 198.51.100.0/24 is assigned as TEST-NET-2 and should be unreachable: https://en.wikipedia.org/wiki/Reserved_IP_addresses
     const UNREACHABLE_HOST = '198.51.100.1';
 
     let loggerStub;


### PR DESCRIPTION
fixes #1165 


See the issue for explanation of the change. I used TEST-NETWORK-2 as mentioned [here](https://superuser.com/a/698392)