### PR TITLE
Update SQL JSON code sample for rerunability

### DIFF
--- a/code_samples/sql_json.js
+++ b/code_samples/sql_json.js
@@ -35,6 +35,10 @@ const { Client, SqlColumnType } = require('hazelcast-client');
         `;
     await client.getSql().execute(createMappingQuery);
 
+    // Clear the map for a fresh start.
+    const map = await client.getMap(mapName);
+    await map.clear();
+
     // You need to use HazelcastJsonValue as parameter if you configured a global serializer
     await client.getSql().execute(`INSERT INTO ${mapName} VALUES (1, ?)`,
         [{age: 1}]


### PR DESCRIPTION
fixes qa process of https://hazelcast.atlassian.net/browse/API-1106


The insert query fails when the sample is run twice. As a fix, clear the map first.

Described here https://docs.hazelcast.com/hazelcast/latest/sql/sink-into#difference-between-insert-into-and-sink-into

We can also use the sink into statement but it will be more confusing for users.