### PR TITLE
Use the correct type name for the serializer in CompactSerializersLiveTest

### DIFF
--- a/test/integration/backward_compatible/parallel/serialization/compact/CompactSerializersLiveTest.js
+++ b/test/integration/backward_compatible/parallel/serialization/compact/CompactSerializersLiveTest.js
@@ -60,7 +60,7 @@ const COMPACT_ENABLED_WITH_SERIALIZER_XML_BETA = `
                 <serialization>
                     <compact-serialization enabled="true">
                             <registered-classes>
-                                <class type-name="example.serialization.EmployeeDTO"
+                                <class type-name="employee"
                                             serializer="example.serialization.EmployeeDTOSerializer">
                                     example.serialization.EmployeeDTO
                                 </class>


### PR DESCRIPTION
We were mistakenly using a different type name than the one defined in the client, which was causing a failure in the backward compatibility tests against 5.1.6 release on 5.1.x clients.