### PR TITLE
Fix `ClientSSLTest` Certificate

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -73,6 +73,7 @@ jobs:
           - name: Copy certificates JAR to destination with the appropriate name
             run: |
               cp ${{ github.workspace }}/certs/certs.jar ${{ github.workspace }}/certs.jar
+              unzip -p ${{ github.workspace }}/certs.jar com/hazelcast/nio/ssl/letsencrypt.jks > test/integration/backward_compatible/parallel/ssl/keystore.jks
 
           - name: Install dependencies and compile client
             run: |

--- a/.github/workflows/nightly_runner_master.yml
+++ b/.github/workflows/nightly_runner_master.yml
@@ -34,6 +34,7 @@ jobs:
             - name: Copy certificates JAR to destination with the appropriate name
               run: |
                 cp ${{ github.workspace }}/certs/certs.jar ${{ github.workspace }}/certs.jar
+                unzip -p ${{ github.workspace }}/certs.jar com/hazelcast/nio/ssl/letsencrypt.jks > test/integration/backward_compatible/parallel/ssl/keystore.jks
             - name: Install dependencies and compile client
               run: |
                   npm install


### PR DESCRIPTION
The [nightly tests are failing](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/14506740078/job/40704373059):
```
[DefaultLogger] WARN at ConnectionManager: Error during initial connection to 127.0.0.1:43973 Error: certificate has expired
```

The certificates were _manually_ updated in https://github.com/hazelcast/hazelcast-nodejs-client/pull/1525, but the upstream source is updated automatically and so they have become outdated.

We already download the upstream source as part of the action anyway, so updated to overwrite the existing `keystore.jks` with the latest version.

[Example execution showing success of `ClientSSLTest`](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/14512620752/job/40714565969) (other test failures out of scope). 