### PR TITLE
Decrease job count to 2

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -178,11 +178,11 @@ if (process.argv.length === 3 || process.argv.length === 4) {
         if (process.argv.length === 4) {
             testCommand = `node node_modules/mocha/bin/mocha -g "${process.argv[3]}" ` +
                           '"test/integration/**/serial/**/*.js" && ';
-            testCommand += `node node_modules/mocha/bin/mocha -j 8 --parallel -g  "${process.argv[3]}" ` +
+            testCommand += `node node_modules/mocha/bin/mocha -j 2 --parallel -g  "${process.argv[3]}" ` +
                 '"test/integration/**/parallel/**/*.js"';
         } else {
             testCommand = 'node node_modules/mocha/bin/mocha "test/integration/**/serial/**/*.js" && node'
-                        + ' node_modules/mocha/bin/mocha -j 8 --parallel "test/integration/**/parallel/**/*.js"';
+                        + ' node_modules/mocha/bin/mocha -j 2 --parallel "test/integration/**/parallel/**/*.js"';
         }
         testType = 'integration';
     } else if (process.argv[2] === 'all') {
@@ -190,12 +190,12 @@ if (process.argv.length === 3 || process.argv.length === 4) {
             testCommand = `node node_modules/mocha/bin/mocha -g "${process.argv[3]}" "test/unit/**/*.js" && `;
             testCommand += `node node_modules/mocha/bin/mocha -g "${process.argv[3]}" ` +
                 '"test/integration/**/serial/**/*.js" && ';
-            testCommand += `node node_modules/mocha/bin/mocha -j 8 --parallel -g  "${process.argv[3]}" ` +
+            testCommand += `node node_modules/mocha/bin/mocha -j 2 --parallel -g  "${process.argv[3]}" ` +
                 '"test/**/parallel/**/*.js"';
         } else {
             testCommand = 'node node_modules/mocha/bin/mocha "test/unit/**/*.js" && ';
             testCommand += 'node node_modules/mocha/bin/mocha "test/**/serial/**/*.js" && ';
-            testCommand += 'node node_modules/mocha/bin/mocha -j 8 --parallel "test/**/parallel/**/*.js"';
+            testCommand += 'node node_modules/mocha/bin/mocha -j 2 --parallel "test/**/parallel/**/*.js"';
         }
         testType = 'all';
     } else if (process.argv[2] === 'startrc') {


### PR DESCRIPTION
There are a lot of remote controller related fails in the past. These happen while creating a member or a cluster such as fail that happen in before all hooks, and `TApplicationError` errors.  I think these are related to parallel execution. I decreased the job count to decrease such errors. I measured the time necessary to spent running tests using with 2, 4 and 8 jobs: 


8: https://github.com/srknzl/hazelcast-nodejs-client/actions/runs/1962142954
4: https://github.com/srknzl/hazelcast-nodejs-client/actions/runs/1962128117
2: https://github.com/srknzl/hazelcast-nodejs-client/actions/runs/1962139938

As can be seen there is no big difference and we wait for windows run anyway. The windows run seems not to be affected by concurrency. 