### PR TITLE
Update `membership` check implementation to avoid PAT requirement

### DIFF
--- a/.github/workflows/coverage_runner.yml
+++ b/.github/workflows/coverage_runner.yml
@@ -24,9 +24,8 @@ jobs:
         id: composite
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
-          organization-name: 'hazelcast'
           member-name: ${{ github.actor }}
-          token: ${{ secrets.PAT }}
+          token: ${{ github.token }}
 
   node-versions:
     uses: ./.github/workflows/get-supported-node-versions.yml


### PR DESCRIPTION
See (and is blocked by) https://github.com/hazelcast/hazelcast-tpm/pull/71

Post-merge actions:
- [x] remove repo-scoped secret PAT