### PR TITLE
Fix `codecov-action` [DI-520]

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -97,23 +97,29 @@ jobs:
 
           - name: Publish results to Codecov for PR coming from hazelcast organization
             if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request_target' }}
-            uses: codecov/codecov-action@v3
+            uses: codecov/codecov-action@v5
             with:
+              token: ${{ secrets.CODECOV_TOKEN }}
               files: coverage/lcov.info
               override_pr: ${{ github.event.pull_request.number }}
+              fail_ci_if_error: true
 
           - name: Publish results to Codecov for Push
             if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'push' }}
-            uses: codecov/codecov-action@v3
+            uses: codecov/codecov-action@v5
             with:
+              token: ${{ secrets.CODECOV_TOKEN }}
               files: coverage/lcov.info
+              fail_ci_if_error: true
 
           - name: Publish result to Codecov for PR coming from community
             if: ${{ matrix.os == 'ubuntu-latest' && github.event_name == 'workflow_dispatch' }}
-            uses: codecov/codecov-action@v3
+            uses: codecov/codecov-action@v5
             with:
+              token: ${{ secrets.CODECOV_TOKEN }}
               files: coverage/lcov.info
               override_pr: ${{ github.event.inputs.pr_number }}
+              fail_ci_if_error: true
 
           - name: Upload remote controller logs if test run fails
             uses: actions/upload-artifact@v4


### PR DESCRIPTION
The C++ coverage action has been [silently failing](https://github.com/hazelcast/hazelcast-cpp-client/actions/runs/15610247637/attempts/1).

Updated all usages to:
- supply a token to properly authenticate (the reason for the failure)
- fail the step if the upload fails (to avoid the error going unreported)
- use the latest version (consistency)

Fixes: [DI-520](https://hazelcast.atlassian.net/browse/DI-520)

[DI-520]: https://hazelcast.atlassian.net/browse/DI-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ