### PR TITLE
Make ReadResultSet iterable [API-1315]

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1917,6 +1917,13 @@ let value = await rb.readOne(sequence);
 console.log('Value:', value);
 value = await rb.readOne(sequence.add(1));
 console.log('Next value:', value);
+// Add some elements to the Ringbuffer
+await rb.addAll([300, 400, 500]);
+// We want to get 5 items from Ringbuffer and write to console.
+const items = await rb.readMany(0, 1, 5);
+for(const item of items){
+    console.log("Item:" item);
+}
 ```
 
 ### 8.4.8. Using Reliable Topic

--- a/src/core/ReadResultSet.ts
+++ b/src/core/ReadResultSet.ts
@@ -62,6 +62,20 @@ export interface ReadResultSet<T> {
     size(): number;
 
     /**
+     * Returns an iterator for elements in the list.
+     * 
+     * @returns the iterator for elements in the list.
+     */
+     values(): Iterator<T>;
+
+     /**
+     * Returns an iterator for elements in the list.
+     * 
+     * @returns the iterator for elements in the list.
+     */
+    [Symbol.iterator](): Iterator<T>; 
+
+    /**
      * Returns the sequence of the item following the last read item. This
      * sequence can then be used to read items following the ones returned by
      * this result set.

--- a/src/core/ReadResultSet.ts
+++ b/src/core/ReadResultSet.ts
@@ -61,13 +61,6 @@ export interface ReadResultSet<T> {
      */
     size(): number;
 
-    /**
-     * Returns an iterator for elements in the list.
-     * 
-     * @returns the iterator for elements in the list.
-     */
-     values(): Iterator<T>;
-
      /**
      * Returns an iterator for elements in the list.
      * 

--- a/src/proxy/topic/ReliableTopicListenerRunner.ts
+++ b/src/proxy/topic/ReliableTopicListenerRunner.ts
@@ -90,7 +90,7 @@ export class ReliableTopicListenerRunner<E> {
             })
             .catch((err) => {
                 if (this.handleInternalError(err)) {
-                    this.next();
+                    setImmediate(this.next.bind(this));
                 } else {
                     this.proxy.removeMessageListener(this.listenerId);
                 }

--- a/test/unit/ringbuffer/LazyReadResultSetTest.js
+++ b/test/unit/ringbuffer/LazyReadResultSetTest.js
@@ -43,7 +43,7 @@ describe('LazyReadResultSetTest', function () {
         expect(set.get(4)).to.be.undefined;
     });
 
-    it('object can be iteratable', function () {
+    it('should be iterable', function () {
         const set = new LazyReadResultSet(mockSerializationService, 4, [1, 2, 3, 4], [11, 12, 13, 14], 15);
         let index = 0;
         const values = [101, 102, 3, 4];

--- a/test/unit/ringbuffer/LazyReadResultSetTest.js
+++ b/test/unit/ringbuffer/LazyReadResultSetTest.js
@@ -42,4 +42,14 @@ describe('LazyReadResultSetTest', function () {
         const set = new LazyReadResultSet(mockSerializationService, 4, [1, 2, 3, 4], [11, 12, 13, 14], 15);
         expect(set.get(4)).to.be.undefined;
     });
+
+    it('object can be iteratable', function () {
+        const set = new LazyReadResultSet(mockSerializationService, 4, [1, 2, 3, 4], [11, 12, 13, 14], 15);
+        let index = 0;
+        const values = [101, 102, 3, 4];
+        for (const item of set) {
+            expect(item).to.equal(values[index]);
+            index++;
+        }
+    });
 });


### PR DESCRIPTION
Following changes done:
1. ReadResultSet interface was changed.
2. Implemented LazyReadResultSet as iterable
3. Added new test for testing LazyReadResultSet is iterable.
4. Changed documentation of Ringbuffer by adding readMany sample.