### PR TITLE
Increase timeouts in MapProxyTest API-1200

### DIFF
--- a/test/integration/backward_compatible/serial/map/MapProxyTest.js
+++ b/test/integration/backward_compatible/serial/map/MapProxyTest.js
@@ -89,37 +89,37 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl puts value to map', async function () {
-                await map.put('key-with-ttl', 'val-with-ttl', 3000);
+                await map.put('key-with-ttl', 'val-with-ttl', 20000);
                 const val = await map.get('key-with-ttl');
                 expect(val).to.equal('val-with-ttl');
             });
 
             it('put with ttl removes value after ttl', async function () {
-                await map.put('key10', 'val10', 2000);
+                await map.put('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('put with maxIdle removes value after maxIdle', async function () {
                 TestUtil.markClientVersionAtLeast(this, '4.1');
-                await map.put('key10', 'val10', undefined, 2000);
+                await map.put('key10', 'val10', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('setTtl updates ttl for entry', async function () {
                 TestUtil.markClientVersionAtLeast(this, '4.1');
-                await map.put('key10', 'val10', 2000);
+                await map.put('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
 
                 await map.setTtl('key10', 60000);
 
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.equal('val10');
             });
 
@@ -312,19 +312,19 @@ describe('MapProxyTest', function () {
             });
 
             it('putIfAbsent_with_ttl', async function () {
-                await map.putIfAbsent('key10', 'new-val', 2000);
+                await map.putIfAbsent('key10', 'new-val', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('new-val');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('putIfAbsent_with_maxIdle', async function () {
                 TestUtil.markClientVersionAtLeast(this, '4.1');
-                await map.putIfAbsent('key10', 'new-val', undefined, 2000);
+                await map.putIfAbsent('key10', 'new-val', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('new-val');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
@@ -335,19 +335,19 @@ describe('MapProxyTest', function () {
             });
 
             it('putTransient_with_ttl', async function () {
-                await map.putTransient('key10', 'val10', 2000);
+                await map.putTransient('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('putTransient_with_maxIdle', async function () {
                 TestUtil.markClientVersionAtLeast(this, '4.1');
-                await map.putTransient('key10', 'val10', undefined, 2000);
+                await map.putTransient('key10', 'val10', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
@@ -379,19 +379,19 @@ describe('MapProxyTest', function () {
             });
 
             it('set_with_ttl', async function () {
-                await map.set('key10', 'val10', 2000);
+                await map.set('key10', 'val10', 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 
             it('set_with_maxIdle', async function () {
                 TestUtil.markClientVersionAtLeast(this, '4.1');
-                await map.set('key10', 'val10', undefined, 2000);
+                await map.set('key10', 'val10', undefined, 20000);
                 let val = await map.get('key10');
                 expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(2100, map.get.bind(map, 'key10'));
+                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 

--- a/test/integration/backward_compatible/serial/map/MapProxyTest.js
+++ b/test/integration/backward_compatible/serial/map/MapProxyTest.js
@@ -95,10 +95,8 @@ describe('MapProxyTest', function () {
             });
 
             it('put with ttl removes value after ttl', async function () {
-                await map.put('key10', 'val10', 20000);
-                let val = await map.get('key10');
-                expect(val).to.equal('val10');
-                val = await TestUtil.promiseLater(21000, map.get.bind(map, 'key10'));
+                await map.put('key10', 'val10', 2000);
+                const val = await TestUtil.promiseLater(3000, map.get.bind(map, 'key10'));
                 expect(val).to.be.null;
             });
 


### PR DESCRIPTION
According to Yuce, in go and java we use ttl like 20 seconds. This will make the test longer to run but less prone to flakiness. I used 20 seconds in all backports too.