### PR TITLE
Improve PR builder

### DIFF
--- a/.github/workflows/code_sample_checker.yml
+++ b/.github/workflows/code_sample_checker.yml
@@ -36,3 +36,12 @@ jobs:
             - name: Check code samples
               run: |
                   npm run check-code-samples
+
+            - name: Upload remote controller logs if test run fails
+              uses: actions/upload-artifact@v4
+              if: failure()
+              with:
+                  name: rc-logs-${{ matrix.os }}
+                  path: |
+                      rc_stderr.log
+                      rc_stdout.log

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -44,7 +44,7 @@ const downloadRC = () => {
     }
 
     function downloadArtifact(repo, artifactId, version, classifier = '') {
-        const filename = classifier ? `${artifactId}-${version}-${classifier}.jar` : `hazelcast-${version}.jar`;
+        const filename = classifier ? `${artifactId}-${version}-${classifier}.jar` : `${artifactId}-${version}.jar`;
         let artifact = `com.hazelcast:${artifactId}:${version}:jar`;
         if (classifier) {
             artifact += `:${classifier}`;

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -44,7 +44,7 @@ const downloadRC = () => {
     }
 
     function downloadArtifact(repo, artifactId, version, classifier = '') {
-        const filename = classifier ? `hazelcast-${version}-${classifier}.jar` : `hazelcast-${version}.jar`;
+        const filename = classifier ? `${artifactId}-${version}-${classifier}.jar` : `hazelcast-${version}.jar`;
         let artifact = `com.hazelcast:${artifactId}:${version}:jar`;
         if (classifier) {
             artifact += `:${classifier}`;

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -33,7 +33,7 @@ const downloadRC = () => {
         TEST_REPO = RELEASE_REPO;
     }
 
-    downloadArtifact(SNAPSHOT_REPO, 'hazelcast-remote-controller', HAZELCAST_RC_VERSION);
+    downloadArtifact(ENTERPRISE_SNAPSHOT_REPO, 'hazelcast-remote-controller', HAZELCAST_RC_VERSION);
     downloadArtifact(TEST_REPO, 'hazelcast', HAZELCAST_TEST_VERSION, HAZELCAST_TEST_VERSION, 'tests');
     downloadArtifact(REPO, 'hazelcast-sql', HAZELCAST_VERSION);
 

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -60,7 +60,7 @@ const downloadRC = () => {
                 '-Dtransitive=false',
                 `-DremoteRepositories=${repo}`,
                 `-Dartifact=${artifact}`,
-                `-Ddest=hazelcast-${filename}`
+                `-Ddest=${filename}`
             ], {
                 stdio: 'inherit',
                 shell: os.platform() === 'win32'

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -45,7 +45,7 @@ const downloadRC = () => {
 
     function downloadArtifact(repo, artifactId, version, classifier = '') {
         const filename = classifier ? `hazelcast-${version}-${classifier}.jar` : `hazelcast-${version}.jar`;
-        let artifact = `com.hazelcast:${artifactId}:${version}`;
+        let artifact = `com.hazelcast:${artifactId}:${version}:jar`;
         if (classifier) {
             artifact += `:${classifier}`;
         }

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -34,7 +34,7 @@ const downloadRC = () => {
     }
 
     downloadArtifact(ENTERPRISE_SNAPSHOT_REPO, 'hazelcast-remote-controller', HAZELCAST_RC_VERSION);
-    downloadArtifact(TEST_REPO, 'hazelcast', HAZELCAST_TEST_VERSION, HAZELCAST_TEST_VERSION, 'tests');
+    downloadArtifact(TEST_REPO, 'hazelcast', HAZELCAST_TEST_VERSION, 'tests');
     downloadArtifact(REPO, 'hazelcast-sql', HAZELCAST_VERSION);
 
     if (process.env.HAZELCAST_ENTERPRISE_KEY) {
@@ -45,7 +45,7 @@ const downloadRC = () => {
 
     function downloadArtifact(repo, artifactId, version, classifier = '') {
         const filename = classifier ? `hazelcast-${version}-${classifier}.jar` : `hazelcast-${version}.jar`;
-        let artifact = `com.hazelcast:${artifactId}:${version}:jar`;
+        let artifact = `com.hazelcast:${artifactId}:${version}`;
         if (classifier) {
             artifact += `:${classifier}`;
         }

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -6,7 +6,7 @@ const HAZELCAST_VERSION = HZ_VERSION;
 const HAZELCAST_ENTERPRISE_VERSION = HZ_VERSION;
 const HAZELCAST_RC_VERSION = '0.8-SNAPSHOT';
 const SNAPSHOT_REPO = 'https://oss.sonatype.org/content/repositories/snapshots';
-const RELEASE_REPO = 'https://repo.maven.apache.org/maven2';
+const RELEASE_REPO = 'http://repo.maven.apache.org/maven2';
 const ENTERPRISE_RELEASE_REPO = 'https://repository.hazelcast.com/release/';
 const ENTERPRISE_SNAPSHOT_REPO = 'https://repository.hazelcast.com/snapshot/';
 
@@ -45,7 +45,7 @@ const downloadRC = () => {
 
     function downloadArtifact(repo, artifactId, version, classifier = '') {
         const filename = classifier ? `hazelcast-${version}-${classifier}.jar` : `hazelcast-${version}.jar`;
-        let artifact = `com.hazelcast:${artifactId}:${version}`;
+        let artifact = `com.hazelcast:${artifactId}:${version}:jar`;
         if (classifier) {
             artifact += `:${classifier}`;
         }

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -6,7 +6,7 @@ const HAZELCAST_VERSION = HZ_VERSION;
 const HAZELCAST_ENTERPRISE_VERSION = HZ_VERSION;
 const HAZELCAST_RC_VERSION = '0.8-SNAPSHOT';
 const SNAPSHOT_REPO = 'https://oss.sonatype.org/content/repositories/snapshots';
-const RELEASE_REPO = 'http://repo.maven.apache.org/maven2';
+const RELEASE_REPO = 'https://repo.maven.apache.org/maven2';
 const ENTERPRISE_RELEASE_REPO = 'https://repository.hazelcast.com/release/';
 const ENTERPRISE_SNAPSHOT_REPO = 'https://repository.hazelcast.com/snapshot/';
 

--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -6,7 +6,7 @@ const HAZELCAST_VERSION = HZ_VERSION;
 const HAZELCAST_ENTERPRISE_VERSION = HZ_VERSION;
 const HAZELCAST_RC_VERSION = '0.8-SNAPSHOT';
 const SNAPSHOT_REPO = 'https://oss.sonatype.org/content/repositories/snapshots';
-const RELEASE_REPO = 'http://repo1.maven.apache.org/maven2';
+const RELEASE_REPO = 'https://repo.maven.apache.org/maven2';
 const ENTERPRISE_RELEASE_REPO = 'https://repository.hazelcast.com/release/';
 const ENTERPRISE_SNAPSHOT_REPO = 'https://repository.hazelcast.com/snapshot/';
 

--- a/scripts/test-runner.js
+++ b/scripts/test-runner.js
@@ -68,7 +68,7 @@ const getRC = () => {
 };
 
 const startRC = async () => {
-    console.log('Starting Hazelcast Remote Controller ... oss ...');
+    console.log('Starting Hazelcast Remote Controller ...');
     if (ON_WINDOWS) {
         const outFD = fs.openSync('rc_stdout.log', 'w');
         const errFD = fs.openSync('rc_stderr.log', 'w');


### PR DESCRIPTION
While investigating a [build failure](https://github.com/hazelcast/hazelcast-nodejs-client/actions/runs/17822746545/job/50668746108) I noticed several areas of improvement:
- The `download-rc.js` file duplicates the code for downloading _each_ JAR
   - should be centralised 
- Log messages are not correct, prints both regardless:
   - `Starting Remote Controller ... enterprise ...`
   - `Starting Hazelcast Remote Controller ... oss ...`
- The RCD logs are not viewable during a PR builder execution (making debugging startup failures tricky)