### PR TITLE
[TRIVIAL] Use test network 2 ip as unreachable host...

### DIFF
--- a/test/integration/backward_incompatible/serial/ConnectionManagerTranslateTest.js
+++ b/test/integration/backward_incompatible/serial/ConnectionManagerTranslateTest.js
@@ -32,6 +32,7 @@ const TestUtil = require('../../../TestUtil');
 describe('ConnectionManagerTranslateTest', function () {
     const PROPERTY_DISCOVERY_PUBLIC_IP_ENABLED = 'hazelcast.discovery.public.ip.enabled';
     const REACHABLE_HOST = '127.0.0.1';
+    // 198.51.100.0/24 is assigned as TEST-NET-2 and should be unreachable: https://en.wikipedia.org/wiki/Reserved_IP_addresses
     const UNREACHABLE_HOST = '198.51.100.1';
     const testFactory = new TestUtil.TestFactory();
 

--- a/test/integration/backward_incompatible/serial/ConnectionManagerTranslateTest.js
+++ b/test/integration/backward_incompatible/serial/ConnectionManagerTranslateTest.js
@@ -32,7 +32,7 @@ const TestUtil = require('../../../TestUtil');
 describe('ConnectionManagerTranslateTest', function () {
     const PROPERTY_DISCOVERY_PUBLIC_IP_ENABLED = 'hazelcast.discovery.public.ip.enabled';
     const REACHABLE_HOST = '127.0.0.1';
-    const UNREACHABLE_HOST = '192.168.0.1';
+    const UNREACHABLE_HOST = '198.51.100.1';
     const testFactory = new TestUtil.TestFactory();
 
     let cluster;


### PR DESCRIPTION
...because on windows and github actions, 192.168.0.1 is sometimes reachable.

Fail link https://github.com/hazelcast/hazelcast-nodejs-client/runs/6619587538?check_suite_focus=true#step:7:3433

Just like https://github.com/hazelcast/hazelcast-nodejs-client/pull/1251, I did the same to the integration test as well.