### PR TITLE
Refactor assertTrueEventually to make output better

### DIFF
--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -92,11 +92,11 @@ exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutM
 
             let errorString = '';
             for (const error in errorsToCount) {
-                errorString += `\tThe following error happened ${errorsToCount[error]} times:\n\n\t${error} \n\n`;
+                errorString += `\tThe following error occurred ${errorsToCount[error]} times:\n\n\t${error} \n\n`;
             }
 
-            reject(new Error('Rejected due to timeout of ' + timeoutMs
-                + 'ms. The following are the errors occurred and their counts: \n\n' + errorString));
+            reject(new Error(`Rejected due to timeout of ${timeoutMs}ms. `
+            + `The following are the errors that occurred and their counts: \n\n${errorString}`));
         }, timeoutMs);
     }));
 };

--- a/test/TestUtil.js
+++ b/test/TestUtil.js
@@ -64,7 +64,7 @@ exports.promiseWaitMilliseconds = function (milliseconds) {
     }));
 };
 
-exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutMs = 10000) {
+exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutMs = 60000) {
     const errorsToCount = {};
     return new Promise(((resolve, reject) => {
         let intervalTimer;
@@ -92,7 +92,7 @@ exports.assertTrueEventually = function (taskAsyncFn, intervalMs = 100, timeoutM
 
             let errorString = '';
             for (const error in errorsToCount) {
-                errorString += `\tThe error "${error}" happened ${errorsToCount[error]} times. \n\n`;
+                errorString += `\tThe following error happened ${errorsToCount[error]} times:\n\n\t${error} \n\n`;
             }
 
             reject(new Error('Rejected due to timeout of ' + timeoutMs


### PR DESCRIPTION
The output of assertTrueEventually can be very long and make test outputs hard to read, e.g https://github.com/hazelcast/hazelcast-nodejs-client/runs/5720674425?check_suite_focus=true

I refactored it so that we group the same errors now. 

Sample output: 
```
Error: Rejected due to timeout of 3000ms. The following are the errors occurred and their counts: 

        The following error happened 14 times:

        AssertionError: expected [ 'map2', 'map3' ] to have the same members as [ 'map5', 'map3' ]
    at /home/serkan/forked/hazelcast-nodejs-client/test/integration/backward_compatible/parallel/HazelcastClientTest.js:135:39
    at processTicksAndRejections (internal/process/task_queues.js:97:5) 

        The following error happened 14 times:

        Error: random error
    at /home/serkan/forked/hazelcast-nodejs-client/test/integration/backward_compatible/parallel/HazelcastClientTest.js:133:27
    at processTicksAndRejections (internal/process/task_queues.js:97:5) 


      at Timeout._onTimeout (test/TestUtil.js:98:20)
      at listOnTimeout (internal/timers.js:554:17)
      at processTimers (internal/timers.js:497:7)
```