### PR TITLE
Update nightly workflows

### DIFF
--- a/.github/workflows/nightly_runner_maintenance.yml
+++ b/.github/workflows/nightly_runner_maintenance.yml
@@ -11,7 +11,7 @@ jobs:
             matrix:
                 branch: [ 5.0.x, 4.2.x, 4.1.x, 4.0.x ]
                 os: [ ubuntu-latest, windows-latest ]
-                nodejs_version: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+                nodejs_version: [ 10, 18 ]
             fail-fast: false
         steps:
             - name: Setup Java

--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                nodejs_version: [ 10, 11, 12, 13, 14, 15, 16, 17 ]
+                nodejs_version: [ 10, 18 ]
             fail-fast: false
         steps:
             - name: Setup Java


### PR DESCRIPTION
Run nightlies in Node 10 and 18 which are the oldest supported and newest Node versions. Running on every versions makes tracking the bug harder since 64 of them are run in maintenance nightly. I hope running on two will be enough though.