### PR TITLE
Upgrade `upload-artifact` from a non-deprecated version

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -106,7 +106,7 @@ jobs:
               override_pr: ${{ github.event.inputs.pr_number }}
 
           - name: Upload remote controller logs if test run fails
-            uses: actions/upload-artifact@v2
+            uses: actions/upload-artifact@v4
             if: failure()
             with:
               name: rc-logs-${{ matrix.os }}


### PR DESCRIPTION
GitHub are now [preventing builds with outdated versions of `upload-artifact` from running](https://github.com/hazelcast/hazelcast-docker/actions/runs/13172853058):
> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

As such upgraded to the latest version.