### PR TITLE
Fix broken `DOCUMENTATION.md` references

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -699,19 +699,19 @@ When Hazelcast Node.js client serializes an object:
 
 4. If the above check fails, then it checks if it is an instance of one of the default types (see above default types).
 
-5. If the above check fails, then it looks for a user-specified [Custom Serialization](#43-custom-serialization).
+5. If the above check fails, then it looks for a user-specified [Custom Serialization](#44-custom-serialization).
 
-6. If the above check fails, it will use the registered [Global Serialization](#44-global-serialization) if one exists.
+6. If the above check fails, it will use the registered [Global Serialization](#45-global-serialization) if one exists.
 
 7. If the above check fails, then the Node.js client uses `JSON Serialization` by default.
 
 However, `JSON Serialization` may not be the best way of serialization in terms of performance and interoperability between
 the clients in different languages. If you want the serialization to work faster or you use the clients in different languages,
 Hazelcast offers its own native serialization methods, such as
-[`IdentifiedDataSerializable` Serialization](#41-identifieddataserializable-serialization) and
-[`Portable` Serialization](#42-portable-serialization).
+[`IdentifiedDataSerializable` Serialization](#42-identifieddataserializable-serialization) and
+[`Portable` Serialization](#43-portable-serialization).
 
-Or, if you want to use your own serialization method, you can use [Custom Serialization](#43-custom-serialization).
+Or, if you want to use your own serialization method, you can use [Custom Serialization](#44-custom-serialization).
 
 > **NOTE: Hazelcast Node.js client is a TypeScript-based project but JavaScript does not have interfaces. Therefore, some
 > interfaces are given to the user by using the TypeScript files that have `.ts` extension. In this guide, implementing an
@@ -3567,7 +3567,7 @@ results of your query are ready, they are parsed from JSON strings and returned 
 
 For the purposes of your application, you may want to get rid of the parsing and just work with the raw JSON strings using
 `HazelcastJsonValue` objects. Then, you can configure your client to do so as described in the
-[JSON Serialization](#45-json-serialization) section.
+[JSON Serialization](#46-json-serialization) section.
 
 ```javascript
 const client = await Client.newHazelcastClient({


### PR DESCRIPTION
Fixes problems [blocking unrelated PRs](https://github.com/hazelcast/hazelcast-nodejs-client/pull/1548#issuecomment-3305627227).

Note _one_ check still fails due to https://github.com/ruzickap/action-my-markdown-link-checker/issues/107