### PR TITLE
Make retry count 100 API-1286

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -113,7 +113,7 @@ const startRC = async () => {
 
     console.log('Please wait for Hazelcast Remote Controller to start ...');
 
-    const retryCount = 10;
+    const retryCount = 100;
 
     for (let i = 0; i < retryCount; i++) {
         console.log('Trying to connect to Hazelcast Remote Controller (127.0.0.1:9701)...');


### PR DESCRIPTION
Trying 10 times is not enough, increase it to fix the test failures due to rc not starting in 10 seconds. There are quite a few of them in nightly runners recently.

fixes #1258