### PR TITLE
Make tests use a dynamic / non-hardcoded (outdated) version(s) of Node

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -8,15 +8,19 @@ on:
     pull_request:
 
 jobs:
+    node-versions:
+      uses: ./.github/workflows/get-supported-node-versions.yml
+
     check-code-quality:
         name: Check code quality
         runs-on: ubuntu-latest
+        needs: node-versions
 
         steps:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 12
+                  node-version: ${{ needs.node-versions.outputs.default-version }}
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Install dependencies

--- a/.github/workflows/code_sample_checker.yml
+++ b/.github/workflows/code_sample_checker.yml
@@ -2,9 +2,13 @@ name: Code sample checker
 on: pull_request
 
 jobs:
+    node-versions:
+      uses: ./.github/workflows/get-supported-node-versions.yml
+
     test-code-samples:
         name: Check code samples
         runs-on: ${{matrix.os}}
+        needs: node-versions
 
         strategy:
             matrix:
@@ -23,7 +27,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 10
+                  node-version: ${{ needs.node-versions.outputs.default-version }}
             - name: Install dependencies and compile client
               run: |
                   npm install

--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -28,9 +28,14 @@ jobs:
           member-name: ${{ github.actor }}
           token: ${{ secrets.PAT }}
 
+  node-versions:
+    uses: ./.github/workflows/get-supported-node-versions.yml
+
   run-tests:
       name: Run Tests on (${{ matrix.os }})
-      needs: [check_for_membership]
+      needs:
+        - check_for_membership
+        - node-versions
       if: github.event_name == 'push' || needs.check_for_membership.outputs.check-result == 'true' || github.event_name == 'workflow_dispatch'
       runs-on: ${{ matrix.os }}
       strategy:
@@ -64,7 +69,7 @@ jobs:
           - name: Setup Node.js
             uses: actions/setup-node@v4
             with:
-                node-version: 10
+                node-version: ${{ needs.node-versions.outputs.default-version }}
 
           - name: Checkout to test artifacts
             uses: actions/checkout@v4

--- a/.github/workflows/get-supported-node-versions.yml
+++ b/.github/workflows/get-supported-node-versions.yml
@@ -18,11 +18,16 @@ jobs:
       - name: Get supported Node.js versions
         id: get_versions
         run: |
+          # Look for versions that are:
+          # - Currently supported
+          # - That are LTS
+          # - Within LTS date range (i.e. not future LTS)
           NODE_VERSIONS=$(curl --silent https://raw.githubusercontent.com/nodejs/Release/main/schedule.json | jq --compact-output '
               def today: now | strftime("%Y-%m-%d");
               to_entries
-              | map(select(.value.end > today))
+              | map(select(.value.end > today and .value.lts != null and .value.lts < today))
               | [.[0].key, .[-1].key]
+              | unique
           ')
 
           echo "node-versions=${NODE_VERSIONS}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/get-supported-node-versions.yml
+++ b/.github/workflows/get-supported-node-versions.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get supported Node.js versions
         id: get_versions
         run: |
-          NODE_VERSIONS = $(curl --silent https://raw.githubusercontent.com/nodejs/Release/main/schedule.json | jq --compact-output '
+          NODE_VERSIONS=$(curl --silent https://raw.githubusercontent.com/nodejs/Release/main/schedule.json | jq --compact-output '
               def today: now | strftime("%Y-%m-%d");
               to_entries
               | map(select(.value.end > today))

--- a/.github/workflows/get-supported-node-versions.yml
+++ b/.github/workflows/get-supported-node-versions.yml
@@ -1,0 +1,30 @@
+name: Get supported Node.js versions
+
+on:
+  workflow_call:
+    outputs:
+      node-versions:
+        value: ${{ jobs.get-supported-node-versions.outputs.node-versions }}
+      default-version:
+        value: ${{ jobs.get-supported-node-versions.outputs.default-version }}
+
+jobs:
+  get-supported-node-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      node-versions: ${{ steps.get_versions.outputs.node-versions }}
+      default-version: ${{ steps.get_versions.outputs.default-version }}
+    steps:
+      - name: Get supported Node.js versions
+        id: get_versions
+        run: |
+          NODE_VERSIONS = $(curl --silent https://raw.githubusercontent.com/nodejs/Release/main/schedule.json | jq --compact-output '
+              def today: now | strftime("%Y-%m-%d");
+              to_entries
+              | map(select(.value.end > today))
+              | [.[0].key, .[-1].key]
+          ')
+
+          echo "node-versions=${NODE_VERSIONS}" >> ${GITHUB_OUTPUT}
+          # Default to using the newest version
+          echo "default-version=$(jq -r '.[1]' <<< ${NODE_VERSIONS})" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/nightly_runner_maintenance.yml
+++ b/.github/workflows/nightly_runner_maintenance.yml
@@ -4,14 +4,18 @@ on:
     schedule:
         - cron: '0 2 */2 * *'
 jobs:
+    node-versions:
+      uses: ./.github/workflows/get-supported-node-versions.yml
+
     run-tests:
         runs-on: ${{ matrix.os }}
+        needs: node-versions
         name: Run tests of branch ${{ matrix.branch }} on ${{ matrix.os }} with Node ${{ matrix.nodejs_version }}
         strategy:
             matrix:
                 branch: [ 5.0.x, 4.2.x, 4.1.x, 4.0.x ]
                 os: [ ubuntu-latest, windows-latest ]
-                nodejs_version: [ 10, 18 ]
+                nodejs_version: ${{ fromJSON(needs.node-versions.outputs.node-versions) }}
             fail-fast: false
         steps:
             - name: Setup Java

--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -4,13 +4,17 @@ on:
     schedule:
         - cron: '0 2 * * *'
 jobs:
+    node-versions:
+      uses: ./.github/workflows/get-supported-node-versions.yml
+
     run-tests:
         runs-on: ${{ matrix.os }}
+        needs: node-versions
         name: Run tests of master on ${{ matrix.os }} with Node ${{ matrix.nodejs_version }}
         strategy:
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                nodejs_version: [ 10, 18 ]
+                nodejs_version: ${{ fromJSON(needs.node-versions.outputs.node-versions) }}
             fail-fast: false
         steps:
             - name: Checkout code


### PR DESCRIPTION
[The build fails on Node 10](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/14506740078/job/40704372723):
```
/home/runner/work/hazelcast-nodejs-client/hazelcast-nodejs-client/node_modules/nise/node_modules/@sinonjs/fake-timers/src/fake-timers-src.js:2059
                                    if (options.signal?.aborted && !hasThrown) {
```

In https://github.com/hazelcast/hazelcast-nodejs-client/pull/1321 the tests were updated to:
> Run nightlies in Node 10 and 18 which are the oldest supported and newest Node versions

_(except for `code_quality.yml`, which was left on 12)_

However, the version of `sinonjs/fake-timers` we use (dependency of `nise` which is a dependency of `sinon`) uses optional chaining syntax, requiring Node >=14.

Instead of hardcoding Node version(s), we can take the original logic (newest/oldest supported versions) and compute that dynamically instead [based on the NodeJS release metadata](https://raw.githubusercontent.com/nodejs/Release/main/schedule.json).

The net result of this change is that (today), tests that run on a range of versions will run on `18` & `22`, with tests on a specific version using `22`.

[Example execution showing it now successfully compiles with the dynamic versions](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/14512391261) (other test failures out of scope). 