### PR TITLE
Enable strict in user code tsconfig to catch type definition files errors in strict mode

### DIFF
--- a/test/user_code/tsconfig.json
+++ b/test/user_code/tsconfig.json
@@ -3,7 +3,8 @@
         "noEmit": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "stripInternal": true
+        "stripInternal": true,
+        "strict": true
     },
     "include": [
         "UserCodeTest.ts"


### PR DESCRIPTION
If we had this before, we could catch the issue: 

#1317 

Now we have the bug in every maintenance branch 🤦🏻‍♂️ and need patches for every branch. 

After this change, if any public API breaks compilation in strict mode, we will catch it. 