### PR TITLE
Fix ssl tests - downloading cert from repo

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           organization-name: 'hazelcast'
           member-name: ${{ github.event.pull_request.head.repo.owner.login }}
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GH_PAT }}
 
   run-tests:
       name: Run Tests on (${{ matrix.os }})


### PR DESCRIPTION
Fix ssl tests - downloading cert from repo

Checkout "private-test-artifacts" repo and use certs.jar for SSL tests.

Related PR #1436