### PR TITLE
Increase test runner RC retry count API-1286 [4.2.x]

### DIFF
--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -97,7 +97,7 @@ const startRC = async () => {
 
     console.log('Please wait for Hazelcast Remote Controller to start ...');
 
-    const retryCount = 10;
+    const retryCount = 100;
 
     for (let i = 0; i < retryCount; i++) {
         console.log('Trying to connect to Hazelcast Remote Controller (127.0.0.1:9701)...');


### PR DESCRIPTION
Backport of #1258 

The retry logic is there in 5.0.x and 4.2.x too. 

See https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/2037731435 for fails