### PR TITLE
Increase wait time for RC [4.0.x]

### DIFF
--- a/scripts/download-rc.bat
+++ b/scripts/download-rc.bat
@@ -94,4 +94,4 @@ if defined HAZELCAST_ENTERPRISE_KEY (
 start /min "hazelcast-remote-controller" cmd /c "java -Dhazelcast.enterprise.license.key=%HAZELCAST_ENTERPRISE_KEY% -cp %CLASSPATH% com.hazelcast.remotecontroller.Main --use-simple-server> rc_stdout.txt 2>rc_stderr.txt"
 
 echo wait for Hazelcast to start ...
-timeout /t 100
+ping -n 150 127.0.0.1 > nul

--- a/scripts/download-rc.bat
+++ b/scripts/download-rc.bat
@@ -94,4 +94,4 @@ if defined HAZELCAST_ENTERPRISE_KEY (
 start /min "hazelcast-remote-controller" cmd /c "java -Dhazelcast.enterprise.license.key=%HAZELCAST_ENTERPRISE_KEY% -cp %CLASSPATH% com.hazelcast.remotecontroller.Main --use-simple-server> rc_stdout.txt 2>rc_stderr.txt"
 
 echo wait for Hazelcast to start ...
-ping -n 15 127.0.0.1 > nul
+timeout /t 100

--- a/scripts/download-rc.sh
+++ b/scripts/download-rc.sh
@@ -95,5 +95,5 @@ fi
 
 nohup java -Dhazelcast.enterprise.license.key=${HAZELCAST_ENTERPRISE_KEY} -cp ${CLASSPATH}  com.hazelcast.remotecontroller.Main --use-simple-server>rc_stdout.log 2>rc_stderr.log &
 
-sleep 10
+sleep 100
 


### PR DESCRIPTION
In 4.0.x and 4.1.x RC fails to start in 10 seconds leading all tests to fail. We increased the wait time in newer branches to be **maximum** 100 seconds. In 4.0.x and 4.1.x, I will make the wait time always 100 seconds. I will not bother with testing the 9701 port is up and running because doing that is more complex and may require the script to be rewritten in Node.js.

On windows, timeout don't work due to this error. https://knowledge.broadcom.com/external/article/29524/the-timeout-command-in-batch-script-job.html. As mentioned in the linked document, I used ping again. 

 Also, waiting extra 100 seconds is not critical because we only run tests of these branches nightly. 

Example fail: https://github.com/hazelcast/hazelcast-nodejs-client/runs/6854367568?check_suite_focus=true#step:9:1957