### PR TITLE
Fix ssl tests - downloading cert from repo

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           organization-name: 'hazelcast'
           member-name: ${{ github.event.pull_request.head.repo.owner.login }}
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GH_PAT }}
 
   run-tests:
       name: Run Tests on (${{ matrix.os }})
@@ -45,7 +45,16 @@ jobs:
             uses: actions/setup-java@v1
             with:
                 java-version: 8
-          
+          - name: Checkout to test artifacts
+            uses: actions/checkout@v2
+            with:
+              repository: hazelcast/private-test-artifacts
+              path: certs
+              ref: data
+              token: ${{ secrets.GH_PAT }}
+          - name: Copy certificates JAR to destination with the appropriate name
+            run: |
+              cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/certs.jar
           - name: Setup Node.js
             uses: actions/setup-node@v2
             with:


### PR DESCRIPTION
Fix ssl tests - downloading cert from repo

Checkout "private-test-artifacts" repo and use certs.jar for SSL tests.

Related PR #1436