### PR TITLE
Update documentation support links

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4477,8 +4477,6 @@ You can use the following channels for your questions and development/usage issu
 
 * This repository by opening an issue.
 * [Slack](https://slack.hazelcast.com)
-* [Google Groups](https://groups.google.com/forum/#!forum/hazelcast)
-* [Stack Overflow](https://stackoverflow.com/questions/tagged/hazelcast)
 
 # 12. Contributing
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,6 @@ You can use the following channels for your questions and development/usage issu
 * [Complete documentation](https://github.com/hazelcast/hazelcast-nodejs-client/blob/master/DOCUMENTATION.md)
 * [API documentation](http://hazelcast.github.io/hazelcast-nodejs-client)
 * [Slack](https://slack.hazelcast.com)
-* [Google Groups](https://groups.google.com/forum/#!forum/hazelcast)
-* [Stack Overflow](https://stackoverflow.com/questions/tagged/hazelcast)
 
 ## Contributing
 


### PR DESCRIPTION
Update support channels in documentation:
- Google Group link removed
   - > The Hazelcast Google User Group is read-only. Please post your questions on the Hazelcast Community Slack)