### PR TITLE
Nested compact field's serializer can be None if it is not registered [API-1415]

### DIFF
--- a/src/serialization/compact/CompactStreamSerializer.ts
+++ b/src/serialization/compact/CompactStreamSerializer.ts
@@ -22,10 +22,11 @@ import {DefaultCompactReader} from './DefaultCompactReader';
 import {SchemaService} from './SchemaService';
 import {DefaultCompactWriter} from './DefaultCompactWriter';
 import {FieldOperations} from '../generic_record/FieldOperations';
-import {SchemaNotFoundError, SchemaNotReplicatedError} from '../../core';
+import {HazelcastSerializationError, SchemaNotFoundError, SchemaNotReplicatedError} from '../../core';
 import {ObjectDataInput, ObjectDataOutput, PositionalObjectDataOutput} from '../ObjectData';
 import {CompactGenericRecordImpl} from '../generic_record/CompactGenericRecord';
 import {SchemaWriter} from './SchemaWriter';
+
 /**
  * Serializer for compact serializable objects.
  *
@@ -138,6 +139,9 @@ export class CompactStreamSerializer {
 
     writeObject(output: PositionalObjectDataOutput, obj: any) : void {
         const compactSerializer = this.classToSerializerMap.get(obj.constructor);
+        if (compactSerializer == undefined) {
+            throw new HazelcastSerializationError(`No serializer is registered for class ${obj.constructor.name}.`)
+        }
         const clazz = compactSerializer.getClass();
         let schema = this.classToSchemaMap.get(clazz);
         if (schema === undefined) {

--- a/src/serialization/compact/CompactStreamSerializer.ts
+++ b/src/serialization/compact/CompactStreamSerializer.ts
@@ -140,7 +140,7 @@ export class CompactStreamSerializer {
     writeObject(output: PositionalObjectDataOutput, obj: any) : void {
         const compactSerializer = this.classToSerializerMap.get(obj.constructor);
         if (compactSerializer == undefined) {
-            throw new HazelcastSerializationError(`No serializer is registered for class ${obj.constructor.name}.`)
+            throw new HazelcastSerializationError(`No serializer is registered for class/constructor ${obj.constructor.name}.`)
         }
         const clazz = compactSerializer.getClass();
         let schema = this.classToSchemaMap.get(clazz);

--- a/test/integration/backward_compatible/parallel/serialization/compact/CompactUtil.js
+++ b/test/integration/backward_compatible/parallel/serialization/compact/CompactUtil.js
@@ -15,7 +15,6 @@
  */
 'use strict';
 const TestUtil = require('../../../../../TestUtil');
-const {HazelcastSerializationError} = require('../../../../../../lib');
 
 let serialize;
 let createCompactGenericRecord;
@@ -1487,10 +1486,9 @@ if (TestUtil.isClientVersionAtLeast('5.1.0')) {
         } catch (e) {
             if (e instanceof SchemaNotReplicatedError) {
                 await schemaService.put(e.schema);
-            } else if (e instanceof HazelcastSerializationError) {
-                throw new HazelcastSerializationError(e.message, e.cause, e.serverStackTrace);
+                return serialize(serializationService, schemaService, obj);
             }
-            return await serialize(serializationService, schemaService, obj);
+            throw e;
         }
     };
 

--- a/test/integration/backward_compatible/parallel/serialization/compact/CompactUtil.js
+++ b/test/integration/backward_compatible/parallel/serialization/compact/CompactUtil.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 const TestUtil = require('../../../../../TestUtil');
+const {HazelcastSerializationError} = require('../../../../../../lib');
 
 let serialize;
 let createCompactGenericRecord;
@@ -1486,6 +1487,8 @@ if (TestUtil.isClientVersionAtLeast('5.1.0')) {
         } catch (e) {
             if (e instanceof SchemaNotReplicatedError) {
                 await schemaService.put(e.schema);
+            } else if (e instanceof HazelcastSerializationError) {
+                throw new HazelcastSerializationError(e.message, e.cause, e.serverStackTrace);
             }
             return await serialize(serializationService, schemaService, obj);
         }

--- a/test/unit/serialization/compact/CompactTest.js
+++ b/test/unit/serialization/compact/CompactTest.js
@@ -247,7 +247,7 @@ describe('CompactTest', function () {
         object.should.be.deep.equal(employer);
     });
 
-    it('should not serialize without nested fields serializer', async function() {
+    it('should throw proper error when nested field serializer is missing', async function() {
         const bundle = createSerializationService(
             [new MainDTOSerializer(), new InnerDTOSerializer()]
         );
@@ -258,6 +258,7 @@ describe('CompactTest', function () {
         await expect(serialize(
             serializationService,
             bundle.schemaService,
-            mainDTO)).to.be.rejectedWith(HazelcastSerializationError);
+            mainDTO)).to.be.eventually.rejectedWith(HazelcastSerializationError).and.have.property('message',
+            'No serializer is registered for class/constructor NamedDTO.');
     });
 });

--- a/test/unit/serialization/compact/CompactTest.js
+++ b/test/unit/serialization/compact/CompactTest.js
@@ -256,11 +256,6 @@ describe('CompactTest', function () {
         serializationService = bundle.serializationService;
 
         const mainDTO = createMainDTO();
-        TestUtil.getRejectionReasonOrThrow(serialize(
-            serializationService,
-            bundle.schemaService,
-            mainDTO
-        ));
         const error = await TestUtil.getRejectionReasonOrThrow(async () => {
             await serialize(serializationService, bundle.schemaService, mainDTO);
         });


### PR DESCRIPTION
Fixes #1323  

- Added check for `undefined` serializer before calling `getClass()` on it, throw a `HazelcastSerializationError` in this case.
- Added a new test for missing nested serializer case, it checks if a `HazelcastSerializationError` has been thrown.
- Change the `serialize()` method to prevent an infinite loop in case of a missing serializer.
