### PR TITLE
Fix pre-commit hook on Windows

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm run compile
-npm run lint
-npm run validate-user-code
+# See https://github.com/typicode/husky/issues/1072#issuecomment-1784006332
+npm_exec=$([[ $OS == "Windows_NT" ]] && echo "npm.cmd" || echo "npm")
+
+"${npm_exec}" run compile
+"${npm_exec}" run lint
+"${npm_exec}" run validate-user-code


### PR DESCRIPTION
The pre-commit hooks do not work on Windows due to issue described in https://github.com/typicode/husky/issues/1072#issuecomment-1784006332

This means you cannot commit any changes without using `--no-verify` which is... annoying.