### PR TITLE
Revert "Change logic around closing connections and writers API-1283 (#1417)"

### DIFF
--- a/test/unit/connection/DirectWriterTest.js
+++ b/test/unit/connection/DirectWriterTest.js
@@ -26,10 +26,9 @@ const {
     Frame
 } = require('../../../lib/protocol/ClientMessage');
 const { deferredPromise } = require('../../../lib/util/Util');
-const sandbox = sinon.createSandbox();
 
 describe('DirectWriterTest', function () {
-    let writer;
+    let queue;
     let mockSocket;
     let writtenBytes;
 
@@ -41,28 +40,24 @@ describe('DirectWriterTest', function () {
 
     const setUpWriteSuccess = () => {
         mockSocket = new Socket({});
-        sandbox.stub(mockSocket, 'write').callsFake((data, cb) => {
+        sinon.stub(mockSocket, 'write').callsFake((data, cb) => {
             cb();
             mockSocket.emit('data', data);
         });
-        writer = new DirectWriter(mockSocket, numberOfBytes => {
+        queue = new DirectWriter(mockSocket, numberOfBytes => {
             writtenBytes += numberOfBytes;
         });
     };
 
     const setUpWriteFailure = (err) => {
         mockSocket = new Socket({});
-        sandbox.stub(mockSocket, 'write').callsFake((_, cb) => {
+        sinon.stub(mockSocket, 'write').callsFake((_, cb) => {
             cb(err);
         });
-        writer = new DirectWriter(mockSocket, numberOfBytes => {
+        queue = new DirectWriter(mockSocket, numberOfBytes => {
             writtenBytes += numberOfBytes;
         });
     };
-
-    afterEach(function() {
-        sandbox.restore();
-    });
 
     it('increment written bytes correctly', function(done) {
         setUpWriteSuccess();
@@ -75,7 +70,7 @@ describe('DirectWriterTest', function () {
             done();
         });
 
-        writer.write(msg, deferredPromise());
+        queue.write(msg, deferredPromise());
     });
 
     it('writes single message into socket', function(done) {
@@ -87,7 +82,7 @@ describe('DirectWriterTest', function () {
             done();
         });
 
-        writer.write(msg, deferredPromise());
+        queue.write(msg, deferredPromise());
     });
 
     it('writes multiple messages separately into socket', function(done) {
@@ -102,16 +97,16 @@ describe('DirectWriterTest', function () {
             }
         });
 
-        writer.write(msg, deferredPromise());
-        writer.write(msg, deferredPromise());
-        writer.write(msg, deferredPromise());
+        queue.write(msg, deferredPromise());
+        queue.write(msg, deferredPromise());
+        queue.write(msg, deferredPromise());
     });
 
     it('resolves promise on write success', function(done) {
         setUpWriteSuccess();
 
         const resolver = deferredPromise();
-        writer.write(createMessage('test'), resolver);
+        queue.write(createMessage('test'), resolver);
         resolver.promise.then(done);
     });
 
@@ -120,7 +115,7 @@ describe('DirectWriterTest', function () {
         setUpWriteFailure(err);
 
         const resolver = deferredPromise();
-        writer.write(createMessage('test'), resolver);
+        queue.write(createMessage('test'), resolver);
         resolver.promise.catch((err) => {
             expect(err).to.be.equal(err);
             done();
@@ -130,29 +125,18 @@ describe('DirectWriterTest', function () {
     it('emits write event on write success', function(done) {
         setUpWriteSuccess();
 
-        writer.on('write', done);
-        writer.write(createMessage('test'), deferredPromise());
+        queue.on('write', done);
+        queue.write(createMessage('test'), deferredPromise());
     });
 
     it('does not emit write event on write failure', function(done) {
         setUpWriteFailure(new Error());
 
-        writer.on('write', () => done(new Error()));
+        queue.on('write', () => done(new Error()));
         const resolver = deferredPromise();
-        writer.write(createMessage('test'), resolver);
+        queue.write(createMessage('test'), resolver);
         resolver.promise.catch(() => {
             done();
         });
-    });
-
-    it('should close the socket upon being closed', function() {
-        setUpWriteSuccess();
-
-        // This is equivalent to a sinon spy
-        const spy = sandbox.fake(mockSocket.destroy);
-        sandbox.replace(mockSocket, 'destroy', spy);
-        writer.close();
-
-        expect(spy.calledOnce).to.be.true;
     });
 });


### PR DESCRIPTION
The change should have been merged after 5.2.0 release. Reverting until then. 


This reverts commit 2d0b3975997c491143ab1b02364b789afe6f520d.