### PR TITLE
Fix ssl tests - downloading cert from repo

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           organization-name: 'hazelcast'
           member-name: ${{ github.event.pull_request.head.repo.owner.login }}
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.PAT }}
 
   run-tests:
       name: Run Tests on (${{ matrix.os }})
@@ -51,7 +51,7 @@ jobs:
               repository: hazelcast/private-test-artifacts
               path: certs
               ref: data
-              token: ${{ secrets.GH_PAT }}
+              token: ${{ secrets.GH_TOKEN }}
           - name: Copy certificates JAR to destination with the appropriate name
             run: |
               cp $GITHUB_WORKSPACE/certs/certs.jar $GITHUB_WORKSPACE/certs.jar


### PR DESCRIPTION
Fix ssl tests - downloading cert from repo

Checkout "private-test-artifacts" repo and use certs.jar for SSL tests.

Related PR https://github.com/hazelcast/hazelcast-nodejs-client/pull/1436