### PR TITLE
Relocate `hazelcast-remote-controller` [DI-639]

### DIFF
--- a/scripts/download-rc.js
+++ b/scripts/download-rc.js
@@ -6,7 +6,7 @@ const HAZELCAST_VERSION = HZ_VERSION;
 const HAZELCAST_ENTERPRISE_VERSION = HZ_VERSION;
 const HAZELCAST_RC_VERSION = '0.8-SNAPSHOT';
 const SNAPSHOT_REPO = 'https://oss.sonatype.org/content/repositories/snapshots';
-const RELEASE_REPO = 'http://repo1.maven.apache.org/maven2';
+const RELEASE_REPO = 'https://repo.maven.apache.org/maven2';
 const ENTERPRISE_RELEASE_REPO = 'https://repository.hazelcast.com/release/';
 const ENTERPRISE_SNAPSHOT_REPO = 'https://repository.hazelcast.com/snapshot/';
 
@@ -46,7 +46,7 @@ const downloadRC = () => {
                 '-q',
                 'org.apache.maven.plugins:maven-dependency-plugin:2.10:get',
                 '-Dtransitive=false',
-                `-DremoteRepositories=${SNAPSHOT_REPO}`,
+                `-DremoteRepositories=${ENTERPRISE_SNAPSHOT_REPO}`,
                 `-Dartifact=com.hazelcast:hazelcast-remote-controller:${HAZELCAST_RC_VERSION}`,
                 `-Ddest=hazelcast-remote-controller-${HAZELCAST_RC_VERSION}.jar`
             ], {


### PR DESCRIPTION
In https://github.com/hazelcast/hazelcast-remote-controller/pull/75, `hazelcast-remote-controller` is deployed to a different repository to address build issues. Update the paths to suit.

Also:
- updated Maven central URL as per https://github.com/hazelcast/hazelcast-mono/pull/4897
- updated Maven central URL to use `HTTPS`, as `HTTP` is [no longer supported](https://maven.apache.org/docs/3.8.1/release-notes.html).

Fixes: [DI-639](https://hazelcast.atlassian.net/browse/DI-639)

[DI-639]: https://hazelcast.atlassian.net/browse/DI-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ