### PR TITLE
HZC-7235: change-cloud-url

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -181,7 +181,7 @@ const DEFAULT_PROPERTIES: Properties = {
     'hazelcast.client.schema.max.put.retry.count': 100,
     'hazelcast.client.invocation.timeout.millis': 120000,
     'hazelcast.client.internal.clean.resources.millis': 100,
-    'hazelcast.client.cloud.url': 'https://api.viridian.hazelcast.com',
+    'hazelcast.client.cloud.url': 'https://api.cloud.hazelcast.com',
     /**
      * `hazelcast.client.statistics.enabled` and `hazelcast.client.period.seconds` are
      * @deprecated since 5.1

--- a/src/discovery/HazelcastCloudDiscovery.ts
+++ b/src/discovery/HazelcastCloudDiscovery.ts
@@ -26,7 +26,7 @@ import {HazelcastError} from '../core';
 
 /**
  * Discovery service that discovers nodes via hazelcast.cloud
- * https://api.viridian.hazelcast.com/cluster/discovery?token=<TOKEN>
+ * https://api.cloud.hazelcast.com/cluster/discovery?token=<TOKEN>
  * @internal
  */
 export class HazelcastCloudDiscovery {

--- a/test/unit/discovery/HazelcastCloudConfigTest.js
+++ b/test/unit/discovery/HazelcastCloudConfigTest.js
@@ -27,7 +27,7 @@ describe('HazelcastClientCloudConfigTest', function () {
 
         const urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(config.properties, token);
 
-        expect(urlEndpoint).to.be.equal('https://api.viridian.hazelcast.com/cluster/discovery?token=TOKEN');
+        expect(urlEndpoint).to.be.equal('https://api.cloud.hazelcast.com/cluster/discovery?token=TOKEN');
     });
 
     it('customCloudUrlEndpoint', function () {


### PR DESCRIPTION
chore: update cloud url to api.cloud.hazelcast.com to part of deprecation of using viridian