### PR TITLE
Fix GitHub Actions on Windows

### DIFF
--- a/.github/workflows/code_sample_checker.yml
+++ b/.github/workflows/code_sample_checker.yml
@@ -14,6 +14,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Read Java Config
+              shell: bash
               run: cat .github/java-config.env >> $GITHUB_ENV
             - name: Setup Java
               uses: actions/setup-java@v4

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -55,6 +55,7 @@ jobs:
               ref: refs/pull/${{ github.event.inputs.pr_number }}/merge
 
           - name: Read Java Config
+            shell: bash
             run: cat .github/java-config.env >> $GITHUB_ENV
           - name: Setup Java
             uses: actions/setup-java@v4

--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -16,6 +16,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Read Java Config
+              shell: bash
               run: cat .github/java-config.env >> $GITHUB_ENV
             - name: Setup Java
               uses: actions/setup-java@v4

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -43,7 +43,7 @@ const downloadRC = () => {
             + HAZELCAST_RC_VERSION);
         const subprocess = spawnSync('mvn',
             [
-                '-q',
+                '-X',
                 'org.apache.maven.plugins:maven-dependency-plugin:2.10:get',
                 '-Dtransitive=false',
                 `-DremoteRepositories=${SNAPSHOT_REPO}`,

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -43,7 +43,7 @@ const downloadRC = () => {
             + HAZELCAST_RC_VERSION);
         const subprocess = spawnSync('mvn',
             [
-                '-X',
+                '-q',
                 'org.apache.maven.plugins:maven-dependency-plugin:2.10:get',
                 '-Dtransitive=false',
                 `-DremoteRepositories=${SNAPSHOT_REPO}`,


### PR DESCRIPTION
The [actions fail](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/14506740078/job/40704373693) because the `java-config.env` isn't parsed correctly.

Specifically, we are using the _default_ shell (on Windows, `pwsh`), which doesn't work with `cat` - we should be specifying `bash` explicitly (even on Windows) as per the C++ repo:
https://github.com/hazelcast/hazelcast-cpp-client/blob/0659bebcca6f8d001ef9abb11077f7431fb39bbd/.github/actions/build-test/windows/action.yml#L53-L55

[Example Windows execution showing that it succeeded in setting the Java version with this change](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/14509405447/job/40704693730) (other test failures out of scope).